### PR TITLE
chore(skills): add the new-construct build skill

### DIFF
--- a/.claude/skills/new-construct/SKILL.md
+++ b/.claude/skills/new-construct/SKILL.md
@@ -1,0 +1,208 @@
+---
+name: new-construct
+description: Build a new Terraform construct in this provider — resource, data source, list resource, action or provider-defined function — end to end, from family classification and wire probes through acceptance tests, docs and the pre-PR gates. Use when adding, planning, or writing a kickoff brief for any jamfplatform_* construct.
+---
+
+# New construct build
+
+This skill encodes the *order of work* and the *checked gates*. It does not restate
+`STYLE_GUIDE.md`, `CONTRIBUTING.md` or `TESTING.md` — those are authoritative and move often.
+Where this file names a section, go read it. A rule copied here would be a second source of
+truth, and the previous generation of kickoff prompts died of exactly that.
+
+**`STYLE_GUIDE.md` wins on conflict.** §5 below makes adherence a checked gate at three
+points, not a vibe — sessions drift from it and need maintainer course-correction otherwise.
+
+---
+
+## 0. Classify first — family, then shape
+
+Everything downstream (Configure helper, version gate, folder, error translation, test
+pre-check) follows from these two answers. Getting the family wrong means mirroring the wrong
+reference implementation, which is the most expensive early mistake available.
+
+### Family
+
+| Family | SDK package | Terraform name | Go path | Configure | Version gate |
+|---|---|---|---|---|---|
+| Platform Services | `blueprints`, `cbengine`, `devices`… | `jamfplatform_<x>` | `internal/resources/<domain>/<x>/` | hand-rolled type-assert + `pd.RequireScope(...)` | none |
+| Jamf Pro | `pro/` | `jamfplatform_pro_<x>` | `internal/resources/pro/<x>/` — **flat, no domain tier** | `providerdata.ConfigurePro` | `minJamfProVersion` **required** |
+| Jamf Pro classic | `proclassic/` | `jamfplatform_pro_<x>` | same | `providerdata.ConfigureProClassic` | required |
+| Security Cloud | `securitycloud` | `jamfplatform_security_cloud_<x>` | `internal/resources/security_cloud/<x>/` — flat | `providerdata.ConfigureSecurityCloud` | **none — must not use ConfigurePro** |
+| Actions | `pro`/`proclassic`/`deviceactions` | `jamfplatform_pro_<verb>` / `jamfplatform_device_<verb>` | `internal/actions/pro/<family>/` | `ConfigurePro`/`ConfigureProClassic` | per-action const |
+| Functions | none — offline | `jamfplatform::<fn>` | `internal/functions/<fn>/` | none, no client, no provider config | none |
+
+Then read the family file: `references/pro.md`, `references/security_cloud.md`,
+`references/platform.md`, `references/actions.md`, `references/functions.md`.
+
+### Shape
+
+Classify against [STYLE_GUIDE §Endpoint shape classification](../../../STYLE_GUIDE.md#endpoint-shape-classification):
+resource / data source / list resource / singleton / action / read-only catalogue (plural DS
+only, no per-id endpoint). Then pick the closest row from the **Reference implementations**
+table in `CLAUDE.md` and diff against it throughout the build. Do not pick the reference from
+memory — the table is maintained and your recollection of the tree layout is probably stale.
+
+File split: [STYLE_GUIDE §Resource Package File Conventions](../../../STYLE_GUIDE.md#resource-package-file-conventions).
+Two conventions that get invented instead of looked up: name-to-value lookup tables go in
+**`mappings.go`** (there is no `enums.go` in the table), and a plural data source lives **in
+the singular's package**, not a sibling `<x>s/` directory.
+
+---
+
+## 1. Collect the inputs
+
+A build cannot start from the SDK alone. Gather, and stop and ask for whatever is missing:
+
+- **Construct name + shape + family** per §0. For Pro, also `minJamfProVersion` and its
+  source (release notes URL / SDK `// Available since` / hand-research).
+- **SDK function set** — Create / Read-by-id / Read-by-name / Update / Delete / List, with the
+  list-item shape (full object vs `[]IDName`) and whether Update is full-replace or
+  partial-merge. **Do not invent SDK functions or fields.** A missing function or an
+  under-specified type (`*[]any`, absent field, divergent write shape) **stops the build** —
+  fix the SDK upstream and cut a tag first. See `references/pro.md` §payload audit.
+- **UI evidence** — admin-UI screenshots of every tab the construct exposes, saved under
+  `spike/screenshots/` (gitignored). Two jobs: attribute/value naming, and surface coverage.
+  You cannot screenshot for yourself; ask.
+- **Wire evidence** — raw request/response bodies under `local-testing/<endpoint>/`
+  (gitignored, PII-sanitised). See `references/wire-probes.md` for how to get them and how to
+  write them down honestly.
+- **Anything weird** — suspected server invariants, computed echoes that drift, lossy PUTs,
+  write-only secrets, multipart upload, paged children. One line each, as *probes to run*.
+
+---
+
+## 2. Workflow
+
+1. **Planner** — flip the tracking row/card to `in-design` (`spike/JAMF_PRO_INVENTORY.md` for
+   Pro; GitHub Project #2 otherwise — see the `reference_online_planner` memory).
+2. **Branch.** Cut a dedicated branch; never work on `main`.
+3. **SDK audit** — every function in §1 exists with concrete field types. ProClassic: run the
+   payload audit gate before any Terraform code.
+4. **STYLE_GUIDE read** — §5(a) below, *before* the spike, not after.
+5. **Wire-probe** and write a one-page spike doc at `spike/<RESOURCE>_SPIKE.md` (gitignored).
+   Every non-trivial decision **cites the governing STYLE_GUIDE section**; an uncited decision
+   is the flag to re-check. Open questions numbered, each with the default you will adopt if
+   unanswered. Unrun probes marked NOT-PROBED with the reason — never a plausible-looking
+   invented result.
+6. **UI naming review** — before the schema exists, not after. `references/naming.md`. This is
+   the single most commonly deferred gate and the most expensive to defer.
+7. **PAUSE for maintainer approval.** Surface the spike doc and the numbered questions in
+   chat. Locked in at this point: SDK function set, construct name, package name, version
+   floor, schema sketch.
+8. **Scaffold** per the file conventions, mirroring the §0 reference implementation.
+9. **Shared abstractions** — extract only at the trigger ([STYLE_GUIDE §Shared abstractions](../../../STYLE_GUIDE.md#shared-abstractions--when-to-extract):
+   schemas at 3 consumers, non-trivial code helpers at 2). If a trigger fires mid-build, ship
+   the extraction as a **separate prior commit**. Extracting tends to expose a bug the
+   duplication was hiding — expect that, and check for it.
+10. **Register** in `internal/provider/provider.go`.
+11. **Tests** — `references/acceptance.md`. Unit tests always; acceptance coverage per
+    [TESTING.md §Writing Acceptance Tests](../../../TESTING.md#writing-acceptance-tests).
+12. **Examples** under `examples/{resources,data-sources,list-resources,actions,functions}/<name>/`.
+13. **`make fix fmt lint test`** clean, then **`make generate`** — *after* the last HCL edit,
+    because the generated doc inlines the example. Commit the regenerated `docs/`.
+14. **§5(c) conformance re-check, then the quality gate** (`advisor()` / `/code-review`).
+15. **Planner** — flip to `shipped` after merge. **Delete the spike doc**, having first lifted
+    every load-bearing finding into STYLE_GUIDE / CONTRIBUTING / the package's own doc
+    comments. A spike doc left behind rots into a false authority.
+
+---
+
+## 3. Gates — cheap before, expensive after
+
+Each of these has been paid for late at least once. The right-hand column is what late costs.
+
+| Gate | Do it | Late cost |
+|---|---|---|
+| SDK payload audit (ProClassic) | before any Terraform code | provider-side decoders working around a fixable SDK bug |
+| UI naming + value review | before the schema | schema + tests + examples + docs rewritten; two refactor commits on the Security Cloud branch |
+| Wire-probe collection write semantics (omit / `[]` / present) | before modelling any collection | silent data loss, discovered by a user |
+| Enum vocabulary from the SDK's `*Values()` helper | at schema time | a restated list that drifts from the API |
+| `make generate` | after the **last** HCL edit | ships a stale, sometimes invalid, inlined example |
+| Description jargon grep | before the PR | wire vocabulary published to the Terraform Registry |
+| Plumbing (`GNUmakefile`, `.github/workflows/**`, `go.mod`, `scripts/acctargets/**`) in its own PR | from the start | `acctargets` widens CI to `./...` — the full serial suite on the shared tenant |
+
+---
+
+## 4. Guard-rails (DON'T)
+
+- **Don't** invent SDK functions, fields, or enum values. Stop and ask; fix upstream.
+- **Don't** ship `*[]any` or other under-specified SDK types.
+- **Don't** copy a wire-shape assumption from another construct — even in the same namespace.
+  Probe afresh.
+- **Don't** write state upgraders. The provider is unshipped; breaking changes are free
+  (`feedback_no_state_upgraders`). Renames are free now and breaking after merge.
+- **Don't** put wire vocabulary in `MarkdownDescription` — no API/endpoint/SDK/HTTP-verb/status-code
+  language ([STYLE_GUIDE §User-facing descriptions are UI-aligned](../../../STYLE_GUIDE.md#user-facing-descriptions-are-ui-aligned-not-wire-aligned)).
+  Wire facts belong in Go comments and the `crud.go` annotation block.
+- **Don't** put comments inside function bodies or type definitions (STYLE_GUIDE:11). A schema
+  is built inside a function body — so the wire-name mapping table goes in the **package doc
+  comment**, not beside each attribute.
+- **Don't** use `Optional+Computed` with `UseStateForUnknown` inside a `ListNestedAttribute` /
+  `SetNestedAttribute` — use `UseNonNullStateForUnknown`.
+- **Don't** use HCL block syntax for nested attributes. `scope = { ... }`, never `scope { ... }`
+  — block syntax fails in examples *and* acceptance configs.
+- **Don't** put real tenant / LDAP / directory-group / account / device names in any public
+  file. Placeholders in examples and committed tests; acceptance reads real values from env and
+  `t.Skip`s when unset. (`spike/` and `local-testing/` are gitignored — captures there are fine.)
+- **Don't** call a surface "deprecated" or "legacy" without maintainer confirmation. A wrong
+  premise misdirects the whole build.
+- **Don't** mask a 4xx/5xx with longer timeouts or added polling. Diagnose the payload — a
+  prior Create-500 was XML field order, and "timing/contention" wasted the cycles.
+- **Don't** silently skip an acceptance test around a server bug. Raise it, record the skip and
+  the escalation link in a memory.
+- **Don't** read a green CI run as coverage. Security Cloud's 29 acceptance tests skip in CI by
+  design; green and zero-coverage look identical from the outside.
+
+---
+
+## 5. STYLE_GUIDE compliance gate (read → apply → verify)
+
+**(a) Before the spike** — read the sections that apply to this shape and design against them.
+High-frequency: §Resource Package File Conventions; §Schema Guidelines → §Attribute names
+mirror the admin UI, §User-facing descriptions are UI-aligned; §Sets vs Lists (**Computed
+nested collections are `types.List`**); §Server-derived computed fields & `Optional+Computed`;
+§`SingleNestedAttribute` blocks: Optional-only with typed-pointer models; §Cross-field
+validation; §Plaintext secrets `WriteOnly` / §Server-minted secrets `Computed+Sensitive`;
+§ID type handling; §Import format; §Delete semantics; §Shared abstractions. ProClassic adds
+§Classic XML PUT merge where empty clears, §Classic sub-collections, §Field-order-sensitive
+classic write payloads, §Form-decoded classic input fields.
+
+**(b) In the spike doc** — each non-trivial decision names the section it follows, or justifies
+the divergence so the maintainer can rule on it at the §2.7 pause.
+
+**(c) Pre-PR re-check** — walk the (a) list against the actual code. Structural checks miss
+prose, so this pass is **mechanical too**:
+
+```sh
+grep -n "MarkdownDescription" internal/<path>/*.go \
+  | grep -iE "api|wire|server|endpoint|PUT|GET|POST|DELETE|HTTP|sdk|/v1/|/JSSResource"
+```
+
+Judge the hits: "Jamf Pro rejects…" as product framing is fine, protocol framing is not.
+
+---
+
+## 6. Done definition
+
+- ✅ §2 complete; spike decisions cite their sections; spike doc deleted, findings lifted.
+- ✅ Acceptance coverage complete per `references/acceptance.md` — no "deferred to follow-up".
+- ✅ `make fix fmt lint test` clean; `make generate` run after the last HCL edit; `docs/` committed.
+- ✅ §5(c) re-check passed, including the description grep; quality gate passed.
+- ✅ Planner row/card flipped; acceptance suite handed to the maintainer to run
+  (`feedback_user_runs_acc_tests` — the maintainer runs acceptance, not the agent).
+
+---
+
+## References
+
+| File | Contents |
+|---|---|
+| `references/pro.md` | Pro / ProClassic: the CONTRIBUTING workflow, payload audit gate, version floor, annotation block |
+| `references/security_cloud.md` | Security Cloud: Configure, entitlement, the recurring shapes, acc scope declaration |
+| `references/platform.md` | Platform Services: scope gate, no version gate, GA cutover |
+| `references/actions.md` | Actions: no state, framework limits on secrets, partial-failure diagnostics |
+| `references/functions.md` | Provider-defined functions: offline, `types.Dynamic`, both sides of the seam |
+| `references/wire-probes.md` | How to probe the gateway, and how to record results honestly |
+| `references/naming.md` | The UI-naming review: names, enum values, what to keep wire-spelled |
+| `references/acceptance.md` | Coverage requirements + the harness traps found live |

--- a/.claude/skills/new-construct/references/README.md
+++ b/.claude/skills/new-construct/references/README.md
@@ -1,0 +1,8 @@
+# References
+
+Loaded on demand by `../SKILL.md` — read the family file for the construct being built, plus
+`wire-probes.md`, `naming.md` and `acceptance.md`, which apply to every family.
+
+These files deliberately do **not** restate `STYLE_GUIDE.md`, `CONTRIBUTING.md` or
+`TESTING.md`. They carry build order, gates, and findings that have no other home. When a rule
+here disagrees with the style guide, the style guide is right and this file needs fixing.

--- a/.claude/skills/new-construct/references/acceptance.md
+++ b/.claude/skills/new-construct/references/acceptance.md
@@ -1,0 +1,71 @@
+# Acceptance tests
+
+Authoritative: `TESTING.md` §Writing Acceptance Tests — the coverage requirements there are
+the contract, and `internal/resources/pro/enrollment_customization/resource_acceptance_test.go`
+is the reference enumeration. Copy from it. This file adds the harness traps and the things
+`TESTING.md` cannot say for you.
+
+## The contract, in one line each
+
+A single Create-only test is not sufficient. Collectively the suite must exercise: a
+multi-step **Update round-trip** (every non-`RequiresReplace` attribute, a nested element add
+**and** remove, a computed sibling re-resolving); an **`ExpectError` per declared cross-field
+validator**; an **`ImportStateVerify` round-trip** with every `ImportStateVerifyIgnore` entry
+justified in a comment; **one happy path per mutually-exclusive shape**; and **drift-recovery**
+assertions for self-healing computed attributes. `//go:build acceptance` on line 1 or the file
+leaks into the unit run.
+
+## Harness traps
+
+- **A `TestStep` cannot set both `Config` and `RefreshState`** — the framework refuses before
+  running anything. A drift/disappears test is `{Config: cfg}` then
+  `{PreConfig: deleteOutOfBand, RefreshState: true, ExpectNonEmptyPlan: true}`; the refresh
+  step reuses the preceding config.
+- **`ExactlyOneOf` emits two different summaries** — "Invalid Attribute Combination" when both
+  are set, "Missing Attribute Configuration" when neither is. A regex matching one passes for
+  the wrong reason on the other. Match the shared detail (`Exactly one of these attributes
+  must be configured`).
+- **Terraform wraps error output at ~80 columns**, so an `ExpectError` regex must not depend on
+  whitespace at the wrap point. Anchor on no-space tokens.
+- **Read the failure output before assuming a provider bug.** Six failures on the Security
+  Cloud suite's first live run were all stale assertions — the printed state map showed the
+  provider writing the correct values.
+- **Never pipe a test run through `tail`** when logging in the background: the pipeline's exit
+  status becomes `tail`'s, so a run looks green while the package you cared about never
+  reported. Redirect the whole log, then grep it.
+- **Do not cancel an in-progress acceptance run** to save time — a killed run skips
+  `CheckDestroy` and orphans `tf-acc-*` fixtures across the shared tenant.
+
+## Absence is not a result
+
+A fixture that cannot find the tenant object it needs **skips** — it never infers, and it never
+substitutes a guess. The same applies to gates: a Pro-only tenant is a legitimate environment
+for a Security Cloud suite to skip in, not a failure. And a suite that skips everywhere still
+prints green: report skips as skips.
+
+## Async computed values do not round-trip
+
+A `Computed` attribute the server populates asynchronously can read empty on a plain GET even
+on a settled object, so it belongs in `ImportStateVerifyIgnore` alongside `timeouts` and
+WriteOnly secrets. Do **not** add a readiness poll in `Read` to force it — for a GET-sensitive
+value that turns a transient empty into a hard refresh error.
+
+## Tenant-prerequisite fixtures
+
+Some features only exist when the tenant is in a prerequisite state. Stand the prerequisite up
+as an in-config fixture the subject `depends_on`, so the apply orders it first. A prerequisite
+that needs no live connectivity can be a dummy needing no env var; one that needs real external
+infra is env-gated and `t.Skipf`s when unset. Prefer a fixture that mutates the tenant
+minimally and reversibly, and remember that many prerequisite singletons have state-only
+deletes — teardown leaves the tenant in the fixture's state.
+
+## Who runs them
+
+The maintainer runs the acceptance suite against their tenant; hand off after unit tests and
+lint are clean, with the exact command:
+
+```sh
+make testacc-run RUN=<regex> PKG=./internal/resources/<path>/
+```
+
+Before trusting CI's scope, compute it: `go run scripts/acctargets/main.go origin/main`.

--- a/.claude/skills/new-construct/references/functions.md
+++ b/.claude/skills/new-construct/references/functions.md
@@ -1,0 +1,38 @@
+# Provider-defined functions
+
+Authoritative: `STYLE_GUIDE.md` §Provider Function File Conventions and §Testing a provider
+function. Functions are **offline** — called before provider configuration is evaluated, so no
+SDK client, no credentials, no provider config. Namespace: `jamfplatform::<fn>`, package
+`internal/functions/<fn>/`.
+
+## Shape
+
+`function.go` holds `Metadata`, `Definition` and `Run` plus the argument decode; a separate
+`<core>.go` holds the framework-free core returning `([]byte, error)` or a plain value. `Run`
+decodes, delegates, sets the result — nothing else.
+
+Declare arguments as `function.DynamicParameter` and decode with `req.Arguments.Get` →
+`helpers.TerraformDynamicToJSON` → `map[string]any`. `DynamicParameter` rather than a typed
+`ObjectParameter`/`ListParameter` is deliberate: it lets a heterogeneous input — a list whose
+objects have different key sets — decode as a cty tuple instead of being rejected for
+non-uniform element types. Guard the top-level type assert and return
+`function.NewArgumentFuncError(argIndex, …)` on mismatch.
+
+Share a core between related functions rather than duplicating it (`mcx_forced_payload` imports
+`mobileconfig` for `Assemble`). At a third consumer, lift the neutral core into its own package
+that each function imports, rather than importing one function package from another.
+
+Register via the provider's `Functions()` method.
+
+## Testing both sides of the seam
+
+- **Core unit tests** feed Go values straight to the core — fast, exhaustive, and where golden
+  output is pinned.
+- **`Run` seam tests** build a real `types.Dynamic` and call `Run` through
+  `function.NewArgumentsData([]attr.Value{…})`, asserting the happy path **and** at least one
+  argument-error path. This is the path Terraform actually invokes; core tests bypass it.
+- **Acceptance** invokes the function from a real config through an `output` and asserts with
+  `statecheck.ExpectKnownOutputValue` + `knownvalue.StringRegexp`. It **must not** call
+  `testhelpers.AccPreCheck` — that gates on tenant credentials and would skip. Call
+  `testhelpers.AccPreCheckOffline(t)`, use `ProtoV6ProviderFactories` directly, and gate only
+  on `tfversion.SkipBelow(tfversion.Version1_8_0)`.

--- a/.claude/skills/new-construct/references/naming.md
+++ b/.claude/skills/new-construct/references/naming.md
@@ -1,0 +1,62 @@
+# The UI-naming review
+
+Authoritative: `STYLE_GUIDE.md` §Attribute names mirror the Jamf Pro admin UI when the wire
+name is cryptic, §Translating UI labels/presets to wire values, §User-facing descriptions are
+UI-aligned. Run this review **before the schema exists**. Renames are free while the provider
+is unshipped and breaking after merge, so late is the expensive direction.
+
+## The rule, including the half that gets missed
+
+Rename to the UI label when the wire name is cryptic **OR differs materially from it**. The OR
+is the part that gets dropped: `datacenter` is not cryptic, but the UI says "Egress region"
+and never "datacenter" — so it renames.
+
+**Enum values follow the UI too**, not just attribute names: `"AES-256"` → `aes256`,
+`"Group 14 (modp2048)"` → `modp2048`, `"First available"` → `ACTIVE_STANDBY`,
+`"30 minutes"` → `1800`. Be consistent across a resource — translating one enum and leaving
+its neighbour wire-spelled reads badly in a single config. Skip the table only when the UI and
+wire strings are identical.
+
+## What stays wire-spelled
+
+A UX phrase is not a field name. Keep the wire-ish name when the UI label describes a
+*relationship* rather than naming the value: "Reachable via" → `gateway_id`, "Choose your
+gateways" → `gateway_ids`. `reachable_via = "a7d2"` says nothing. Keep the **ID** rather than
+the name wherever a sibling resource reference has to work.
+
+## Where the mapping lives
+
+`mappings.go` — "Lookup tables and name mappings" in the file-conventions table. There is no
+`enums.go` in that table; do not invent one.
+
+The wire mapping goes in the **package doc comment as a table**, not in comments beside each
+attribute: a schema is built inside a function body, and STYLE_GUIDE:11 forbids comments there.
+
+## Keeping a label table honest
+
+A round-trip test passes by construction even with a wrong pairing, so use three guards
+instead:
+
+1. Key the map on the SDK's generated value **constants** — a renamed value breaks the build.
+2. Derive the accepted-label slice from the SDK's `*Values()` helper — a coverage test then
+   catches a value with no label, and a label outliving its value.
+3. Wire-probe every stored value.
+
+Flag any label you did not read off an actual screen. A wrong label is a docs bug, not a
+data-integrity one — but say which you are unsure of.
+
+## Scope of the review
+
+Run it across **every construct in the PR**, not just the one asked about. The pass that fixed
+the ZTNA gateway found the same class of miss in the DNS zone (`name_servers` →
+`authoritative_name_servers`, `ip` → `ip_address`) and, separately, an IPv4 validator
+duplicated across both packages — extracting it per the 2-consumer rule exposed a real bug the
+duplication had been hiding.
+
+## After a rename, the sweep
+
+A grep for the old attribute name misses: the *key* of a `TestCheckTypeSetElemNestedAttrs`
+map (`map[string]string{"ip": …}`), dotted state paths (`"…name_servers.0.ip"`), and HCL
+arguments whose alignment padding differs (`datacenter         = %q` when you matched
+`datacenter = %q`). Grep the old **value** literals too — a rename that changed the vocabulary
+invalidates assertions on values, not just names (`"1800"` → `"30 minutes"`).

--- a/.claude/skills/new-construct/references/platform.md
+++ b/.claude/skills/new-construct/references/platform.md
@@ -1,0 +1,37 @@
+# Platform Services
+
+Blueprints, Compliance Benchmarks (cbengine), devices, device groups. The oldest constructs in
+the provider and the loosest-gated.
+
+## Configure
+
+No helper. Hand-roll the type-assert on `*providerdata.Data`, then apply the per-construct
+scope gate:
+
+```go
+resp.Diagnostics.Append(pd.RequireScope("jamfplatform_<name>",
+    providerdata.ScopeEnvironment, providerdata.ScopeTenant)...)
+```
+
+Pass the allowed kinds in preference order — environment first, because that is the order the
+diagnostic lists them in. **No version gate**: these target continuously-deployed microservices
+with no customer-tenant version, so no `minJamfProVersion` and no `ConfigurePro`.
+
+No SDK-endpoints annotation block either — that requirement is Pro / ProClassic only.
+
+## The GA cutover is coming for the scope list
+
+Blueprints and Compliance Benchmarks become **environment-only** at the Platform API GA, at
+which point their `RequireScope` call sites drop `ScopeTenant`. That is the one-token narrowing
+the per-construct gate was built for — see the `project_platform_api_ga_cutover` memory for the
+four breaking changes in that cutover. Do not pre-emptively drop it; do not add a new call site
+that would be awkward to narrow.
+
+## Blueprint legacy payloads are validated against Apple's schema
+
+Anything touching `component_blocks[].legacy_payloads` goes through
+`internal/common/appleprofiles`. The rules there are wire-established and asymmetric — an
+unknown *payload type* is rejected and matched case-sensitively; an unknown *key* is silently
+discarded; a key differing only in case is silently stored under Apple's spelling; enum and
+range constraints are **not** enforced. `CLAUDE.md` §Apple profile schemas has the orientation;
+do not re-derive it by probing.

--- a/.claude/skills/new-construct/references/pro.md
+++ b/.claude/skills/new-construct/references/pro.md
@@ -1,0 +1,54 @@
+# Jamf Pro / ProClassic
+
+Authoritative: `CONTRIBUTING.md` §Adding a Jamf Pro Resource (the 11-step workflow),
+`STYLE_GUIDE.md` §Jamf Pro Resource Naming, §Minimum Jamf Pro version check,
+§Endpoint adoption & migration policy. Read those. This file carries only what a build
+needs held in mind at the same time.
+
+## Choosing the layer
+
+Default to `pro/`. Switch to `proclassic/` only when `pro/` is missing the namespace or is
+materially less feature-complete. The user never learns which one you picked — the Terraform
+name is `jamfplatform_pro_<x>` either way.
+
+## ProClassic SDK payload audit — a gate, not a review
+
+If the layer is `proclassic/`, run `CONTRIBUTING.md` §ProClassic SDK payload audit **before
+writing any Terraform code**. Any gap — `*[]any`, a missing field, a divergent write shape, a
+mis-tagged bare slice — **must be fixed upstream and a new SDK tag cut** before the provider
+code is written. Do not hand-decode around an SDK defect.
+
+Stop-to-modify-the-SDK is the norm here, not an exception; the `feedback_proclassic_sdk_fix_toolbox`
+memory carries the defect taxonomy. A mis-tagged bare slice is a data-loss bug, not a cosmetic
+one — the `class` build stopped on seven of them.
+
+## Version floor
+
+Every Pro construct declares an unexported `const minJamfProVersion` and funnels Configure
+through `providerdata.ConfigurePro` / `ConfigureProClassic` — never a hand-rolled type-assert,
+version fetch, gate and floor-warning. Source the floor from Jamf release notes, the SDK
+function's `// Available since` comment, or hand-research, and record it in the inventory.
+
+## Endpoint annotation block
+
+`crud.go` opens with the SDK-endpoints annotation block carrying
+`Status: current. Last reviewed YYYY-MM-DD.` — Pro and ProClassic only; Platform Services
+constructs are exempt. Endpoint paths and SDK function names live **here and in Go comments**,
+never in user-facing schema text.
+
+## Classic write semantics to probe, never assume
+
+Each of these bit a shipped build. They are per-endpoint, not per-namespace:
+
+- **Merge PUT where empty clears** — omit to retain, empty to clear. Always-emit scalars.
+- **Sub-collection omit / `[]` / present** semantics — and whether clearing is gated on a
+  discriminator transition.
+- **Field-order sensitivity** in the XML body — a 500 on Create that looks transient.
+- **Form-decoded input fields** needing encode-on-write.
+- **Subset reads that silently drop structure** — the classic policy subset drops
+  `PackageConfiguration` entirely; use the full get.
+
+## Inventory and planner
+
+`spike/JAMF_PRO_INVENTORY.md` is gitignored by design — edit locally, never commit. Flip
+`in-design` → `in-progress` → `shipped`. The online planner is GitHub Project #2, not Jira.

--- a/.claude/skills/new-construct/references/security_cloud.md
+++ b/.claude/skills/new-construct/references/security_cloud.md
@@ -1,0 +1,70 @@
+# Jamf Security Cloud
+
+Authoritative: `STYLE_GUIDE.md` §Jamf Security Cloud Resource Naming — including
+§Security Cloud shapes that recur and §Security Cloud Configure. `CLAUDE.md` carries the
+one-paragraph orientation. Read both; this file is the build-order overlay.
+
+## The two things most likely to be got wrong
+
+**Configure is `ConfigureSecurityCloud`, never `ConfigurePro`.** Security Cloud is
+continuously deployed, has no customer-tenant version, and a tenant can hold it without
+holding Jamf Pro — so a Pro version fetch is both meaningless and fatal. There is no
+`minJamfProVersion` in these packages.
+
+**Entitlement is not authentication.** A perfectly valid integration is still refused with
+`403 NOT_ENTITLED`. Translate the code into a named diagnostic rather than surfacing the raw
+error.
+
+## Diagnostics the server will not write for you
+
+| Server says | Actually means | Point the diagnostic at |
+|---|---|---|
+| `403 NOT_ENTITLED` | tenant lacks the Security Cloud surface | the construct, naming the entitlement |
+| `400 [INVALID_FIELD] Request body is missing or malformed.` | an enum value the server does not accept — **no field, no value named** | prevented at plan time; validate every enum |
+| `422 GATEWAY_NOT_FOUND` | a DNS zone written before its gateway exists | `name_servers`, not the zone |
+| `409 CONFLICT` (bare) | something still references the object you are deleting | a destroy-ordering diagnostic naming the possible referrers |
+
+The 409 is a Terraform destroy-ordering trap: removing the reference *and* destroying the
+target in one apply lets Terraform sequence the destroy first. Say so, because the server
+will not.
+
+## Build every enum from the SDK's own helper
+
+Because an enum violation is unattributed, validate at plan time — and build **both** the
+`OneOf` validator and the documented value list from the SDK's generated `*Values()` helper,
+so they cannot drift from each other or from the API. Where the SDK documents a set but
+generates no helper, restate it in `mappings.go` and say why in a comment.
+
+## Single-element arrays are scalars
+
+Several fields are declared as arrays and rejected at any size but one (the IPsec cipher
+suites' `encryption` / `integrity` / `dhGroups`, `left.subnets`). Model as a single value and
+collapse at the boundary. A list only offers room the server refuses, and the refusal names
+the field's size rather than the mistake.
+
+## Read-only status timestamps stay out of the schema
+
+A field that advances on every server-side re-evaluation (`status.updatedAt`) makes every
+refresh report drift about something no configuration can act on. Omit it, say so in the state
+builder's doc comment, and keep the fields that settle (`status.state`, `status.tunnelState`)
+and those that never move (`createdAt`).
+
+## Acceptance gating
+
+Call `testhelpers.AccPreCheckSecurityCloud`, never bare `AccPreCheck`. It requires the operator
+to **declare** that the configured scope is a Security Cloud one —
+`JAMFPLATFORM_SECURITY_CLOUD_{ENVIRONMENT,TENANT}_ID` set **and equal** to the corresponding
+`JAMFPLATFORM_*` value. Unset, both set, or mismatched → skip. The equality check is what makes
+the declaration load-bearing: a stale value from another tenant skips rather than running
+against the wrong estate.
+
+Neither variable is set in CI, so every Security Cloud acceptance test skips there. **Green CI
+and zero coverage are indistinguishable** — do not report one as the other. Anything needing a
+`tenantIds` value (gateways, grouped gateways) additionally cannot run under an
+environment-scoped integration at all, because no API exposes an environment's tenants.
+
+Untested, and worth stating in any PR that touches Configure: the Security Cloud surface under
+`X-Environment-Id`. Every wire probe used a tenant-scoped integration;
+`ConfigureSecurityCloud` admits both scopes on the strength of the spec. If `/api/securitycloud`
+turns out not to answer under an environment header, the fix is dropping `ScopeEnvironment`
+from that one call.

--- a/.claude/skills/new-construct/references/wire-probes.md
+++ b/.claude/skills/new-construct/references/wire-probes.md
@@ -1,0 +1,65 @@
+# Wire probes
+
+Wire evidence drives schema decisions, so collect it **before** sketching the schema. Raw
+bodies go under `local-testing/<endpoint>/` (gitignored). Never paste real device UDIDs,
+serials, tenant names or directory names into a committed file.
+
+## Reaching the gateway directly
+
+Scope travels in a **header**, not the URL path (SDK v0.17.0 onward). Probe recipes written
+before that — including every kickoff prompt in `.claude/prompts/` — put
+`/tenant/<tenant-id>/` in the path and are wrong now.
+
+```sh
+TOK=$(jamf-cli platform auth token --field token -p <profile>)   # opaque, not a JWT
+jamf-cli config list                                            # region + tenant-id per profile
+
+# Pro: version segment in the path, scope in the header
+curl -s -H "Authorization: Bearer $TOK" -H "X-Tenant-Id: <tenant-id>" \
+  "https://<region>.apigw.jamf.com/api/pro/v1/<endpoint>"
+
+# ProClassic: no version segment, no JSSResource segment, and ask for JSON
+curl -s -H "Authorization: Bearer $TOK" -H "X-Tenant-Id: <tenant-id>" \
+  -H "Accept: application/json" \
+  "https://<region>.apigw.jamf.com/api/proclassic/<classic-resource>"
+
+# Security Cloud: one unified prefix for all five namespaces
+curl -s -H "Authorization: Bearer $TOK" -H "X-Tenant-Id: <tenant-id>" \
+  "https://<region>.apigw.jamf.com/api/securitycloud/<endpoint>"
+```
+
+`X-Environment-Id` substitutes for `X-Tenant-Id` under an environment-scoped integration —
+sending the wrong one is `403 OWNERSHIP_FORBIDDEN` even when both IDs belong to the same
+customer. Capture the real URL of any CLI command with `-vvv`. Authoritative prefix logic
+lives in the SDK's `internal/client`.
+
+Two `jamf-cli` traps: a classic update through the CLI is read-modify-write, so use raw curl
+when probing what a bare PUT does; and `jamf-cli delete` needs `--yes` or it hangs waiting on
+a prompt that never renders.
+
+## The probe list worth writing down
+
+At minimum, per endpoint:
+
+| Probe | Answers |
+|---|---|
+| `GET` at factory defaults | are sub-objects present-but-null, or absent? decides Read normalisation |
+| `GET` minimal vs populated | which fields the server omits vs nulls |
+| `POST` create request + response | fields the create drops (a POST-then-PUT dance may be needed) |
+| `PUT` partial vs full body | full-replace or merge; what an omitted field does |
+| `PUT` with `{}` / `{"block": {}}` | does empty clear, get rejected, or preserve? |
+| collection `[]` vs omitted vs populated | the three-way clear semantics — **per resource, never inherited** |
+| an out-of-vocabulary enum value | is it enum-constrained or freeform? |
+| a value outside the UI's presets | `OneOf` validator or range validator? |
+| unit-bearing fields | the wire multiplier behind a UI number+unit control |
+
+## Honesty rules
+
+- A probe you did not run is marked **NOT-PROBED with the reason**. Never write a
+  plausible-looking result you inferred. In a pre-spike doc, every entry is a *probe to run*,
+  not a finding — label it that way so the next reader cannot mistake one for the other.
+- **Probes mutate.** Anything destructive runs against disposable test devices or a
+  non-production tenant, or it is marked NOT-PROBED.
+- Absence of tenant data is not evidence. If the tenant has no object of the needed kind, the
+  test skips — it does not infer.
+- Respect the load budget: max 5 concurrent requests, ~10 req/s.

--- a/.gitignore
+++ b/.gitignore
@@ -146,8 +146,10 @@ tfsec-report.json
 
 # -----------------------------------------------------------------------------
 # Claude Code local state (worktrees, agent runs, settings overrides)
+# The skills directory is committed: it encodes the construct-build workflow.
 # -----------------------------------------------------------------------------
-.claude/
+.claude/*
+!.claude/skills/
 
 # -----------------------------------------------------------------------------
 # Local planning artifacts (not committed)


### PR DESCRIPTION
## What

Adds `.claude/skills/new-construct/` — the workflow for adding a resource, data source, list resource, action or provider-defined function to this provider — and un-ignores `.claude/skills/` so it is versioned and reviewable.

```
SKILL.md                        router: classify family + shape, gate order, guard-rails, done definition
references/pro.md               Pro / ProClassic: payload audit gate, version floor, classic write probes
references/security_cloud.md    Configure, entitlement vs auth, the unattributed error codes, acc scope declaration
references/platform.md          RequireScope, no version gate, the GA cutover
references/actions.md           no state; action secrets have no framework protection available
references/functions.md         offline, types.Dynamic, both sides of the framework seam
references/wire-probes.md       header-scoped probe recipes, and the honesty rules for recording them
references/naming.md            the admin-UI naming review, and the post-rename assertion sweep
references/acceptance.md        the coverage contract plus the harness traps found live
```

## Why

The order of work is the part that goes wrong, not the knowledge. Four gates are cheap in their place and expensive out of it:

| Gate | Late cost |
|---|---|
| ProClassic SDK payload audit before any Terraform code | provider-side decoders working around a fixable SDK bug |
| Admin-UI naming review before the schema | schema, tests, examples and docs rewritten |
| Collection write-semantics probe before modelling | silent data loss, found by a user |
| `make generate` after the last HCL edit | ships a stale, sometimes invalid, inlined example |

The Security Cloud branch paid for the second one twice — `9fca58b` and `645101e` are naming refactors landing *after* the build — and `fd50a81` fixed acceptance defects the first live run exposed. Both lessons already existed; neither was applied at the right moment.

## Why not leave it in `.claude/prompts/`

That is where it was, as 56 hand-forked kickoff documents, gitignored and unreviewable. Each fork re-copied the skeleton, so refinements propagated by hand or not at all:

- **51 of 56** name a nested `internal/resources/pro/<domain>/<entity>/` layout that no longer exists — the tree is flat, 102 packages.
- **17** cite memory files as `../../README.md` — dead links.
- **Every** wire-probe recipe puts `/tenant/<id>/` in the URL path. SDK v0.17.0 moved scope into the `X-Tenant-Id` / `X-Environment-Id` header; the provider pins v0.19.1, so those probes now 404.
- Last edited 2026-06-14. The Security Cloud family arrived ten weeks later with no prompt at all.

Committing is what makes that rot visible: a PR moving a STYLE_GUIDE section can now update the skill in the same diff.

## Design: routes, does not restate

`STYLE_GUIDE.md`, `CONTRIBUTING.md` and `TESTING.md` stay authoritative and are cited by anchor. The skill owns only what has no other home — gate order, guard-rails traceable to the builds that paid for them, and findings previously scattered across agent memory. Copying the rules in is what killed the prompt library; a second source of truth drifts from a style guide that moves weekly. `references/README.md` says so explicitly, so the next editor does not helpfully paste rules in.

## Risk

- `.claude/` stays ignored apart from `skills/`; local agent state, worktrees and settings overrides are unaffected. Verified with `git add -n .claude/` — exactly the nine files here.
- Markdown and `.gitignore` only, both `fileIgnore` in `scripts/acctargets`. `go run scripts/acctargets/main.go origin/main` returns empty, so no acceptance package is gated and the acceptance job skips.
- No tenant identifiers, profile names, UUIDs or addresses in the added files — checked, since this repo is heading public.
- All relative links and STYLE_GUIDE / TESTING anchors resolve.

## Follow-up, not in this PR

Deleting the superseded prompts: 46 are for shipped constructs whose findings are already lifted, 2 are superseded by this skill (the base template and a typo'd duplicate). Three need harvesting first — `extension-attributes` (6 of 9 planned constructs unbuilt), `audit-pro-optional-field-write-semantics` (sweep completion unrecorded), and `patch-management` (memory says paused on an SDK defect).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
