### PR TITLE
test(patch_external_source): stop asserting third-party catalog contents

### DIFF
--- a/internal/resources/pro/patch_external_source/resource_acceptance_test.go
+++ b/internal/resources/pro/patch_external_source/resource_acceptance_test.go
@@ -143,11 +143,13 @@ func TestAccDataSource_ProPatchExternalSource_ByID(t *testing.T) {
 					resource.TestCheckResourceAttrPair("data.jamfplatform_pro_patch_external_source.lookup", "name", "jamfplatform_pro_patch_external_source.src", "name"),
 					resource.TestCheckResourceAttr("data.jamfplatform_pro_patch_external_source.lookup", "host_name", "definitions.datajar.mobi/v2/"),
 					resource.TestCheckResourceAttr("data.jamfplatform_pro_patch_external_source.lookup", "ssl_enabled", "true"),
-					// The datajar definitions host publishes a real catalog, so
-					// available_titles is populated — assert the first entry.
+					// Only that the attribute is present. Its contents come from a
+					// third-party definitions host via Jamf Pro, and the data source
+					// treats a failed catalog fetch as non-fatal (warning + empty
+					// list) — so asserting on entry 0 tests datajar's uptime, not
+					// this provider. Entry mapping is covered by the unit tests in
+					// internal/common/availabletitles.
 					resource.TestCheckResourceAttrSet("data.jamfplatform_pro_patch_external_source.lookup", "available_titles.#"),
-					resource.TestCheckResourceAttrSet("data.jamfplatform_pro_patch_external_source.lookup", "available_titles.0.name_id"),
-					resource.TestCheckResourceAttrSet("data.jamfplatform_pro_patch_external_source.lookup", "available_titles.0.app_name"),
 				),
 			},
 		},
@@ -177,8 +179,8 @@ func TestAccDataSource_ProPatchExternalSource_ByName(t *testing.T) {
 				`, name),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrPair("data.jamfplatform_pro_patch_external_source.lookup", "id", "jamfplatform_pro_patch_external_source.src", "id"),
-					// Real definitions host → populated catalog.
-					resource.TestCheckResourceAttrSet("data.jamfplatform_pro_patch_external_source.lookup", "available_titles.0.name_id"),
+					// Presence only — see the ByID test for why entry 0 is not asserted.
+					resource.TestCheckResourceAttrSet("data.jamfplatform_pro_patch_external_source.lookup", "available_titles.#"),
 				),
 			},
 		},


### PR DESCRIPTION
Fixes the intermittent nightly failure in `TestAccDataSource_ProPatchExternalSource_ByName`.

## The failure

From the 2026-08-24 full-suite run:

```
resource_acceptance_test.go:162: Step 1/1 error: Check failed: Check 2/2 error:
data.jamfplatform_pro_patch_external_source.lookup:
Attribute 'available_titles.0.name_id' expected to be set
```

Not a lookup failure — the source resolved fine. `available_titles` came back **empty**, so index `0` didn't exist.

## Why

Both data source tests set `host_name = "definitions.datajar.mobi/v2/"` and then assert on catalog *entries* that Jamf Pro fetches from that **third-party host**. The data source deliberately treats a failed titles fetch as non-fatal — warning plus empty list, on the documented grounds that "a flaky catalog must not break the plan" — so an upstream hiccup surfaces as a *missing attribute* rather than an error. There is no retry anywhere in the path; `ListPatchAvailableTitlesBySourceID` is a single bare GET.

## It was never `ByName`-specific

Test duration tracks catalog payload size, which makes the mechanism visible:

| Run | ByID | ByName |
|---|---|---|
| 2026-08-24 | 10.07s ✅ | **4.46s ❌** |
| 2026-08-25 | 6.96s ✅ | 7.33s ✅ |
| 2026-08-26 | 9.61s ✅ | 9.81s ✅ |

A populated catalog takes 7–10s; the failing run took less than half that — an empty response returning fast. On healthy runs `ByName` is actually *slower* than `ByID`. So `ByID` asserts the same attributes and is equally exposed; it simply hasn't lost the coin flip yet. Both are fixed here.

## The change

Keep `available_titles.#` — always set, because the data source assigns an empty slice unconditionally — and drop the entry assertions. The entry mapping they were protecting is already covered, and **cannot** flake, by `TestMapTitles_FromLiveWire`, `TestMapTitles_NilAndEmptyYieldNonNilEmpty` and `TestDataSourceAttributes_HasExpectedFields` in `internal/common/availabletitles`, which exercise all five fields against a fixture.

## Deliberately left alone

The equivalent assertions on `jamfplatform_pro_patch_internal_source` (`datasource_acceptance_test.go:45-46`). That catalog is Jamf's own first-party "Jamf" source rather than a third party, so the same class of risk exists but is far smaller and has not been observed. Flagging it here so it's a known quantity if it ever does flake.

## Verification

Ran the two tests three times consecutively against a live tenant — green each time (15.8s / 13.7s / 14.5s).

One caveat worth stating plainly: that verification ran with the commit cherry-picked on top of #329, not on this branch's `main` base. `AccPreCheck` on `main` still requires `JAMFPLATFORM_TENANT_ID`, and I only have environment-scoped credentials for this tenant. The data source code is byte-identical between the two bases and this change only *removes* assertions, so it cannot introduce a failure — but the run itself was on the other base, and CI on this branch is the check that matters.

Independent of #329; either can merge first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)