### PR TITLE
fix(profiles): reject payload fragments at plan time

### DIFF
--- a/docs/resources/pro_macos_configuration_profile.md
+++ b/docs/resources/pro_macos_configuration_profile.md
@@ -145,7 +145,7 @@ Pair `display_notifications` with `notification_location` to control whether and
 Required:
 
 - `name` (String) Display name of the profile. Must be unique within the tenant. This value is also used as the profile's display name inside the `.mobileconfig` payload, so any name you set inside `payloads` is overridden.
-- `payloads` (String) The `.mobileconfig` plist XML carrying the configuration the profile delivers. See the resource description for how the provider handles diffs against Jamf Pro's server-side normalisations, and for the characters Jamf Pro cannot store inside a payload value.
+- `payloads` (String) The `.mobileconfig` plist XML carrying the configuration the profile delivers. Must be a complete plist document — a bare `<dict>` fragment is rejected by Jamf Pro. See the resource description for how the provider handles diffs against Jamf Pro's server-side normalisations, and for the characters Jamf Pro cannot store inside a payload value.
 
 Optional:
 

--- a/docs/resources/pro_mobile_device_configuration_profile.md
+++ b/docs/resources/pro_mobile_device_configuration_profile.md
@@ -131,7 +131,7 @@ resource "jamfplatform_pro_mobile_device_configuration_profile" "self_service" {
 Required:
 
 - `name` (String) Display name of the profile. Must be unique within the tenant. This value is also used as the profile's display name inside the `.mobileconfig` payload, so any name you set inside `payloads` is overridden.
-- `payloads` (String) The `.mobileconfig` plist XML carrying the configuration the profile delivers. See the resource description for how the provider handles diffs against Jamf Pro's server-side normalisations, and for the characters Jamf Pro cannot store inside a payload value.
+- `payloads` (String) The `.mobileconfig` plist XML carrying the configuration the profile delivers. Must be a complete plist document — a bare `<dict>` fragment is rejected by Jamf Pro. See the resource description for how the provider handles diffs against Jamf Pro's server-side normalisations, and for the characters Jamf Pro cannot store inside a payload value.
 
 Optional:
 

--- a/internal/common/validators/plist_document.go
+++ b/internal/common/validators/plist_document.go
@@ -1,0 +1,131 @@
+// Copyright Jamf Software LLC 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package validators
+
+import (
+	"context"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+)
+
+// plistWrapperExample is the wrapper the remediation text tells users to add.
+// `version="1.0"` is Apple's canonical value; Jamf Pro stores it as `1` and the
+// payload mask normalises the difference, so either authored form is fine.
+const plistWrapperExample = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  …your existing content…
+</plist>`
+
+// PlistDocument checks that a string attribute holds a complete plist document
+// — one whose root element is `<plist>` — rather than a bare fragment such as a
+// lone `<dict>…</dict>`.
+//
+// Why this exists: Jamf Pro's configuration-profile endpoints reject a fragment
+// with HTTP 409 "Unable to update the database", which tells the user nothing
+// about the actual mistake. Wire-probed against a live tenant 2026-08-24
+// (issue #326): the same payload is accepted the moment a `<plist>` root is
+// added, and the root element alone is sufficient — the XML declaration and the
+// DOCTYPE are both optional. So the root element is the gate, and neither of the
+// other two is checked.
+//
+// The validator only errors when it positively identifies a wrong root element
+// (or no element at all). Anything it cannot parse is deferred to the server:
+// false-rejecting a payload Jamf Pro would have accepted is worse than passing
+// an unparseable one through to the existing error path. Null/unknown values are
+// deferred per STYLE_GUIDE §Config-time validators.
+//
+// Why plan time and not create time: a fragment used to fail on create yet
+// succeed on update, which reads as a create/update difference in Jamf Pro but
+// is not one — a raw PUT of the same fragment to an existing profile 409s
+// identically (wire-probed 2026-08-24). The asymmetry was ours.
+// payloadhelpers.InjectTopLevelIdentifierValues returns early on create (no
+// identifiers to inject yet) and sends the authored bytes untouched, but on
+// update it parses the payload — plisthelpers.ParsePlist accepts a bare dict
+// fragment — and re-encodes it, and the encoder always emits a whole document.
+// So update silently repaired the payload and create could not. Gating in the
+// schema closes that gap from both directions: the fragment never reaches
+// either path, so neither can disagree about it again.
+func PlistDocument() validator.String {
+	return plistDocumentValidator{}
+}
+
+type plistDocumentValidator struct{}
+
+// Description returns a plain-text description of the validator.
+func (plistDocumentValidator) Description(_ context.Context) string {
+	return "value must be a complete plist document whose root element is <plist>."
+}
+
+// MarkdownDescription returns the markdown description of the validator.
+func (v plistDocumentValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+// ValidateString implements validator.String.
+func (plistDocumentValidator) ValidateString(_ context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
+	}
+	raw := req.ConfigValue.ValueString()
+	if strings.TrimSpace(raw) == "" {
+		resp.Diagnostics.AddAttributeError(
+			req.Path,
+			"Empty payload",
+			"The payload is empty. Supply the plist document describing the settings this profile delivers.",
+		)
+		return
+	}
+	// A binary plist carries no XML root element to inspect. Defer rather than
+	// false-reject.
+	if strings.HasPrefix(raw, "bplist00") {
+		return
+	}
+
+	root, ok := xmlRootElement(raw)
+	if !ok {
+		return // Unparseable — leave it to Jamf Pro to reject.
+	}
+	if root == "plist" {
+		return
+	}
+	resp.Diagnostics.AddAttributeError(
+		req.Path,
+		"Payload is not a complete plist document",
+		fmt.Sprintf(
+			"The payload starts with <%s>, so it is a fragment rather than a whole plist document. "+
+				"Jamf Pro refuses a fragment with \"Unable to update the database\" and reports nothing more specific.\n\n"+
+				"Wrap the payload:\n\n%s",
+			root, plistWrapperExample,
+		),
+	)
+}
+
+// xmlRootElement returns the local name of the first element in raw. ok is false
+// when raw holds no element or cannot be tokenised, in which case the caller must
+// not report an error — see PlistDocument's contract.
+func xmlRootElement(raw string) (name string, ok bool) {
+	dec := xml.NewDecoder(strings.NewReader(raw))
+	// Accept any declared encoding. Only element names are read, and those are
+	// ASCII in every plist, so decoding the bytes as-is is sufficient. Without
+	// this, `encoding="ISO-8859-1"` makes Token fail and the whole payload would
+	// be deferred for a reason unrelated to its structure.
+	dec.CharsetReader = func(_ string, input io.Reader) (io.Reader, error) { return input, nil }
+	// Jamf payloads reference Apple's DTD by URL; entity resolution is not
+	// needed to find the root element and must never trigger a network fetch.
+	dec.Strict = false
+	for {
+		tok, err := dec.Token()
+		if err != nil {
+			return "", false
+		}
+		if start, isStart := tok.(xml.StartElement); isStart {
+			return start.Name.Local, true
+		}
+	}
+}

--- a/internal/common/validators/plist_document_test.go
+++ b/internal/common/validators/plist_document_test.go
@@ -1,0 +1,128 @@
+// Copyright Jamf Software LLC 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package validators_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/validators"
+)
+
+// payloadBody is the settings dict from issue #326, shared by the wrapped and
+// unwrapped cases so the wrapper is the only difference between them.
+const payloadBody = `<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadType</key>
+			<string>com.apple.ManagedClient.preferences</string>
+		</dict>
+	</array>
+</dict>`
+
+func validatePlistDocument(t *testing.T, value types.String) validator.StringResponse {
+	t.Helper()
+	req := validator.StringRequest{
+		Path:        path.Root("general").AtName("payloads"),
+		ConfigValue: value,
+	}
+	resp := validator.StringResponse{}
+	validators.PlistDocument().ValidateString(context.Background(), req, &resp)
+	return resp
+}
+
+func TestPlistDocument_AcceptsCompleteDocuments(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]string{
+		// Wire-probed 2026-08-24: Jamf Pro accepts all three forms.
+		"root element only":             "<plist version=\"1.0\">\n" + payloadBody + "\n</plist>",
+		"declaration and root":          "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<plist version=\"1.0\">\n" + payloadBody + "\n</plist>",
+		"declaration, doctype and root": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n<plist version=\"1\">\n" + payloadBody + "\n</plist>",
+		"leading whitespace":            "\n\t<plist version=\"1.0\">" + payloadBody + "</plist>",
+		"comment before root":           "<!-- built by templatefile -->\n<plist version=\"1.0\">" + payloadBody + "</plist>",
+	}
+
+	for name, payload := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if resp := validatePlistDocument(t, types.StringValue(payload)); resp.Diagnostics.HasError() {
+				t.Fatalf("expected no error, got: %v", resp.Diagnostics.Errors())
+			}
+		})
+	}
+}
+
+func TestPlistDocument_RejectsFragment(t *testing.T) {
+	t.Parallel()
+
+	resp := validatePlistDocument(t, types.StringValue(payloadBody))
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("expected an error for a bare <dict> fragment, got none")
+	}
+	detail := resp.Diagnostics.Errors()[0].Detail()
+	for _, want := range []string{"<dict>", "<plist version=\"1.0\">"} {
+		if !strings.Contains(detail, want) {
+			t.Errorf("detail should mention %q, got:\n%s", want, detail)
+		}
+	}
+	withPath, ok := resp.Diagnostics.Errors()[0].(diag.DiagnosticWithPath)
+	if !ok {
+		t.Fatal("expected an attribute-scoped diagnostic")
+	}
+	if got := withPath.Path().String(); got != "general.payloads" {
+		t.Errorf("expected the error on general.payloads, got %s", got)
+	}
+}
+
+func TestPlistDocument_RejectsEmpty(t *testing.T) {
+	t.Parallel()
+
+	for name, payload := range map[string]string{"empty": "", "whitespace": " \n\t "} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			resp := validatePlistDocument(t, types.StringValue(payload))
+			if !resp.Diagnostics.HasError() {
+				t.Fatal("expected an error for an empty payload, got none")
+			}
+			if summary := resp.Diagnostics.Errors()[0].Summary(); summary != "Empty payload" {
+				t.Errorf("unexpected summary: %s", summary)
+			}
+		})
+	}
+}
+
+// TestPlistDocument_DefersWhenUnresolvable covers everything the validator must
+// hand to Jamf Pro rather than reject itself: values not yet known at validate
+// time, and payloads it cannot tokenise. False-rejecting a payload Jamf Pro
+// would accept is worse than letting an unparseable one reach the API.
+func TestPlistDocument_DefersWhenUnresolvable(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]types.String{
+		"null":                  types.StringNull(),
+		"unknown":               types.StringUnknown(),
+		"binary plist":          types.StringValue("bplist00\xd1\x01\x02"),
+		"no element at all":     types.StringValue("not xml at all"),
+		"declaration only":      types.StringValue("<?xml version=\"1.0\" encoding=\"UTF-8\"?>"),
+		"non-utf8 declaration":  types.StringValue("<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?><plist version=\"1.0\">" + payloadBody + "</plist>"),
+		"unterminated fragment": types.StringValue("<plist version=\"1.0\"><dict>"),
+	}
+
+	for name, value := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if resp := validatePlistDocument(t, value); resp.Diagnostics.HasError() {
+				t.Fatalf("expected no error, got: %v", resp.Diagnostics.Errors())
+			}
+		})
+	}
+}

--- a/internal/resources/pro/macos_configuration_profile/resource.go
+++ b/internal/resources/pro/macos_configuration_profile/resource.go
@@ -23,6 +23,7 @@ import (
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/impact"
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/ldapgroups"
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/scope"
+	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/validators"
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/providerdata"
 )
 
@@ -140,8 +141,9 @@ func (r *Resource) Schema(_ context.Context, _ resource.SchemaRequest, resp *res
 						PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 					},
 					"payloads": schema.StringAttribute{
-						MarkdownDescription: "The `.mobileconfig` plist XML carrying the configuration the profile delivers. See the resource description for how the provider handles diffs against Jamf Pro's server-side normalisations, and for the characters Jamf Pro cannot store inside a payload value.",
+						MarkdownDescription: "The `.mobileconfig` plist XML carrying the configuration the profile delivers. Must be a complete plist document — a bare `<dict>` fragment is rejected by Jamf Pro. See the resource description for how the provider handles diffs against Jamf Pro's server-side normalisations, and for the characters Jamf Pro cannot store inside a payload value.",
 						Required:            true,
+						Validators:          []validator.String{validators.PlistDocument()},
 					},
 					"category_id": schema.StringAttribute{
 						MarkdownDescription: "Jamf Pro category ID. Use `-1` (default) for \"no category\".",

--- a/internal/resources/pro/mobile_device_configuration_profile/resource.go
+++ b/internal/resources/pro/mobile_device_configuration_profile/resource.go
@@ -24,6 +24,7 @@ import (
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/impact"
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/ldapgroups"
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/scope"
+	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/validators"
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/providerdata"
 )
 
@@ -141,8 +142,9 @@ func (r *Resource) Schema(_ context.Context, _ resource.SchemaRequest, resp *res
 						PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 					},
 					"payloads": schema.StringAttribute{
-						MarkdownDescription: "The `.mobileconfig` plist XML carrying the configuration the profile delivers. See the resource description for how the provider handles diffs against Jamf Pro's server-side normalisations, and for the characters Jamf Pro cannot store inside a payload value.",
+						MarkdownDescription: "The `.mobileconfig` plist XML carrying the configuration the profile delivers. Must be a complete plist document — a bare `<dict>` fragment is rejected by Jamf Pro. See the resource description for how the provider handles diffs against Jamf Pro's server-side normalisations, and for the characters Jamf Pro cannot store inside a payload value.",
 						Required:            true,
+						Validators:          []validator.String{validators.PlistDocument()},
 					},
 					"category_id": schema.StringAttribute{
 						MarkdownDescription: "Jamf Pro category ID. Use `-1` (default) for \"no category\".",

--- a/internal/resources/pro/patch_software_title/data_source.go
+++ b/internal/resources/pro/patch_software_title/data_source.go
@@ -203,8 +203,7 @@ func (d *PatchSoftwareTitleDataSource) Read(ctx context.Context, req datasource.
 		return
 	}
 	if err != nil {
-		var ambErr *jamfplatform.AmbiguousMatchError
-		if errors.As(err, &ambErr) {
+		if _, ok := errors.AsType[*jamfplatform.AmbiguousMatchError](err); ok {
 			resp.Diagnostics.AddError(
 				"Multiple Jamf Pro patch software titles match this display name",
 				err.Error()+". Look the title up by id instead.",

--- a/internal/resources/pro/return_to_service/data_source.go
+++ b/internal/resources/pro/return_to_service/data_source.go
@@ -129,8 +129,7 @@ func (d *ReturnToServiceDataSource) Read(ctx context.Context, req datasource.Rea
 		// Display names are not unique, so a name lookup can match more than one
 		// configuration; surface that as a distinct, actionable diagnostic rather
 		// than a generic not-found.
-		var ambErr *jamfplatform.AmbiguousMatchError
-		if errors.As(err, &ambErr) {
+		if _, ok := errors.AsType[*jamfplatform.AmbiguousMatchError](err); ok {
 			resp.Diagnostics.AddError(
 				"Multiple Jamf Pro Return to Service configurations match this display name",
 				err.Error()+". Look the configuration up by id instead.",


### PR DESCRIPTION
Fixes #326.

## What was wrong

A `general.payloads` value that is a bare `<dict>` fragment rather than a whole plist document is rejected by Jamf Pro with HTTP 409 `Unable to update the database`, which names neither the attribute nor the mistake. The reporter reasonably read it as a `templatefile()` problem.

Reproduced against a live tenant, then isolated: same config, same `templatefile()` call, wrapper the only variable.

| Payload | Result |
|---|---|
| bare `<dict>` fragment | 409 `Unable to update the database` |
| `<plist>` root only | created |
| declaration + `<plist>` | created |
| declaration + DOCTYPE + `<plist>` | created |

So the root element is the whole requirement — the XML declaration and the DOCTYPE are both optional.

## The create-vs-update asymmetry was ours

The issue thread notes that updates appeared to work with or without the wrapper, and only a destroy-and-reapply surfaced the failure. That is real, and it is not a Jamf Pro create/update difference — a raw `PUT` of the same fragment to an existing profile 409s exactly as the `POST` does.

`payloadhelpers.InjectTopLevelIdentifierValues` returns early on create (no identifiers to inject yet) and sends the authored bytes untouched. On update it parses the payload — `plisthelpers.ParsePlist` accepts a bare dict fragment by design — and re-encodes it, and the encoder always emits a whole document. **Update was silently repairing what create could not.** So a fragment survived indefinitely in a tenant until the next create, which is exactly what the reporter hit.

Gating in the schema closes it from both directions: the fragment reaches neither path, so neither can disagree about it again.

## The change

- New `validators.PlistDocument()` — checks the root element via an `encoding/xml` token scan. `plisthelpers.ParsePlist` could not serve as the gate; its own doc comment notes it accepts a fragment.
- Wired onto `general.payloads` on `jamfplatform_pro_macos_configuration_profile` and `jamfplatform_pro_mobile_device_configuration_profile`, plus the attribute descriptions and regenerated docs.

It errors only on a positively-identified wrong root element, and defers anything it cannot tokenise (binary plist, non-UTF8 declaration, malformed XML) to the server. False-rejecting a payload Jamf Pro would accept is worse than letting an unparseable one reach the existing error path.

## Before / after

Before — 409 at apply, after the profile object was already being created:
```
CreateOSXConfigurationProfileByID(0): API request failed with status 409 …: Unable to update the database
```

After — at plan:
```
Error: Payload is not a complete plist document

  with jamfplatform_pro_macos_configuration_profile.test,
  on main.tf line 18, in resource "jamfplatform_pro_macos_configuration_profile" "test":

The payload starts with <dict>, so it is a fragment rather than a whole plist
document. Jamf Pro refuses a fragment with "Unable to update the database" and
reports nothing more specific.

Wrap the payload:

<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
  …your existing content…
</plist>
```

## Verification

- Issue's exact config now fails at plan; wrapped config applies and destroys clean, follow-up plan clean.
- 15 unit cases covering accepted forms, the fragment, empty payloads, and every defer path (including null/unknown per STYLE_GUIDE §Config-time validators).
- All 20 profile test fixtures and all 5 example `.mobileconfig` files carry `<plist>` roots, so acceptance tests are unaffected. `jamfplatform::mobileconfig` output is a whole document too.
- `make fix fmt lint test` green — 4349 unit tests, `make generate` produces no further diff.
- Test profiles created during probing were all destroyed.

## Commits

1. `chore: apply go fix modernisations` — `make fix` rewriting the two remaining `errors.As` call sites to `errors.AsType`. Gate byproduct, no behaviour change, separated so the fix is reviewable on its own.
2. `fix(profiles): reject payload fragments at plan time` — the fix.

## Note for maintainers

`make lint` fails locally for anyone carrying scratch files in the gitignored `local-testing/` tree (4 issues in `probe-mobile-cr/` and `probe-charmatrix/` on my machine). Nothing tracked, nothing this PR can fix, but the default `make` target hitting it is a papercut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)