### PR TITLE
fix(security_cloud): name the referrer that blocks a ZTNA gateway delete

### DIFF
--- a/internal/resources/security_cloud/ztna_gateway/enum_literals_test.go
+++ b/internal/resources/security_cloud/ztna_gateway/enum_literals_test.go
@@ -1,0 +1,61 @@
+// Copyright Jamf Software LLC 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package ztna_gateway
+
+import (
+	"testing"
+
+	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/securitycloud"
+
+	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/enumguard"
+)
+
+// TestEnumLiteralsComeFromTheSDK pins STYLE_GUIDE.md §"Enum values and error codes
+// come from the SDK, not from literals" for this package. See
+// internal/common/enumguard for what the walker covers.
+//
+// This package was the only Security Cloud package with a write path and no such
+// guard, which matters here more than anywhere: it carries seven error-code literals,
+// the most of any construct in the namespace, and every one of them is a literal for
+// the same structural reason. The generated `ApiErrorItemCode` enum is declared from
+// the DNS schema, so it carries the DNS vocabulary and NOT_ENTITLED and nothing else;
+// the ZTNA codes appear in the spec only as response examples, which the generator
+// does not emit.
+//
+// Each is exempted by name rather than as a set, because "the SDK has none of these"
+// is a claim that has been wrong before when a generated enum carried the generic
+// codes and none of a construct's own.
+//
+// Absent rather than Ignore, deliberately: these are values the SDK does not yet
+// generate, not members of a different vocabulary that happen to share a spelling. So
+// an SDK release that starts generating one fails this test and the literal gets
+// replaced with the constant, which is exactly the drift this guard is for.
+func TestEnumLiteralsComeFromTheSDK(t *testing.T) {
+	got, err := enumguard.Check(enumguard.Params{
+		Covered: enumguard.Union(
+			securitycloud.ApiErrorItemCodeValues(),
+			securitycloud.GatewayCreateRequestDatacenterValues(),
+			securitycloud.RoutingStrategyValues(),
+		),
+		Absent: map[string]string{
+			"GATEWAY_TYPE_CHANGE_NOT_SUPPORTED": "documented in the ZTNA spec's 4xx prose but absent from the generated ApiErrorItemCode enum, which is declared from the DNS schema",
+			"IPSEC_SECRET_CLEAR_NOT_SUPPORTED":  "documented in the ZTNA spec's 4xx prose; not in the generated enum",
+			"DEDICATED_IPS_LIMIT":               "taken from the spec's shared 409 catalogue; not in the generated enum",
+			"BAD_REQUEST":                       "the spec's generic 400 fallback code; not in the generated enum",
+
+			"GATEWAY_REFERENCED_BY_ACCESS_POLICIES":  "wire-probed 2026-08-30 on the gateway delete path; documented in the spec's 409 prose but not in the generated enum",
+			"GATEWAY_REFERENCED_BY_DNS_ZONES":        "wire-probed 2026-08-30 on the gateway delete path; not in the generated enum",
+			"GATEWAY_REFERENCED_BY_GROUPED_GATEWAYS": "wire-probed 2026-08-30 on the gateway delete path; not in the generated enum",
+		},
+	})
+	if err != nil {
+		t.Fatalf("enumguard.Check: %v", err)
+	}
+	for _, problem := range got.Problems() {
+		t.Error(problem)
+	}
+	if got.Examined == 0 {
+		t.Fatal("no string literals parsed — the guard found nothing to check")
+	}
+}

--- a/internal/resources/security_cloud/ztna_gateway/helpers.go
+++ b/internal/resources/security_cloud/ztna_gateway/helpers.go
@@ -29,6 +29,10 @@ const (
 	codeIPSecSecretClearNotSupported  = "IPSEC_SECRET_CLEAR_NOT_SUPPORTED"
 	codeDedicatedIPsLimit             = "DEDICATED_IPS_LIMIT"
 	codeBadRequest                    = "BAD_REQUEST"
+
+	codeReferencedByAccessPolicies  = "GATEWAY_REFERENCED_BY_ACCESS_POLICIES"
+	codeReferencedByDNSZones        = "GATEWAY_REFERENCED_BY_DNS_ZONES"
+	codeReferencedByGroupedGateways = "GATEWAY_REFERENCED_BY_GROUPED_GATEWAYS"
 )
 
 // appendWriteDiagnostics turns a create/update failure into the most specific
@@ -102,47 +106,91 @@ func appendWriteDiagnostics(diags *diag.Diagnostics, err error) bool {
 // in the configuration but an ordering problem in the plan.
 //
 // Jamf Security Cloud refuses to delete a gateway that anything still references,
-// with a `409 CONFLICT`. Terraform will happily plan that destroy when the config
-// dependency edge disappears in the same apply that removes the reference, so this
-// is worth spelling out rather than passing through.
+// with a `409`. Terraform will happily plan that destroy when the config dependency
+// edge disappears in the same apply that removes the reference, so this is worth
+// spelling out rather than passing through. In every case the remedy is the same
+// two-apply sequence: drop the reference, apply, then destroy the gateway.
 //
-// Three things about the referrer list. First, a ZTNA access policy is one, and
-// since `jamfplatform_security_cloud_ztna_app` landed it can be a reference
-// Terraform manages: the application's `routing.gateway_id` and
-// `routing_overrides[].routing.gateway_id` each name a gateway, so moving an
-// application from one gateway to another and destroying the old gateway in a single
-// apply is precisely the ordering trap above, and the two-apply sequence is the
-// remedy. Only an access policy created outside Terraform is beyond its reach, and
-// then the reference does live in the admin UI. The bundled spec names
-// GATEWAY_REFERENCED_BY_ACCESS_POLICIES, GATEWAY_REFERENCED_BY_DNS_ZONES and
-// GATEWAY_REFERENCED_BY_GROUPED_GATEWAYS.
-// Second, the 2026-08-27 probe of the zone and grouped-gateway cases returned a
-// bare 409 with no structured detail, so the spec's codes are not something the
-// wire has been seen to send. Details() is therefore appended when present rather
-// than relied on, and the wording no longer asserts that the body says nothing —
-// that was true of the two cases probed, not of the endpoint.
-// Third, the access-policy edge is unprobed as of 2026-08-30: the acceptance tenant
-// holds no customer-owned gateway and a shared gateway cannot be deleted, so whether
-// a gateway referenced only by an access policy really does answer 409 is inherited
-// from the spec rather than wire-verified. Probe it once a deletable gateway exists —
-// the rule for this namespace is that a referenced delete is probed per construct,
-// never inherited from a sibling.
+// All three referrers name themselves. Wire-probed against production EU on
+// 2026-08-30 by creating a dedicated gateway, pointing each referrer at it in turn
+// and deleting it: an access policy answers GATEWAY_REFERENCED_BY_ACCESS_POLICIES, a
+// custom DNS zone name server GATEWAY_REFERENCED_BY_DNS_ZONES, and grouped-gateway
+// membership GATEWAY_REFERENCED_BY_GROUPED_GATEWAYS, each with a description naming
+// the referrer class and the fix. Releasing the reference and repeating the delete
+// answered 204 in all three, so the reference is the sole cause. That is why each
+// code gets its own diagnostic naming the one thing to go and look at, rather than
+// the operator being handed all three possibilities.
+//
+// The generic fallback stays, and is not dead code. The 2026-08-27 probe of the zone
+// and grouped-gateway cases recorded a bare 409 carrying no structured detail, which
+// today's probe contradicts — whether that was a misread then or a server change
+// since, an endpoint that has been seen to answer both shapes gets code-keyed
+// diagnostics for the shape that carries a code and the three-way explanation for the
+// shape that does not.
+//
+// A ZTNA access policy is a reference Terraform manages: the application's
+// `routing.gateway_id` and `routing_overrides[].routing.gateway_id` each name a
+// gateway, so moving an application between gateways and destroying the old one in a
+// single apply is exactly the ordering trap above. Only an access policy created
+// outside Terraform is beyond its reach, and then the reference does live in the
+// admin UI.
+//
+// None of the three codes is an SDK constant: the generated `ApiErrorItemCode` enum
+// is declared from the DNS schema, and these appear in the ZTNA spec only as response
+// examples, which the generator does not emit. enum_literals_test.go exempts each by
+// name so an SDK release that starts generating one fails the guard.
 func appendDeleteDiagnostics(diags *diag.Diagnostics, err error) bool {
 	apiErr := jamfplatform.AsAPIError(err)
 	if apiErr == nil || !apiErr.HasStatus(http.StatusConflict) {
 		return false
 	}
+	for _, detail := range apiErr.Details() {
+		summary, referrer, ok := referencedByDetail(detail.Code)
+		if !ok {
+			continue
+		}
+		diags.AddError(
+			summary,
+			"Jamf Security Cloud will not delete a gateway while "+referrer+" still points at it. Remove the "+
+				"reference first in a separate apply, then destroy the gateway: dropping the reference and the "+
+				"gateway in one apply lets Terraform sequence the destroy before the update that would have "+
+				"released it."+reportedDetails(apiErr),
+		)
+		return true
+	}
 	diags.AddError(
 		"Gateway is still referenced",
 		"Jamf Security Cloud refuses to delete a gateway that something still points at: a ZTNA access policy, a "+
-			"custom DNS zone name server, or membership of a grouped gateway. Access policies created outside "+
-			"Terraform are invisible to it, so check the Jamf Security Cloud admin UI if no "+
-			"`jamfplatform_security_cloud_ztna_app`, zone or grouped gateway in your configuration names this "+
-			"gateway. For a reference Terraform does manage, remove it first in a separate "+
-			"apply, then destroy the gateway: dropping the reference and the gateway in one apply lets Terraform "+
-			"sequence the destroy before the update that would have released it."+reportedDetails(apiErr),
+			"custom DNS zone name server, or membership of a grouped gateway. It did not say which, so check each "+
+			"in turn. Access policies created outside Terraform are invisible to it, so check the Jamf Security "+
+			"Cloud admin UI if no `jamfplatform_security_cloud_ztna_app`, zone or grouped gateway in your "+
+			"configuration names this gateway. For a reference Terraform does manage, remove it first in a "+
+			"separate apply, then destroy the gateway: dropping the reference and the gateway in one apply lets "+
+			"Terraform sequence the destroy before the update that would have released it."+reportedDetails(apiErr),
 	)
 	return true
+}
+
+// referencedByDetail maps a referenced-by error code to its diagnostic summary and
+// the phrase naming what holds the reference, reporting whether the code is one of
+// the three.
+func referencedByDetail(code string) (summary, referrer string, ok bool) {
+	switch code {
+	case codeReferencedByAccessPolicies:
+		return "Gateway is still referenced by an access policy application",
+			"an access policy application — a `jamfplatform_security_cloud_ztna_app` whose " +
+				"`routing.gateway_id` or `routing_overrides[].routing.gateway_id` names this gateway, or one " +
+				"created outside Terraform, which appears only in the admin UI —", true
+	case codeReferencedByDNSZones:
+		return "Gateway is still referenced by a custom DNS zone",
+			"a custom DNS zone name server — a `jamfplatform_security_cloud_dns_zone` whose " +
+				"`name_servers[].gateway_id` names this gateway —", true
+	case codeReferencedByGroupedGateways:
+		return "Gateway is still a member of a grouped gateway",
+			"a grouped gateway — a `jamfplatform_security_cloud_ztna_grouped_gateway` whose `gateway_ids` " +
+				"includes this gateway —", true
+	}
+	return "", "", false
 }
 
 // reportedDetails renders whatever structured detail an error carries, for the

--- a/internal/resources/security_cloud/ztna_gateway/helpers_test.go
+++ b/internal/resources/security_cloud/ztna_gateway/helpers_test.go
@@ -148,13 +148,15 @@ func TestAppendDeleteDiagnostics_OtherStatusesFallThrough(t *testing.T) {
 	}
 }
 
-// TestAppendDeleteDiagnostics_NamesAccessPolicies pins the referrer the operator
-// cannot resolve by reordering applies.
+// TestAppendDeleteDiagnostics_NamesAccessPolicies pins the fallback wording used when
+// the 409 carries no code the provider recognises.
 //
-// The provider does not manage ZTNA access policies, so a gateway referenced by one
-// has no Terraform-visible dependency edge and no apply ordering releases it. The
-// diagnostic used to list only zones and grouped gateways, sending the operator to
-// check two things that were not the cause.
+// The three referrers each name themselves on the wire (see
+// TestAppendDeleteDiagnostics_NamesTheReferrer), but the 2026-08-27 probe recorded a
+// bare 409 with no structured detail, so this path is still reachable. When it is, the
+// operator gets all three possibilities rather than a wrong single guess, and access
+// policies have to be among them — one created outside Terraform has no
+// Terraform-visible dependency edge at all.
 func TestAppendDeleteDiagnostics_NamesAccessPolicies(t *testing.T) {
 	var diags diag.Diagnostics
 
@@ -169,10 +171,10 @@ func TestAppendDeleteDiagnostics_NamesAccessPolicies(t *testing.T) {
 // TestAppendDeleteDiagnostics_SurfacesDetailWhenPresent pins that a structured
 // detail is passed through rather than contradicted.
 //
-// The probed referrer cases answered with a bare 409, but the bundled spec
-// documents per-referrer codes with remediation text. If the endpoint starts
-// sending one, the operator must see it — the old wording asserted the body said
-// nothing while never reading it.
+// A code the provider does not recognise still has to surface the server's own remedy.
+// The code used here is the spelling the spec suggested, which the 2026-08-30 probe
+// showed is not what the wire sends (it sends the GATEWAY_-prefixed form), so this
+// exercises the fallback rather than the translation.
 func TestAppendDeleteDiagnostics_SurfacesDetailWhenPresent(t *testing.T) {
 	var diags diag.Diagnostics
 
@@ -196,5 +198,102 @@ func TestReportedDetails(t *testing.T) {
 	withDetail := jamfplatform.AsAPIError(apiError(http.StatusConflict, "SOME_CODE", "Because reasons."))
 	if got := reportedDetails(withDetail); !strings.Contains(got, "Because reasons.") {
 		t.Errorf("reportedDetails = %q, want it to carry the description", got)
+	}
+}
+
+// TestAppendDeleteDiagnostics_NamesTheReferrer pins the three per-referrer codes to
+// diagnostics naming the one thing to go and look at.
+//
+// All three were wire-probed against production EU on 2026-08-30 by creating a
+// dedicated gateway, pointing each referrer at it in turn and deleting it; releasing
+// the reference and repeating the delete answered 204 every time, so the reference is
+// the sole cause. Before this, the provider keyed on the 409 status alone and handed
+// the operator all three possibilities on every conflict.
+func TestAppendDeleteDiagnostics_NamesTheReferrer(t *testing.T) {
+	cases := []struct {
+		name        string
+		code        string
+		description string
+		wantSummary string
+		wantDetail  []string
+		wantAbsent  []string
+	}{
+		{
+			name:        "access policy application",
+			code:        codeReferencedByAccessPolicies,
+			description: "The gateway could not be deleted because it is referenced by one or more Access Policies. Disconnect this gateway from all policies, then try again.",
+			wantSummary: "access policy application",
+			wantDetail:  []string{"jamfplatform_security_cloud_ztna_app", "routing.gateway_id", "separate apply"},
+			wantAbsent:  []string{"custom DNS zone name server", "grouped gateway"},
+		},
+		{
+			name:        "custom DNS zone",
+			code:        codeReferencedByDNSZones,
+			description: "The gateway could not be deleted because it is referenced by one or more Custom DNS Zones. Disconnect this gateway from all zones, then try again.",
+			wantSummary: "custom DNS zone",
+			wantDetail:  []string{"jamfplatform_security_cloud_dns_zone", "name_servers[].gateway_id"},
+			wantAbsent:  []string{"access policy application", "grouped gateway"},
+		},
+		{
+			name:        "grouped gateway membership",
+			code:        codeReferencedByGroupedGateways,
+			description: "The gateway could not be deleted because it is referenced by one or more grouped gateways. Disconnect this gateway from all grouped gateways, then try again.",
+			wantSummary: "grouped gateway",
+			wantDetail:  []string{"jamfplatform_security_cloud_ztna_grouped_gateway", "gateway_ids"},
+			wantAbsent:  []string{"access policy application", "custom DNS zone name server"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var diags diag.Diagnostics
+			if !appendDeleteDiagnostics(&diags, apiError(http.StatusConflict, tc.code, tc.description)) {
+				t.Fatal("a 409 carrying a referenced-by code must be recognised")
+			}
+			if len(diags) != 1 {
+				t.Fatalf("expected exactly one diagnostic, got %d: %v", len(diags), diags)
+			}
+			if !strings.Contains(diags[0].Summary(), tc.wantSummary) {
+				t.Errorf("summary %q does not name the referrer %q", diags[0].Summary(), tc.wantSummary)
+			}
+			for _, want := range tc.wantDetail {
+				if !strings.Contains(diags[0].Detail(), want) {
+					t.Errorf("detail does not mention %q:\n%s", want, diags[0].Detail())
+				}
+			}
+			for _, absent := range tc.wantAbsent {
+				if strings.Contains(diags[0].Detail(), absent) {
+					t.Errorf("detail names %q, which this code rules out:\n%s", absent, diags[0].Detail())
+				}
+			}
+			if !strings.Contains(diags[0].Detail(), tc.description) {
+				t.Errorf("detail must surface the server's own message:\n%s", diags[0].Detail())
+			}
+		})
+	}
+}
+
+// TestAppendDeleteDiagnostics_UnknownCodeFallsBackToAllThree pins that a 409 carrying
+// a code the table does not know still gets the three-way explanation rather than
+// silently naming nothing.
+func TestAppendDeleteDiagnostics_UnknownCodeFallsBackToAllThree(t *testing.T) {
+	var diags diag.Diagnostics
+	if !appendDeleteDiagnostics(&diags, apiError(http.StatusConflict, "GATEWAY_REFERENCED_BY_SOMETHING_NEW", "held by something.")) {
+		t.Fatal("a 409 must be recognised whatever code it carries")
+	}
+	for _, want := range []string{"access policy", "DNS zone", "grouped gateway", "held by something."} {
+		if !strings.Contains(diags[0].Detail(), want) {
+			t.Errorf("fallback detail does not mention %q:\n%s", want, diags[0].Detail())
+		}
+	}
+}
+
+// TestReferencedByDetail_RejectsUnknownCodes keeps the table closed, so a new code
+// reaches the fallback rather than an empty summary.
+func TestReferencedByDetail_RejectsUnknownCodes(t *testing.T) {
+	for _, code := range []string{"", "CONFLICT", "REFERENCED_BY_ACCESS_POLICIES", "GATEWAY_NOT_FOUND"} {
+		if _, _, ok := referencedByDetail(code); ok {
+			t.Errorf("referencedByDetail(%q) claimed a match", code)
+		}
 	}
 }


### PR DESCRIPTION
## Description

`appendDeleteDiagnostics` keyed on the bare HTTP 409 status and handed the operator all three possible referrers on every conflict — "check an access policy, a DNS zone, or a grouped gateway" — because the 409 was believed to be unattributed.

It isn't. **All three referrers name themselves**, wire-probed against production EU on 2026-08-30. This is the probe CLAUDE.md said was owed for this namespace ("probe the referenced delete for each new construct rather than inheriting either answer") and that the acceptance tenant previously could not support, having zero customer-owned gateways.

A dedicated gateway was created, each referrer pointed at it in turn, the delete attempted, then the reference released and the delete repeated:

| Referrer | Code the wire sends | Delete after release |
|---|---|---|
| ZTNA access policy (`ztna_app.routing.gateway_id`) | `GATEWAY_REFERENCED_BY_ACCESS_POLICIES` | `204` |
| Custom DNS zone name server | `GATEWAY_REFERENCED_BY_DNS_ZONES` | `204` |
| Grouped-gateway membership | `GATEWAY_REFERENCED_BY_GROUPED_GATEWAYS` | `204` |

Each description names the referrer class and the remedy. Since releasing the reference makes the delete succeed every time, the reference is the sole cause — so each code now gets a diagnostic naming the one thing to look at and the Terraform attribute holding the reference, instead of three possibilities to work through.

### Three things worth a reviewer's attention

**1. The fallback is not dead code.** The 2026-08-27 probe recorded in the doc comment saw a *bare* 409 with no structured detail for the zone and grouped-gateway cases. Today's probe contradicts that. I cannot tell whether it was a misread then or a server change since, so the three-way explanation stays for the codeless shape and the discrepancy is recorded rather than quietly overwritten. `TestAppendDeleteDiagnostics_UnknownCodeFallsBackToAllThree` pins it.

**2. The spec's code spelling is wrong.** It documents `REFERENCED_BY_ACCESS_POLICIES`; the wire sends the `GATEWAY_`-prefixed form. An existing test used the spec spelling, which is why it had been passing through the fallback rather than exercising a translation — it read as coverage and wasn't. That test's doc comment is corrected to say what it actually covers.

**3. Retires a stale doc comment I added myself yesterday**, which said the access-policy edge was "unprobed as of 2026-08-30" and inherited from the spec. It is probed now.

### `enum_literals_test.go`

Adds the enumguard test this package lacked — the only Security Cloud package with a write path and no such guard, and the one carrying the most error-code literals (seven now).

None of the three new codes is an SDK constant: `securitycloud.ApiErrorItemCode` is generated from the DNS schema and carries exactly nine values (`INVALID_FIELD`, `LIST_SIZE_EXCEEDED`, `DOMAIN_CONFLICT`, `GATEWAY_NOT_FOUND`, `NAMESERVER_IP_OUT_OF_RANGE`, `NAMESERVER_IP_RESTRICTED`, `ZONE_NOT_FOUND`, `SEARCH_DOMAIN_NOT_SET`, `NOT_ENTITLED`), while the ZTNA codes appear in the spec only as response examples, which the generator does not emit. Each is exempted by name so an SDK release that starts generating one fails the guard rather than leaving a stale literal.

Both guard mechanisms verified by mutation rather than assumed:

- restating an SDK-generated literal (`DOMAIN_CONFLICT` as a const) → trips `Restated`
- listing a generated value in `Absent` → trips `Promoted` **and** `Stale`

## Type of Change

- [x] Bug fix
- [x] Enhancement to existing resource/data source
- [x] Refactoring/code cleanup

## Resources/Data Sources Modified

- `jamfplatform_security_cloud_ztna_gateway` — delete-conflict diagnostics only; no schema change, no state change, no wire change

## Testing

### Automated Tests

- [x] Added Go unit tests — `TestAppendDeleteDiagnostics_NamesTheReferrer` (3 subtests, each asserting the summary names its referrer, the detail names the Terraform attribute, the server's own message is surfaced, **and** the other two referrers are *not* mentioned), `TestAppendDeleteDiagnostics_UnknownCodeFallsBackToAllThree`, `TestReferencedByDetail_RejectsUnknownCodes`, plus the new `TestEnumLiteralsComeFromTheSDK`
- [x] Acceptance tests — no new ones; the referenced-delete path needs a customer-owned gateway plus a referrer, which is a multi-construct fixture. Existing suites re-run below.
- [x] `make fix fmt lint test` passes locally — `golangci-lint run` on the changed package reports `0 issues` (repo-wide it reports 4 pre-existing issues, all in gitignored `local-testing/`)
- [x] `make generate` — not required: no schema description changed, so `docs/` is unaffected

Mutation-checked the new tests have teeth: disconnecting the code table makes all three subtests fail; every mutation reverted and the tree verified byte-identical.

### Manual Testing

- [x] Tested against a live tenant — the probe above *is* the manual test, run through the API directly
- [x] Tested CRUD — gateway create/delete, zone create/delete, grouped-gateway create/delete, app create/delete, all against production EU; every object created was removed and the tenant verified back to its prior state
- [ ] Verified resources appear correctly in Jamf Pro UI — n/a, Security Cloud construct with no Jamf Pro UI surface

Acceptance re-run on the three packages this touches or references:

```
ok  .../security_cloud/ztna_gateway          46.386s
ok  .../security_cloud/ztna_grouped_gateway  23.568s
ok  .../security_cloud/dns_zone              24.153s
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation — the doc comments are the documentation here; no user-facing docs change
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective
- [x] New and existing Go unit and acceptance tests pass locally with my changes
- [x] Any dependent changes have been merged and published — builds on #343

## Additional Context

Incidental wire facts found while building the probe fixture, recorded here because they are not obvious and cost time:

- A plain internet gateway needs `dedicatedIps.enabled=true` **or** `ipsec`. A bare `name`/`datacenter`/`tenantIds`/`contact` payload is refused with `400 INVALID_FIELD dedicatedIps` — "Gateway must be configured as dedicated (dedicatedIps.enabled=true) or ipsec."
- `datacenter` takes the identifier (`eu-west-2`), not the region label.
- A freshly created gateway reads back `status.state: PENDING` and is still deletable in that state.
- Zone name servers are IP-restricted: `10.60.43.10` drew `422 NAMESERVER_IP_RESTRICTED`; `192.0.2.53` (the acceptance fixture's choice) is accepted.

## Related Issues

Relates to #343
