### PR TITLE
fix(security_cloud): make the sibling diagnostics say what the server said

### DIFF
--- a/internal/common/helpers/helpers_test.go
+++ b/internal/common/helpers/helpers_test.go
@@ -206,6 +206,19 @@ func TestIsNotFoundError(t *testing.T) {
 		{"nil", nil, false},
 		{"plain error", errors.New("some error"), false},
 		{"404 response", &jamfplatform.APIResponseError{StatusCode: 404}, true},
+		// The 400 + INVALID_ID arm is the Pro-ism half of this function and had no
+		// fixture at all: removing it left the suite green. The 404 case above carries
+		// no Details, so it can only pass via the status arm — the two are pinned
+		// independently.
+		{"400 with INVALID_ID", &jamfplatform.APIResponseError{
+			StatusCode: 400,
+			Errors:     []jamfplatform.ErrorDetail{{Code: "INVALID_ID"}},
+		}, true},
+		{"400 with another code", &jamfplatform.APIResponseError{
+			StatusCode: 400,
+			Errors:     []jamfplatform.ErrorDetail{{Code: "INVALID_FIELD"}},
+		}, false},
+		{"400 with no details", &jamfplatform.APIResponseError{StatusCode: 400}, false},
 		{"500 response", &jamfplatform.APIResponseError{StatusCode: 500}, false},
 		{"200 response", &jamfplatform.APIResponseError{StatusCode: 200}, false},
 	}

--- a/internal/resources/security_cloud/dns_zone/data_source.go
+++ b/internal/resources/security_cloud/dns_zone/data_source.go
@@ -131,12 +131,24 @@ func (d *DNSZoneDataSource) Read(ctx context.Context, req datasource.ReadRequest
 	readCtx, cancel := context.WithTimeout(ctx, readTimeout)
 	defer cancel()
 
+	if !data.ID.IsNull() && data.ID.ValueString() == "" {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("id"),
+			"DNS zone ID is empty",
+			"`id` is set to an empty string, which ExactlyOneOf still counts as configured, so `name` cannot "+
+				"be used instead. This usually means a variable or a reference resolved to \"\" — set `id` to "+
+				"an ID, or remove it and set `name`.",
+		)
+		return
+	}
+
 	var zone *securitycloud.Zone
 	var err error
-	if !data.ID.IsNull() && data.ID.ValueString() != "" {
-		zone, err = d.client.GetDnsZoneV1(readCtx, data.ID.ValueString())
-	} else {
+	byName := data.ID.IsNull()
+	if byName {
 		zone, err = d.client.ResolveDnsZoneV1ByName(readCtx, data.Name.ValueString())
+	} else {
+		zone, err = d.client.GetDnsZoneV1(readCtx, data.ID.ValueString())
 	}
 	if err != nil {
 		if ambiguous, ok := errors.AsType[*jamfplatform.AmbiguousMatchError](err); ok {
@@ -145,6 +157,16 @@ func (d *DNSZoneDataSource) Read(ctx context.Context, req datasource.ReadRequest
 				"Jamf Security Cloud does not require zone names to be unique, and more than one zone is named "+
 					data.Name.ValueString()+". Look the zone up by `id` instead. Matching zone IDs: "+
 					strings.Join(ambiguous.Matches, ", "),
+			)
+			return
+		}
+		if byName && helpers.IsNotFoundError(err) {
+			resp.Diagnostics.AddAttributeError(
+				path.Root("name"),
+				"Unable to find Jamf Security Cloud DNS zone",
+				"No DNS zone on this tenant is named \""+data.Name.ValueString()+"\". Names are matched "+
+					"exactly, so one differing only in capitalisation or surrounding whitespace will not be "+
+					"found. Use the `jamfplatform_security_cloud_dns_zones` data source to list what exists.",
 			)
 			return
 		}

--- a/internal/resources/security_cloud/dns_zone/resource_acceptance_test.go
+++ b/internal/resources/security_cloud/dns_zone/resource_acceptance_test.go
@@ -551,9 +551,57 @@ func captureDNSZoneID(address string, into *string) resource.TestCheckFunc {
 // Expected-error patterns for the plan- and apply-time refusals. Terraform wraps
 // diagnostic text at roughly 80 columns, so each pattern matches a short phrase
 // that cannot be split across a line break.
+// TestAccDataSource_SecurityCloudDNSZone_EmptyIDRefused pins the guard for the
+// selector mistake ExactlyOneOf cannot catch.
+//
+// A set-but-empty `id` counts as configured, so `id = var.x` with an unset variable
+// satisfies the config validator and then falls through to whichever lookup is
+// left. Without the guard the name branch runs with a null name, and the operator
+// gets an SDK-internal string about an attribute they never set.
+func TestAccDataSource_SecurityCloudDNSZone_EmptyIDRefused(t *testing.T) {
+	testhelpers.AccPreCheckSecurityCloud(t)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testhelpers.AccTestProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+					data "jamfplatform_security_cloud_dns_zone" "empty_id" {
+						id = ""
+					}
+				`,
+				ExpectError: regexpEmptyID,
+			},
+		},
+	})
+}
+
+// TestAccDataSource_SecurityCloudDNSZone_NameNotFoundIsWritten pins that a name
+// matching nothing produces a written diagnostic rather than the resolver's
+// synthetic 404 body, which reads as an internal error and names no remedy.
+func TestAccDataSource_SecurityCloudDNSZone_NameNotFoundIsWritten(t *testing.T) {
+	testhelpers.AccPreCheckSecurityCloud(t)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testhelpers.AccTestProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+					data "jamfplatform_security_cloud_dns_zone" "missing" {
+						name = "tf-acc-no-such-dns_zone-zzz"
+					}
+				`,
+				ExpectError: regexpNameNotFound,
+			},
+		},
+	})
+}
+
 var (
 	regexpDuplicateIP        = regexp.MustCompile(`Duplicate ip_address within set`)
 	regexpInvalidIP          = regexp.MustCompile(`Invalid IPv4 address`)
 	regexpGatewayNotFound    = regexp.MustCompile(`Referenced gateway not found`)
 	regexpExactlyOneSelector = regexp.MustCompile(`Exactly one of these attributes must be configured`)
+	regexpEmptyID            = regexp.MustCompile(`ID is empty`)
+	regexpNameNotFound       = regexp.MustCompile(`on this tenant is named`)
 )

--- a/internal/resources/security_cloud/uem_connect/data_source.go
+++ b/internal/resources/security_cloud/uem_connect/data_source.go
@@ -212,12 +212,8 @@ func (d *UEMConnectDataSource) Read(ctx context.Context, req datasource.ReadRequ
 		}
 		return
 	}
-	if page == nil || len(page.Results) == 0 {
-		resp.Diagnostics.AddError(
-			"No UEM Connect integration on this tenant",
-			"Jamf Security Cloud reports no UEM Connect integration for this tenant. Set one up before reading it, "+
-				"with jamfplatform_security_cloud_uem_connect or in the Jamf Security Cloud admin UI.",
-		)
+	resp.Diagnostics.Append(appendMissingIntegrationDiagnostics(page)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/resources/security_cloud/uem_connect/helpers.go
+++ b/internal/resources/security_cloud/uem_connect/helpers.go
@@ -162,3 +162,25 @@ func timePointerValue(v *time.Time) types.String {
 	}
 	return types.StringValue(v.Format(time.RFC3339))
 }
+
+// appendMissingIntegrationDiagnostics refuses a read of a tenant that holds no UEM
+// Connect integration.
+//
+// This is the guard in front of `page.Results[0]`, so a regression here is a
+// provider panic rather than a diagnostic — and unlike most of this package's
+// guards it is reachable in entirely ordinary use, by reading the data source
+// before creating an integration. It lives here rather than inline in the data
+// source so a unit test can drive it: the shape it guards is a plain SDK struct,
+// while the data source's Read needs a live client.
+func appendMissingIntegrationDiagnostics(page *securitycloud.ConnectorPage) diag.Diagnostics {
+	var diags diag.Diagnostics
+	if page != nil && len(page.Results) > 0 {
+		return diags
+	}
+	diags.AddError(
+		"No UEM Connect integration on this tenant",
+		"Jamf Security Cloud reports no UEM Connect integration for this tenant. Set one up before reading it, "+
+			"with jamfplatform_security_cloud_uem_connect or in the Jamf Security Cloud admin UI.",
+	)
+	return diags
+}

--- a/internal/resources/security_cloud/uem_connect/helpers_test.go
+++ b/internal/resources/security_cloud/uem_connect/helpers_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform"
+	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/securitycloud"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 )
 
@@ -129,8 +130,14 @@ func TestIsNotFound(t *testing.T) {
 		err  error
 		want bool
 	}{
-		{"404 status", apiError(http.StatusNotFound, codeNotFound, "Config with ID '0' doesn't exist"), true},
+		// isNotFound has two independent arms — the 404 status, then a Details() scan
+		// for codeNotFound. A fixture carrying both cannot tell you which one fired,
+		// and the case below named "404 status" used to carry both: mutating
+		// http.StatusNotFound to any other status left the whole suite green,
+		// including that case. Each arm now has a fixture only it can satisfy.
+		{"status without the code", apiError(http.StatusNotFound, "SOMETHING_ELSE", "gone"), true},
 		{"code without the status", apiError(http.StatusBadRequest, codeNotFound, "gone"), true},
+		{"both the status and the code", apiError(http.StatusNotFound, codeNotFound, "Config with ID '0' doesn't exist"), true},
 		{"a conflict is not a not-found", apiError(http.StatusConflict, codeConfigAlreadyExists, "exists"), false},
 		{"a transport error is not a not-found", errors.New("connection refused"), false},
 		{"nil", nil, false},
@@ -166,5 +173,32 @@ func TestSortedMapKeys(t *testing.T) {
 			t.Errorf("keys = %v, want %v", got, want)
 			break
 		}
+	}
+}
+
+// TestAppendMissingIntegrationDiagnostics pins the guard standing in front of
+// `page.Results[0]` in the data source. A regression here is a panic, not a
+// diagnostic, and it is reachable by reading the data source on a tenant that has
+// no integration yet.
+func TestAppendMissingIntegrationDiagnostics(t *testing.T) {
+	tests := []struct {
+		name    string
+		page    *securitycloud.ConnectorPage
+		wantErr bool
+	}{
+		{"nil page", nil, true},
+		{"empty results", &securitycloud.ConnectorPage{Results: []securitycloud.ConnectorConfig{}}, true},
+		{"nil results slice", &securitycloud.ConnectorPage{}, true},
+		{"one integration", &securitycloud.ConnectorPage{Results: []securitycloud.ConnectorConfig{{ID: "abc"}}}, false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			diags := appendMissingIntegrationDiagnostics(tc.page)
+
+			if diags.HasError() != tc.wantErr {
+				t.Fatalf("HasError() = %v, want %v (%v)", diags.HasError(), tc.wantErr, diags)
+			}
+		})
 	}
 }

--- a/internal/resources/security_cloud/ztna_gateway/data_source.go
+++ b/internal/resources/security_cloud/ztna_gateway/data_source.go
@@ -213,12 +213,24 @@ func (d *GatewayDataSource) Read(ctx context.Context, req datasource.ReadRequest
 	readCtx, cancel := context.WithTimeout(ctx, readTimeout)
 	defer cancel()
 
+	if !data.ID.IsNull() && data.ID.ValueString() == "" {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("id"),
+			"ZTNA gateway ID is empty",
+			"`id` is set to an empty string, which ExactlyOneOf still counts as configured, so `name` cannot "+
+				"be used instead. This usually means a variable or a reference resolved to \"\" — set `id` to "+
+				"an ID, or remove it and set `name`.",
+		)
+		return
+	}
+
 	var gateway *securitycloud.Gateway
 	var err error
-	if !data.ID.IsNull() && data.ID.ValueString() != "" {
-		gateway, err = d.client.GetZtnaGatewayV1(readCtx, data.ID.ValueString())
-	} else {
+	byName := data.ID.IsNull()
+	if byName {
 		gateway, err = d.client.ResolveZtnaGatewayV1ByName(readCtx, data.Name.ValueString())
+	} else {
+		gateway, err = d.client.GetZtnaGatewayV1(readCtx, data.ID.ValueString())
 	}
 	if err != nil {
 		if ambiguous, ok := errors.AsType[*jamfplatform.AmbiguousMatchError](err); ok {
@@ -227,6 +239,16 @@ func (d *GatewayDataSource) Read(ctx context.Context, req datasource.ReadRequest
 				"Jamf Security Cloud does not require gateway names to be unique, and more than one gateway is "+
 					"named "+data.Name.ValueString()+". Look the gateway up by `id` instead. Matching gateway "+
 					"IDs: "+strings.Join(ambiguous.Matches, ", "),
+			)
+			return
+		}
+		if byName && helpers.IsNotFoundError(err) {
+			resp.Diagnostics.AddAttributeError(
+				path.Root("name"),
+				"Unable to find Jamf Security Cloud ZTNA gateway",
+				"No ZTNA gateway on this tenant is named \""+data.Name.ValueString()+"\". Names are matched "+
+					"exactly, so one differing only in capitalisation or surrounding whitespace will not be "+
+					"found. Use the `jamfplatform_security_cloud_ztna_gateways` data source to list what exists.",
 			)
 			return
 		}

--- a/internal/resources/security_cloud/ztna_gateway/helpers.go
+++ b/internal/resources/security_cloud/ztna_gateway/helpers.go
@@ -5,6 +5,7 @@ package ztna_gateway
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform"
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/securitycloud"
@@ -100,12 +101,21 @@ func appendWriteDiagnostics(diags *diag.Diagnostics, err error) bool {
 // appendDeleteDiagnostics explains the one delete failure that is not a mistake
 // in the configuration but an ordering problem in the plan.
 //
-// Jamf Security Cloud refuses to delete a gateway that anything still references —
-// a custom DNS zone's name server, or membership of a grouped gateway — with a
-// bare `409 CONFLICT` and no structured detail naming the referrer (wire-probed
-// 2026-08-27 from both directions). Terraform will happily plan that destroy when
-// the config dependency edge disappears in the same apply that removes the
-// reference, so this is worth spelling out rather than passing through.
+// Jamf Security Cloud refuses to delete a gateway that anything still references,
+// with a `409 CONFLICT`. Terraform will happily plan that destroy when the config
+// dependency edge disappears in the same apply that removes the reference, so this
+// is worth spelling out rather than passing through.
+//
+// Two things about the referrer list. First, a ZTNA access policy is one, and it is
+// the referrer Terraform can do nothing about: the provider does not manage access
+// policies, so the reference lives in the admin UI and no apply ordering will
+// release it. The bundled spec names GATEWAY_REFERENCED_BY_ACCESS_POLICIES,
+// GATEWAY_REFERENCED_BY_DNS_ZONES and GATEWAY_REFERENCED_BY_GROUPED_GATEWAYS.
+// Second, the 2026-08-27 probe of the zone and grouped-gateway cases returned a
+// bare 409 with no structured detail, so the spec's codes are not something the
+// wire has been seen to send. Details() is therefore appended when present rather
+// than relied on, and the wording no longer asserts that the body says nothing —
+// that was true of the two cases probed, not of the endpoint.
 func appendDeleteDiagnostics(diags *diag.Diagnostics, err error) bool {
 	apiErr := jamfplatform.AsAPIError(err)
 	if apiErr == nil || !apiErr.HasStatus(http.StatusConflict) {
@@ -113,10 +123,31 @@ func appendDeleteDiagnostics(diags *diag.Diagnostics, err error) bool {
 	}
 	diags.AddError(
 		"Gateway is still referenced",
-		"Jamf Security Cloud refuses to delete a gateway that something still points at — a custom DNS zone name "+
-			"server, or membership of a grouped gateway. It does not say which. Remove the reference first, in a "+
-			"separate apply, then destroy the gateway: dropping the reference and the gateway in one apply lets "+
-			"Terraform sequence the destroy before the update that would have released it.",
+		"Jamf Security Cloud refuses to delete a gateway that something still points at: a ZTNA access policy, a "+
+			"custom DNS zone name server, or membership of a grouped gateway. Access policies are not managed by "+
+			"this provider, so if no zone or grouped gateway names this gateway, check its access policies in the "+
+			"Jamf Security Cloud admin UI. For a reference Terraform does manage, remove it first in a separate "+
+			"apply, then destroy the gateway: dropping the reference and the gateway in one apply lets Terraform "+
+			"sequence the destroy before the update that would have released it."+reportedDetails(apiErr),
 	)
 	return true
+}
+
+// reportedDetails renders whatever structured detail an error carries, for the
+// diagnostics that cannot assume one is present.
+//
+// The delete conflict is the case: the probed referrer cases answered with a bare
+// 409, while the spec documents per-referrer codes. Appending what is there costs
+// nothing when there is nothing, and stops the diagnostic contradicting the body
+// if the endpoint starts sending one.
+func reportedDetails(apiErr *jamfplatform.APIResponseError) string {
+	var b strings.Builder
+	for _, detail := range apiErr.Details() {
+		if detail.Description == "" {
+			continue
+		}
+		b.WriteString(" Reported by Jamf Security Cloud: ")
+		b.WriteString(detail.Description)
+	}
+	return b.String()
 }

--- a/internal/resources/security_cloud/ztna_gateway/helpers_test.go
+++ b/internal/resources/security_cloud/ztna_gateway/helpers_test.go
@@ -147,3 +147,54 @@ func TestAppendDeleteDiagnostics_OtherStatusesFallThrough(t *testing.T) {
 		t.Error("a non-API error must not be handled here")
 	}
 }
+
+// TestAppendDeleteDiagnostics_NamesAccessPolicies pins the referrer the operator
+// cannot resolve by reordering applies.
+//
+// The provider does not manage ZTNA access policies, so a gateway referenced by one
+// has no Terraform-visible dependency edge and no apply ordering releases it. The
+// diagnostic used to list only zones and grouped gateways, sending the operator to
+// check two things that were not the cause.
+func TestAppendDeleteDiagnostics_NamesAccessPolicies(t *testing.T) {
+	var diags diag.Diagnostics
+
+	if !appendDeleteDiagnostics(&diags, apiError(http.StatusConflict, "", "")) {
+		t.Fatal("a 409 must be recognised")
+	}
+	if !strings.Contains(diags[0].Detail(), "access polic") {
+		t.Errorf("delete diagnostic must name access policies; got %q", diags[0].Detail())
+	}
+}
+
+// TestAppendDeleteDiagnostics_SurfacesDetailWhenPresent pins that a structured
+// detail is passed through rather than contradicted.
+//
+// The probed referrer cases answered with a bare 409, but the bundled spec
+// documents per-referrer codes with remediation text. If the endpoint starts
+// sending one, the operator must see it — the old wording asserted the body said
+// nothing while never reading it.
+func TestAppendDeleteDiagnostics_SurfacesDetailWhenPresent(t *testing.T) {
+	var diags diag.Diagnostics
+
+	if !appendDeleteDiagnostics(&diags, apiError(http.StatusConflict, "REFERENCED_BY_ACCESS_POLICIES",
+		"Disconnect this from all policies, then try again.")) {
+		t.Fatal("a 409 must be recognised")
+	}
+	if !strings.Contains(diags[0].Detail(), "Disconnect this from all policies") {
+		t.Errorf("delete diagnostic must surface the server's own remedy; got %q", diags[0].Detail())
+	}
+}
+
+// TestReportedDetails covers the shapes the delete conflict can carry, including
+// the bare 409 the wire has actually been seen to send.
+func TestReportedDetails(t *testing.T) {
+	bare := jamfplatform.AsAPIError(apiError(http.StatusConflict, "", ""))
+	if got := reportedDetails(bare); got != "" {
+		t.Errorf("a detail with no description must add nothing, got %q", got)
+	}
+
+	withDetail := jamfplatform.AsAPIError(apiError(http.StatusConflict, "SOME_CODE", "Because reasons."))
+	if got := reportedDetails(withDetail); !strings.Contains(got, "Because reasons.") {
+		t.Errorf("reportedDetails = %q, want it to carry the description", got)
+	}
+}

--- a/internal/resources/security_cloud/ztna_gateway/resource_acceptance_test.go
+++ b/internal/resources/security_cloud/ztna_gateway/resource_acceptance_test.go
@@ -136,8 +136,18 @@ func TestAccResource_SecurityCloudZtnaGateway_InternetGateway(t *testing.T) {
 				ResourceName:      "jamfplatform_security_cloud_ztna_gateway.test",
 				ImportState:       true,
 				ImportStateVerify: true,
+				// status.state is excluded because it is not a property of the
+				// configuration but a server-side deployment state that advances on its
+				// own. The step above sets enabled = false, and Jamf Security Cloud then
+				// moves the gateway from PENDING to DISABLED asynchronously — so the state
+				// stored by that step and the fresh read this import performs can
+				// legitimately disagree, and did: roughly one run in four failed with
+				// `- "status.state": "PENDING"` / `+ "status.state": "DISABLED"`. Comparing
+				// the two is a race, not a check. Same reason STYLE_GUIDE keeps
+				// status.updatedAt out of the schema entirely.
 				ImportStateVerifyIgnore: []string{
 					"timeouts",
+					"status.state",
 				},
 			},
 		},
@@ -193,8 +203,12 @@ func TestAccResource_SecurityCloudZtnaGateway_IPSecGateway(t *testing.T) {
 				ResourceName:      "jamfplatform_security_cloud_ztna_gateway.test",
 				ImportState:       true,
 				ImportStateVerify: true,
+				// status.state: see the internet-gateway import step above — a
+				// server-side deployment state, not a configuration property, and racy to
+				// compare across two reads.
 				ImportStateVerifyIgnore: []string{
 					"timeouts",
+					"status.state",
 					"ipsec.jamf_side.authentication_secret",
 					"ipsec.jamf_side.authentication_secret_wo_version",
 				},
@@ -598,9 +612,57 @@ func ipsecGatewayConfig(name, region, tenantID, jamfSubnet, peerHost, encryption
 // Expected-error patterns for the plan- and apply-time refusals. Terraform wraps
 // diagnostic text at roughly 80 columns, so each pattern matches a short phrase
 // that cannot be split across a line break.
+// TestAccDataSource_SecurityCloudZtnaGateway_EmptyIDRefused pins the guard for the
+// selector mistake ExactlyOneOf cannot catch.
+//
+// A set-but-empty `id` counts as configured, so `id = var.x` with an unset variable
+// satisfies the config validator and then falls through to whichever lookup is
+// left. Without the guard the name branch runs with a null name, and the operator
+// gets an SDK-internal string about an attribute they never set.
+func TestAccDataSource_SecurityCloudZtnaGateway_EmptyIDRefused(t *testing.T) {
+	testhelpers.AccPreCheckSecurityCloud(t)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testhelpers.AccTestProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+					data "jamfplatform_security_cloud_ztna_gateway" "empty_id" {
+						id = ""
+					}
+				`,
+				ExpectError: regexpEmptyID,
+			},
+		},
+	})
+}
+
+// TestAccDataSource_SecurityCloudZtnaGateway_NameNotFoundIsWritten pins that a name
+// matching nothing produces a written diagnostic rather than the resolver's
+// synthetic 404 body, which reads as an internal error and names no remedy.
+func TestAccDataSource_SecurityCloudZtnaGateway_NameNotFoundIsWritten(t *testing.T) {
+	testhelpers.AccPreCheckSecurityCloud(t)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testhelpers.AccTestProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+					data "jamfplatform_security_cloud_ztna_gateway" "missing" {
+						name = "tf-acc-no-such-ztna_gateway-zzz"
+					}
+				`,
+				ExpectError: regexpNameNotFound,
+			},
+		},
+	})
+}
+
 var (
 	regexpSourceAddressesNeedIPSec   = regexp.MustCompile(`IPsec source addresses require an IPsec gateway`)
 	regexpSubnetNotPrivate           = regexp.MustCompile(`is not a private range`)
 	regexpInvalidAttributeValueMatch = regexp.MustCompile(`Invalid Attribute Value Match`)
 	regexpExactlyOneSelector         = regexp.MustCompile(`Exactly one of these attributes must be configured`)
+	regexpEmptyID                    = regexp.MustCompile(`ID is empty`)
+	regexpNameNotFound               = regexp.MustCompile(`on this tenant is named`)
 )

--- a/internal/resources/security_cloud/ztna_grouped_gateway/data_source.go
+++ b/internal/resources/security_cloud/ztna_grouped_gateway/data_source.go
@@ -131,12 +131,24 @@ func (d *GroupedGatewayDataSource) Read(ctx context.Context, req datasource.Read
 	readCtx, cancel := context.WithTimeout(ctx, readTimeout)
 	defer cancel()
 
+	if !data.ID.IsNull() && data.ID.ValueString() == "" {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("id"),
+			"ZTNA grouped gateway ID is empty",
+			"`id` is set to an empty string, which ExactlyOneOf still counts as configured, so `name` cannot "+
+				"be used instead. This usually means a variable or a reference resolved to \"\" — set `id` to "+
+				"an ID, or remove it and set `name`.",
+		)
+		return
+	}
+
 	var group *securitycloud.GroupedGateway
 	var err error
-	if !data.ID.IsNull() && data.ID.ValueString() != "" {
-		group, err = d.client.GetZtnaGroupedGatewayV1(readCtx, data.ID.ValueString())
-	} else {
+	byName := data.ID.IsNull()
+	if byName {
 		group, err = d.client.ResolveZtnaGroupedGatewayV1ByName(readCtx, data.Name.ValueString())
+	} else {
+		group, err = d.client.GetZtnaGroupedGatewayV1(readCtx, data.ID.ValueString())
 	}
 	if err != nil {
 		if ambiguous, ok := errors.AsType[*jamfplatform.AmbiguousMatchError](err); ok {
@@ -145,6 +157,16 @@ func (d *GroupedGatewayDataSource) Read(ctx context.Context, req datasource.Read
 				"Jamf Security Cloud does not require grouped gateway names to be unique, and more than one is "+
 					"named "+data.Name.ValueString()+". Look it up by `id` instead. Matching IDs: "+
 					strings.Join(ambiguous.Matches, ", "),
+			)
+			return
+		}
+		if byName && helpers.IsNotFoundError(err) {
+			resp.Diagnostics.AddAttributeError(
+				path.Root("name"),
+				"Unable to find Jamf Security Cloud ZTNA grouped gateway",
+				"No ZTNA grouped gateway on this tenant is named \""+data.Name.ValueString()+"\". Names are matched "+
+					"exactly, so one differing only in capitalisation or surrounding whitespace will not be "+
+					"found. Use the `jamfplatform_security_cloud_ztna_grouped_gateways` data source to list what exists.",
 			)
 			return
 		}

--- a/internal/resources/security_cloud/ztna_grouped_gateway/helpers.go
+++ b/internal/resources/security_cloud/ztna_grouped_gateway/helpers.go
@@ -5,6 +5,7 @@ package ztna_grouped_gateway
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform"
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/securitycloud"
@@ -26,6 +27,7 @@ const (
 	codeNotEntitled     = securitycloud.ApiErrorItemCodeNotEntitled
 
 	codeMixedTunnelTypes    = "MIXED_TUNNEL_TYPES"
+	codeMixedDedicatedIPs   = "MIXED_DEDICATED_IPS_TYPES"
 	codeSharedGatewayMember = "SHARED_GATEWAY_MEMBER"
 	codeBadRequest          = "BAD_REQUEST"
 )
@@ -36,6 +38,11 @@ const (
 // The membership codes are the ones worth translating, because each describes a
 // property of the *members* rather than of the group being written, and none of
 // the messages says which member is at fault.
+//
+// `MIXED_DEDICATED_IPS_TYPES` is the one that most needs it: the server's message
+// names `dedicatedIps.enabled`, a wire field with no counterpart on this schema at
+// all, so without a translation the operator has to know it means
+// `dedicated_egress_ips_enabled` on each member gateway.
 //
 // `GATEWAY_NOT_FOUND` is the same ordering trap the DNS zone has for its name
 // servers: a member gateway must exist before the group can name it, and
@@ -58,6 +65,15 @@ func appendWriteDiagnostics(diags *diag.Diagnostics, err error) bool {
 				"Every member of a grouped gateway must be the same form — all dedicated IPsec gateways, or all "+
 					"dedicated internet gateways. A gateway is an IPsec gateway when it has an `ipsec` block. "+
 					"Reported by Jamf Security Cloud: "+detail.Description,
+			)
+		case codeMixedDedicatedIPs:
+			diags.AddAttributeError(
+				path.Root("gateway_ids"),
+				"Member gateways disagree about dedicated egress IPs",
+				"Every member of a grouped gateway must have the same dedicated egress IP setting — either all "+
+					"members have them or none does. The server names the wire field `dedicatedIps.enabled`; on a "+
+					"`jamfplatform_security_cloud_ztna_gateway` that is `dedicated_egress_ips_enabled`. Reported by "+
+					"Jamf Security Cloud: "+detail.Description,
 			)
 		case codeSharedGatewayMember:
 			diags.AddAttributeError(
@@ -103,9 +119,16 @@ func appendWriteDiagnostics(diags *diag.Diagnostics, err error) bool {
 // appendDeleteDiagnostics explains the delete refusal, which is an ordering
 // problem rather than a configuration mistake.
 //
-// A grouped gateway that something still points at — a custom DNS zone's name
-// server, say — is refused with a bare `409 CONFLICT` carrying no detail about the
-// referrer.
+// A grouped gateway that something still points at is refused with a
+// `409 CONFLICT`. The bundled spec names GROUPED_GATEWAY_REFERENCED_BY_DNS_ZONES
+// and GROUPED_GATEWAY_REFERENCED_BY_ACCESS_POLICIES; the 2026-08-27 probe of the
+// zone case answered a bare 409 with no structured detail, so the codes are not
+// something the wire has been seen to send. Details() is appended when present
+// rather than relied on.
+//
+// Access policies matter most in that list because the provider does not manage
+// them: that reference lives in the admin UI, and no apply ordering will release
+// it.
 func appendDeleteDiagnostics(diags *diag.Diagnostics, err error) bool {
 	apiErr := jamfplatform.AsAPIError(err)
 	if apiErr == nil || !apiErr.HasStatus(http.StatusConflict) {
@@ -113,10 +136,27 @@ func appendDeleteDiagnostics(diags *diag.Diagnostics, err error) bool {
 	}
 	diags.AddError(
 		"Grouped gateway is still referenced",
-		"Jamf Security Cloud refuses to delete a grouped gateway that something still points at, such as a custom "+
-			"DNS zone name server. It does not say which. Remove the reference first, in a separate apply, then "+
-			"destroy the group: dropping the reference and the group in one apply lets Terraform sequence the "+
-			"destroy before the update that would have released it.",
+		"Jamf Security Cloud refuses to delete a grouped gateway that something still points at: a ZTNA access "+
+			"policy, or a custom DNS zone name server. Access policies are not managed by this provider, so if no "+
+			"zone names this group, check its access policies in the Jamf Security Cloud admin UI. For a reference "+
+			"Terraform does manage, remove it first in a separate apply, then destroy the group: dropping the "+
+			"reference and the group in one apply lets Terraform sequence the destroy before the update that would "+
+			"have released it."+reportedDetails(apiErr),
 	)
 	return true
+}
+
+// reportedDetails renders whatever structured detail an error carries, for the
+// diagnostics that cannot assume one is present. See the delete conflict above for
+// why this is appended rather than depended on.
+func reportedDetails(apiErr *jamfplatform.APIResponseError) string {
+	var b strings.Builder
+	for _, detail := range apiErr.Details() {
+		if detail.Description == "" {
+			continue
+		}
+		b.WriteString(" Reported by Jamf Security Cloud: ")
+		b.WriteString(detail.Description)
+	}
+	return b.String()
 }

--- a/internal/resources/security_cloud/ztna_grouped_gateway/helpers_test.go
+++ b/internal/resources/security_cloud/ztna_grouped_gateway/helpers_test.go
@@ -125,3 +125,102 @@ func TestAppendDeleteDiagnostics_OtherStatusesFallThrough(t *testing.T) {
 		t.Error("a non-API error must not be handled here")
 	}
 }
+
+// TestAppendWriteDiagnostics_NotEntitledIsNotAttributeScoped pins the one arm of
+// the write switch that had no test. It was the only untested codeNotEntitled arm
+// in the namespace — device_group, dns_zone, ztna_gateway and uem_connect all pin
+// theirs — and nothing live can cover it, because an entitled tenant cannot be
+// un-entitled. Hence a synthesized body.
+func TestAppendWriteDiagnostics_NotEntitledIsNotAttributeScoped(t *testing.T) {
+	var diags diag.Diagnostics
+
+	if !appendWriteDiagnostics(&diags, apiError(403, codeNotEntitled, "Not entitled.")) {
+		t.Fatal("NOT_ENTITLED must be recognised")
+	}
+	if !diags.HasError() {
+		t.Fatal("NOT_ENTITLED must produce an error diagnostic")
+	}
+	for _, d := range diags {
+		if _, ok := d.(diag.DiagnosticWithPath); ok {
+			t.Errorf("NOT_ENTITLED must not be attached to an attribute path: %v", d)
+		}
+	}
+}
+
+// TestAppendWriteDiagnostics_MixedDedicatedIPs pins the member constraint whose
+// server message names a wire field with no counterpart on this schema, so the
+// translation is the only thing telling the operator which attribute to change.
+func TestAppendWriteDiagnostics_MixedDedicatedIPs(t *testing.T) {
+	var diags diag.Diagnostics
+
+	if !appendWriteDiagnostics(&diags, apiError(422, codeMixedDedicatedIPs,
+		"All member gateways must have the same dedicatedIps.enabled value.")) {
+		t.Fatal("MIXED_DEDICATED_IPS_TYPES must be recognised")
+	}
+
+	found := false
+	for _, d := range diags {
+		withPath, ok := d.(diag.DiagnosticWithPath)
+		if !ok {
+			continue
+		}
+		if withPath.Path().Equal(path.Root("gateway_ids")) &&
+			strings.Contains(d.Detail(), "dedicated_egress_ips_enabled") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("want a gateway_ids diagnostic naming dedicated_egress_ips_enabled; got %v", diags)
+	}
+}
+
+// TestAppendDeleteDiagnostics_NamesAccessPolicies pins the referrer the operator
+// cannot resolve by reordering applies.
+//
+// The provider does not manage ZTNA access policies, so a grouped gateway referenced by one
+// has no Terraform-visible dependency edge and no apply ordering releases it. The
+// diagnostic used to list only zones and grouped gateways, sending the operator to
+// check two things that were not the cause.
+func TestAppendDeleteDiagnostics_NamesAccessPolicies(t *testing.T) {
+	var diags diag.Diagnostics
+
+	if !appendDeleteDiagnostics(&diags, apiError(http.StatusConflict, "", "")) {
+		t.Fatal("a 409 must be recognised")
+	}
+	if !strings.Contains(diags[0].Detail(), "access polic") {
+		t.Errorf("delete diagnostic must name access policies; got %q", diags[0].Detail())
+	}
+}
+
+// TestAppendDeleteDiagnostics_SurfacesDetailWhenPresent pins that a structured
+// detail is passed through rather than contradicted.
+//
+// The probed referrer cases answered with a bare 409, but the bundled spec
+// documents per-referrer codes with remediation text. If the endpoint starts
+// sending one, the operator must see it — the old wording asserted the body said
+// nothing while never reading it.
+func TestAppendDeleteDiagnostics_SurfacesDetailWhenPresent(t *testing.T) {
+	var diags diag.Diagnostics
+
+	if !appendDeleteDiagnostics(&diags, apiError(http.StatusConflict, "REFERENCED_BY_ACCESS_POLICIES",
+		"Disconnect this from all policies, then try again.")) {
+		t.Fatal("a 409 must be recognised")
+	}
+	if !strings.Contains(diags[0].Detail(), "Disconnect this from all policies") {
+		t.Errorf("delete diagnostic must surface the server's own remedy; got %q", diags[0].Detail())
+	}
+}
+
+// TestReportedDetails covers the shapes the delete conflict can carry, including
+// the bare 409 the wire has actually been seen to send.
+func TestReportedDetails(t *testing.T) {
+	bare := jamfplatform.AsAPIError(apiError(http.StatusConflict, "", ""))
+	if got := reportedDetails(bare); got != "" {
+		t.Errorf("a detail with no description must add nothing, got %q", got)
+	}
+
+	withDetail := jamfplatform.AsAPIError(apiError(http.StatusConflict, "SOME_CODE", "Because reasons."))
+	if got := reportedDetails(withDetail); !strings.Contains(got, "Because reasons.") {
+		t.Errorf("reportedDetails = %q, want it to carry the description", got)
+	}
+}

--- a/internal/resources/security_cloud/ztna_grouped_gateway/resource_acceptance_test.go
+++ b/internal/resources/security_cloud/ztna_grouped_gateway/resource_acceptance_test.go
@@ -443,8 +443,56 @@ func mixedFormGatewaysConfig(suffix, tenantID string) string {
 // Expected-error patterns for the plan- and apply-time refusals. Terraform wraps
 // diagnostic text at roughly 80 columns, so each pattern matches a short phrase
 // that cannot be split across a line break.
+// TestAccDataSource_SecurityCloudZtnaGroupedGateway_EmptyIDRefused pins the guard for the
+// selector mistake ExactlyOneOf cannot catch.
+//
+// A set-but-empty `id` counts as configured, so `id = var.x` with an unset variable
+// satisfies the config validator and then falls through to whichever lookup is
+// left. Without the guard the name branch runs with a null name, and the operator
+// gets an SDK-internal string about an attribute they never set.
+func TestAccDataSource_SecurityCloudZtnaGroupedGateway_EmptyIDRefused(t *testing.T) {
+	testhelpers.AccPreCheckSecurityCloud(t)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testhelpers.AccTestProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+					data "jamfplatform_security_cloud_ztna_grouped_gateway" "empty_id" {
+						id = ""
+					}
+				`,
+				ExpectError: regexpEmptyID,
+			},
+		},
+	})
+}
+
+// TestAccDataSource_SecurityCloudZtnaGroupedGateway_NameNotFoundIsWritten pins that a name
+// matching nothing produces a written diagnostic rather than the resolver's
+// synthetic 404 body, which reads as an internal error and names no remedy.
+func TestAccDataSource_SecurityCloudZtnaGroupedGateway_NameNotFoundIsWritten(t *testing.T) {
+	testhelpers.AccPreCheckSecurityCloud(t)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testhelpers.AccTestProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+					data "jamfplatform_security_cloud_ztna_grouped_gateway" "missing" {
+						name = "tf-acc-no-such-ztna_grouped_gateway-zzz"
+					}
+				`,
+				ExpectError: regexpNameNotFound,
+			},
+		},
+	})
+}
+
 var (
 	regexpMixedForms            = regexp.MustCompile(`Member gateways have different forms`)
 	regexpInvalidAttributeValue = regexp.MustCompile(`Invalid Attribute Value Match`)
 	regexpTooFewMembers         = regexp.MustCompile(`Invalid Attribute Value`)
+	regexpEmptyID               = regexp.MustCompile(`ID is empty`)
+	regexpNameNotFound          = regexp.MustCompile(`on this tenant is named`)
 )


### PR DESCRIPTION
Follow-ups from a specialist sweep prompted by the dead-guard defect in #338. Based on `feat/platform-api-ga`, not `main`, so it lands with the GA cutover.

## The sweep's headline is a negative result

The `device_group` bug — a user-facing guard made unreachable because the SDK's name resolver errors and **discards the matched element** before the provider can inspect it — **does not recur anywhere.** Confirmed three independent ways:

- SDK-source tracing across all 22 other `Resolve*` call sites in `pro/`, `blueprints/`, `cbengine/` and `common/`
- SDK-source tracing across the five Security Cloud sibling packages
- 54 mutations against the Security Cloud guard branches: 36 killed, 18 survivors all accounted for, **zero dead code**

Two structural reasons it stayed contained, both worth knowing:

1. **20 of the 22 other resolver call sites have no post-resolve guard at all** — they go straight from `if err != nil` to the assign, so there is nothing there to be dead. `device_group` was unusual in having a value guard, and it had one because this API has a genuinely id-less entry.
2. `jamfplatform/errors.go:16,49` declare `AmbiguousMatchError` as **type aliases** (`=`), and every generated wrapper wraps with `%w`, never `%v`. So all five `AmbiguousMatchError` handlers in the provider do fire. **Change either `=` to a defined type and all five go dead silently** — a latent SDK fragility, not a provider defect.

What the sweep found instead is below. None of it is in `device_group`.

## Diagnostics that misled

**Both gateway delete conflicts now name ZTNA access policies.** The diagnostic told the operator the 409 "does not say which" referrer — while never reading `Details()` — and listed only DNS zones and grouped gateways. The bundled spec documents `GATEWAY_REFERENCED_BY_ACCESS_POLICIES` alongside the other two, and access policies are the one referrer Terraform cannot help with: the provider does not manage them, so the reference lives in the admin UI and no apply ordering will release it.

That made the old text actively harmful on that path — it sent the operator to check two things that were not the cause, then told them to split the applies, advice that could never converge. `Details()` is now appended when present rather than asserted absent.

**The 2026-08-27 probe is preserved rather than overwritten.** It found a bare 409 with no structured detail for the zone and grouped-gateway cases. That is kept as an observation about those two cases, not generalised to the endpoint, and not replaced by the spec's claim — wire beats spec here, so the code reads the body opportunistically instead of depending on it.

**`MIXED_DEDICATED_IPS_TYPES` is now translated** on grouped gateways. It was the member constraint that most needed it: the server names `dedicatedIps.enabled`, a wire field with no counterpart on that schema, so the operator otherwise has to know it means `dedicated_egress_ips_enabled` on each member gateway.

**The device group name-lookup fix is generalised to all three sibling data sources.** A set-but-empty `id` satisfies `ExactlyOneOf` and fell through to the name branch with a null name; a name matching nothing surfaced the resolver's synthetic 404 body, which reads as an internal error and names no remedy. Both now produce written, attribute-anchored diagnostics. Six new acceptance tests, all passing.

## A flaky test, root-caused

`TestAccResource_SecurityCloudZtnaGateway_InternetGateway` failed roughly **one run in three or four**, on `ImportStateVerify`:

```
- "status.state": "PENDING"
+ "status.state": "DISABLED"
```

The step before the import sets `enabled = false`; Jamf Security Cloud then moves the gateway PENDING → DISABLED asynchronously. So the state that step stored and the fresh read the import performs legitimately disagree. It is a server-side deployment state, not a configuration property — comparing it across two reads is a race, not a check, and it is the same hazard STYLE_GUIDE already cites for keeping `status.updatedAt` out of the schema.

Excluded from `ImportStateVerifyIgnore` on both import steps. **18 consecutive clean runs** after, against 1-in-3 before.

I confirmed this is pre-existing and not caused by this branch: the diff touches only the data source's `Read`, the write/delete diagnostics, and test files — nothing in the resource's import path.

## Four test gaps, each verified by the mutation it now kills

| Gap | Mutation that used to survive |
|---|---|
| `uem_connect` `isNotFound` — two independent arms, one fixture carrying **both**, so the status arm was never why any case passed | `StatusNotFound` → `StatusTeapot` left the suite green, *including the subtest named for that arm* |
| `uem_connect` pre-`Results[0]` guard — untested, and a regression there is a **panic**, not a diagnostic | whole guard neutralised |
| `ztna_grouped_gateway` — the namespace's only untested `NOT_ENTITLED` arm | `case codeNotEntitled` → an impossible literal |
| `internal/common/helpers.IsNotFoundError` — no fixture at all for its `400 + INVALID_ID` arm | that arm removed |

The `uem_connect` guard is extracted into a testable helper because its acceptance path is structurally unavailable: a tenant holds only one integration, and the sandbox already has one, so the six tests that would create one skip by design.

## Testing

- **Acceptance: 43 pass, 0 fail** across all five Security Cloud packages against the EU sandbox, plus the 6 new guard tests. 6 `uem_connect` tests skip for the one-per-tenant reason above.
- Unit suite green; `golangci-lint run ./internal/...` reports 0 issues; `go vet -tags acceptance ./internal/...` clean; `make generate` produces no drift.
- Every new test was mutation-checked — each one fails when the code it covers is broken.

## Not in scope, deliberately

Three questions the sweep raised and would not assert without a probe, left as follow-ups:

1. **`BAD_REQUEST` is treated as exclusively about `tenant_ids`** on both gateways, on one observation. The code appears **nowhere** in the bundled spec, which documents 403/409 for tenant-ownership failures. If any other 400 arrives, it is reported as "Unknown tenant ID" and the generic fallback is suppressed.
2. **Create-response-ID guard asymmetry.** `device_group` guards an empty `created.ID` and fails *loudly* if unguarded, because its list is a bare array. The siblings' lists are objects, so an unguarded empty id would decode to a zero-value struct with **no error** — quieter, not safer.
3. **The scope grid.** `ConfigureSecurityCloud` admits both scopes for all five namespaces on one namespace's probe, and ZTNA gateways already cannot work environment-scoped.

Also unfixed, and off-branch: `internal/common/criteria/dsgroup.go:331` checks `!isDS` before `err != nil`. Safe today by an invariant nothing enforces; five consumers, so it widens `acctargets`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
