### PR TITLE
test(impact): guard subset-read regression at the wire, not the tenant

### DIFF
--- a/internal/common/impact/dependency_acceptance_test.go
+++ b/internal/common/impact/dependency_acceptance_test.go
@@ -8,6 +8,7 @@ package impact
 import (
 	"context"
 	"os"
+	"strconv"
 	"testing"
 	"time"
 
@@ -115,15 +116,17 @@ func TestAcceptance_DependencyIndex_SweepsLiveTenant(t *testing.T) {
 	}
 }
 
-// TestAcceptance_DependencyIndex_PackagesAreFound is the regression guard for the
-// reason this feature reads whole policies rather than subsets.
+// TestAcceptance_DependencyIndex_PackagesAreFound reports what the tenant's own
+// policies reference, and asserts the index agrees with the wire.
 //
-// The Classic API's subset endpoint returns HTTP 200 with an empty body for
-// PackageConfiguration even when the policy has packages, so an implementation
-// that used subsets would build an index with no package references at all and
-// silently report "no policy uses this package". This test fails if that
-// regression is ever introduced, provided the tenant has at least one policy
-// installing a package.
+// It deliberately asserts nothing when the tenant installs no packages. The
+// regression this once tried to catch — a sweep reading Classic subsets, which
+// answer 200 with an empty PackageConfiguration — is indistinguishable from an
+// estate whose policies simply install nothing, so inferring it from
+// "scripts referenced, packages not" fails on any such tenant. That guard now
+// lives where the distinction is observable, in
+// TestDependencyIndex_ReadsWholePoliciesNotSubsets, which drives the real
+// PolicySource against a server reproducing the empty-subset behaviour.
 func TestAcceptance_DependencyIndex_PackagesAreFound(t *testing.T) {
 	c := liveCache(t)
 	ctx := context.Background()
@@ -143,9 +146,41 @@ func TestAcceptance_DependencyIndex_PackagesAreFound(t *testing.T) {
 		}
 	}
 	t.Logf("distinct packages referenced: %d; distinct scripts referenced: %d", packageRefs, scriptRefs)
-	if scriptRefs > 0 && packageRefs == 0 {
-		t.Error("policies reference scripts but no packages at all — the classic subset endpoint " +
-			"drops PackageConfiguration silently, so this is the signature of a regression back to subset reads")
+
+	// The wire, read independently of the index: how many packages the tenant's
+	// policies actually install. Zero is a legitimate estate, and the only honest
+	// response to it is to assert nothing.
+	ids, err := c.policySrc.PolicyIDs(ctx)
+	if err != nil {
+		t.Fatalf("listing policies: %v", err)
+	}
+	wirePackages := map[string]struct{}{}
+	for _, id := range ids {
+		pol, err := c.policySrc.Policy(ctx, id)
+		if err != nil || pol == nil {
+			continue
+		}
+		if pol.PackageConfiguration == nil || pol.PackageConfiguration.Packages == nil ||
+			pol.PackageConfiguration.Packages.Package == nil {
+			continue
+		}
+		for _, pkg := range *pol.PackageConfiguration.Packages.Package {
+			if pkg.ID != nil && *pkg.ID > 0 {
+				wirePackages[strconv.Itoa(*pkg.ID)] = struct{}{}
+			}
+		}
+	}
+	if len(wirePackages) == 0 {
+		t.Skip("no policy in this tenant installs a package; nothing to assert")
+	}
+	if packageRefs != len(wirePackages) {
+		t.Errorf("index holds %d distinct package(s), the wire names %d — the index and the "+
+			"tenant disagree about which packages policies install", packageRefs, len(wirePackages))
+	}
+	for id := range wirePackages {
+		if len(idx.uses[dependencyKey{DependencyPackage, id}]) == 0 {
+			t.Errorf("package %s is installed by a policy on the wire but absent from the index", id)
+		}
 	}
 }
 

--- a/internal/common/impact/dependencywire_test.go
+++ b/internal/common/impact/dependencywire_test.go
@@ -1,0 +1,97 @@
+// Copyright Jamf Software LLC 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package impact
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform"
+	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/proclassic"
+)
+
+// The sweep must read whole policies, never subsets. The Classic API answers
+// GET .../subset/PackageConfiguration with 200 and an empty body even when the
+// policy installs packages, so a subset-based sweep would index no package
+// references at all and every dependency alert for a package would report
+// "no policy uses this" — a confident, wrong denial.
+//
+// This is a property of which endpoint the code calls, not of any tenant's data,
+// so it is guarded here rather than against a live estate: an acceptance test can
+// only observe "no package references", which on a tenant whose policies install
+// nothing is simply the truth.
+
+// policyServer serves the Classic policy surface with Jamf Pro's own asymmetry:
+// the full read carries the package, the subset read returns 200 with an empty
+// body. It records which shape was asked for.
+type policyServer struct {
+	fullReads   int
+	subsetReads int
+}
+
+func (s *policyServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path == "/auth/token" {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"test-token","token_type":"Bearer","expires_in":3600}`))
+		return
+	}
+	w.Header().Set("Content-Type", "application/xml")
+	switch {
+	case strings.HasSuffix(r.URL.Path, "/policies"):
+		_, _ = w.Write([]byte(`<policies><size>1</size>` +
+			`<policy><id>17</id><name>Install Widget</name></policy></policies>`))
+	case strings.Contains(r.URL.Path, "/subset/"):
+		s.subsetReads++
+		_, _ = w.Write([]byte(`<policy/>`))
+	case strings.Contains(r.URL.Path, "/policies/id/"):
+		s.fullReads++
+		_, _ = w.Write([]byte(`<policy>` +
+			`<general><id>17</id><name>Install Widget</name><enabled>true</enabled></general>` +
+			`<scope><all_computers>true</all_computers></scope>` +
+			`<package_configuration><packages><size>1</size>` +
+			`<package><id>42</id><name>Widget.pkg</name><action>Install</action></package>` +
+			`</packages></package_configuration>` +
+			`<scripts><size>1</size><script><id>9</id><name>widget.sh</name></script></scripts>` +
+			`</policy>`))
+	default:
+		w.WriteHeader(http.StatusNotFound)
+	}
+}
+
+// TestDependencyIndex_ReadsWholePoliciesNotSubsets is the regression guard for
+// the reason the sweep reads whole policies.
+func TestDependencyIndex_ReadsWholePoliciesNotSubsets(t *testing.T) {
+	// testhelpers.NewMockClient is not usable here: it drags in internal/provider,
+	// which reaches this package, and the cycle is fatal under the acceptance tag.
+	handler := &policyServer{}
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	client := jamfplatform.NewClient(server.URL, "test-id", "test-secret",
+		jamfplatform.WithRetryPolicy(0, 0, 0))
+	src := policyTenantSource{classic: proclassic.New(client)}
+
+	idx, err := buildDependencyIndex(context.Background(), src)
+	if err != nil {
+		t.Fatalf("sweep failed: %v", err)
+	}
+
+	if got := idx.uses[dependencyKey{DependencyPackage, "42"}]; len(got) != 1 {
+		t.Errorf("package 42 uses = %d, want 1 — the sweep found no package reference, "+
+			"which is what a subset read produces: 200 with an empty PackageConfiguration",
+			len(got))
+	}
+	// The script reference is asserted alongside it so a wholly broken sweep is
+	// told apart from one that reads policies but loses only the packages.
+	if got := idx.uses[dependencyKey{DependencyScript, "9"}]; len(got) != 1 {
+		t.Errorf("script 9 uses = %d, want 1 — the sweep indexed nothing at all", len(got))
+	}
+
+	if handler.fullReads != 1 || handler.subsetReads != 0 {
+		t.Errorf("reads: full=%d subset=%d, want full=1 subset=0 — the sweep must never subset",
+			handler.fullReads, handler.subsetReads)
+	}
+}


### PR DESCRIPTION
`TestAcceptance_DependencyIndex_PackagesAreFound` failed on a tenant whose four policies each run a script and install nothing. The test read that as "the sweep regressed to Classic subset reads" — but an estate with no package-installing policy looks exactly the same, so the inference was unsound.

- **New unit test** `TestDependencyIndex_ReadsWholePoliciesNotSubsets` — drives the real `policyTenantSource` against a server reproducing Jamf Pro's asymmetry (full read carries the package, `subset/` returns 200 + empty body). Mutating `Policy()` to `GetPolicyByIDSubset` fails it.
- **Acceptance test** now reads the wire independently, asserts the index agrees, and skips when no policy installs a package.

`make fmt lint test` clean (lint hits are pre-existing, in gitignored `local-testing/`). Acceptance test now skips on the reporting tenant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)