### PR TITLE
feat(cbengine)!: remove the deprecated target_device_group attribute

### DIFF
--- a/docs/data-sources/cbengine_benchmark.md
+++ b/docs/data-sources/cbengine_benchmark.md
@@ -75,7 +75,6 @@ output "benchmark_by_title_rules" {
 - `rules` (Attributes List) Rules. (see [below for nested schema](#nestedatt--rules))
 - `selected_os_versions` (Attributes Set) Operating system versions the benchmark applies to. (see [below for nested schema](#nestedatt--selected_os_versions))
 - `sources` (Attributes List) mSCP sources (branch + revision) spanned by the benchmark. (see [below for nested schema](#nestedatt--sources))
-- `target_device_group` (String, Deprecated) **Deprecated** — use `target_device_groups`. First device group ID returned by the API, kept for backwards compatibility.
 - `target_device_groups` (Set of String) All device group Platform IDs targeted by this benchmark.
 - `tenant_id` (String) Tenant ID.
 - `update_available` (Boolean) Update available flag.

--- a/docs/resources/cbengine_benchmark.md
+++ b/docs/resources/cbengine_benchmark.md
@@ -105,6 +105,7 @@ resource "jamfplatform_cbengine_benchmark" "custom_cis_lvl1" {
 
 - `enforcement_mode` (String) Enforcement mode for the benchmark; allowed values: MONITOR or MONITOR_AND_ENFORCE. Required and immutable for this resource (replace on change).
 - `rules` (Attributes List) Set of rules to include in the benchmark. Each entry references a rule id and whether it is enabled; additional metadata (title, section, ODV hints) are computed from the API. Use the `jamfplatform_cbengine_rules` data source to look up available rules. (see [below for nested schema](#nestedatt--rules))
+- `target_device_groups` (Set of String) Device groups this benchmark targets, as a set of group UUIDs. Read them from the `jamfplatform_device_group` or `jamfplatform_device_groups` data sources rather than hand-copying. Immutable (replace on change).
 - `title` (String) Benchmark title (max length 100). Required and replaces the resource when changed.
 
 ### Optional
@@ -112,8 +113,6 @@ resource "jamfplatform_cbengine_benchmark" "custom_cis_lvl1" {
 - `description` (String) Optional human-readable description of the benchmark (max length 1000). Replaces the resource when changed.
 - `selected_os_versions` (Attributes Set) Operating system versions the benchmark applies to. Optional: when omitted, the benchmark targets every version available for the baseline. Supplying a subset scopes the benchmark to just those versions. Immutable (replace on change). Look up valid values via `available_os_versions` on the `jamfplatform_cbengine_rules` data source. (see [below for nested schema](#nestedatt--selected_os_versions))
 - `source_baseline_id` (String) mSCP baseline identifier used as the source for rules. Required on creation, but computed for imports. Use the `jamfplatform_cbengine_baselines` data source to look up available baselines.
-- `target_device_group` (String, Deprecated) **Deprecated** — use `target_device_groups` instead. Single device group Platform ID targeted by this benchmark, in UUID format. Mutually exclusive with `target_device_groups`. Immutable (replace on change).
-- `target_device_groups` (Set of String) Device groups this benchmark targets, as a set of group UUIDs. Read them from the `jamfplatform_device_group` or `jamfplatform_device_groups` data sources rather than hand-copying. Mutually exclusive with the deprecated `target_device_group`. Immutable (replace on change).
 - `timeouts` (Attributes) (see [below for nested schema](#nestedatt--timeouts))
 
 ### Read-Only

--- a/internal/resources/cbengine/benchmark/data_source.go
+++ b/internal/resources/cbengine/benchmark/data_source.go
@@ -230,11 +230,6 @@ func (d *BenchmarkDataSource) Schema(ctx context.Context, req datasource.SchemaR
 					},
 				},
 			},
-			"target_device_group": schema.StringAttribute{
-				MarkdownDescription: "**Deprecated** — use `target_device_groups`. First device group ID returned by the API, kept for backwards compatibility.",
-				DeprecationMessage:  "Use target_device_groups instead.",
-				Computed:            true,
-			},
 			"target_device_groups": schema.SetAttribute{
 				MarkdownDescription: "All device group Platform IDs targeted by this benchmark.",
 				ElementType:         types.StringType,

--- a/internal/resources/cbengine/benchmark/impact.go
+++ b/internal/resources/cbengine/benchmark/impact.go
@@ -15,21 +15,12 @@ import (
 // A compliance benchmark targets device groups by their Platform identifier, the
 // same way a blueprint does, and can reach either estate — so its figure is
 // measured against the whole managed estate.
-//
-// The deprecated singular target_device_group is read as well as the plural set,
-// because a configuration written against the older attribute still has an
-// audience worth reporting.
 func benchmarkImpactScope(ctx context.Context, m *BenchmarkResourceModel) impact.Scope {
 	b := impact.NewScopeBuilder(ctx, impact.DeviceTypeAny)
 	if m == nil {
 		return b.Scope()
 	}
 	b.PlatformGroups("target_device_groups", m.TargetDeviceGroups)
-	if v := m.TargetDeviceGroup; !v.IsNull() && !v.IsUnknown() && v.ValueString() != "" {
-		b.PlatformGroupIDs(v.ValueString())
-	} else if v.IsUnknown() {
-		b.Pending("target_device_group")
-	}
 	return b.Scope()
 }
 

--- a/internal/resources/cbengine/benchmark/impact_test.go
+++ b/internal/resources/cbengine/benchmark/impact_test.go
@@ -21,11 +21,8 @@ func benchImpactSet(t *testing.T, vals ...string) types.Set {
 	return out
 }
 
-func benchImpactNullSet() types.Set { return types.SetNull(types.StringType) }
-
 func TestBenchmarkImpactScopePluralTargets(t *testing.T) {
 	got := benchmarkImpactScope(context.Background(), &BenchmarkResourceModel{
-		TargetDeviceGroup:  types.StringNull(),
 		TargetDeviceGroups: benchImpactSet(t, "uuid-1", "uuid-2"),
 	})
 	if got.DeviceType != impact.DeviceTypeAny {
@@ -39,53 +36,6 @@ func TestBenchmarkImpactScopePluralTargets(t *testing.T) {
 	}
 }
 
-func TestBenchmarkImpactScopeDeprecatedSingularIsCounted(t *testing.T) {
-	// A configuration still written against the deprecated singular attribute has
-	// an audience worth reporting, so its value folds into the same category.
-	got := benchmarkImpactScope(context.Background(), &BenchmarkResourceModel{
-		TargetDeviceGroup:  types.StringValue("uuid-3"),
-		TargetDeviceGroups: benchImpactNullSet(),
-	})
-	if len(got.PlatformGroupIDs) != 1 || got.PlatformGroupIDs[0] != "uuid-3" {
-		t.Fatalf("the singular target must be counted, got %v", got.PlatformGroupIDs)
-	}
-	if len(got.PendingPaths) != 0 {
-		t.Fatalf("a known singular target is not pending, got %v", got.PendingPaths)
-	}
-}
-
-func TestBenchmarkImpactScopeUnknownSingularIsPending(t *testing.T) {
-	// An unknown singular value references a group this same plan creates, so the
-	// figure cannot be completed and the path must be recorded as pending.
-	got := benchmarkImpactScope(context.Background(), &BenchmarkResourceModel{
-		TargetDeviceGroup:  types.StringUnknown(),
-		TargetDeviceGroups: benchImpactNullSet(),
-	})
-	if len(got.PlatformGroupIDs) != 0 {
-		t.Fatalf("an unknown target must not be counted, got %v", got.PlatformGroupIDs)
-	}
-	if len(got.PendingPaths) != 1 || got.PendingPaths[0] != "target_device_group" {
-		t.Fatalf("the unknown singular target must be pending, got %v", got.PendingPaths)
-	}
-}
-
-func TestBenchmarkImpactScopeBothAttributesCombine(t *testing.T) {
-	got := benchmarkImpactScope(context.Background(), &BenchmarkResourceModel{
-		TargetDeviceGroup:  types.StringValue("uuid-3"),
-		TargetDeviceGroups: benchImpactSet(t, "uuid-1"),
-	})
-	if len(got.PlatformGroupIDs) != 2 {
-		t.Fatalf("both attributes name groups, so both must be counted, got %v", got.PlatformGroupIDs)
-	}
-	seen := map[string]bool{}
-	for _, id := range got.PlatformGroupIDs {
-		seen[id] = true
-	}
-	if !seen["uuid-1"] || !seen["uuid-3"] {
-		t.Fatalf("both the plural and the singular target must appear, got %v", got.PlatformGroupIDs)
-	}
-}
-
 func TestBenchmarkImpactScopeNilModel(t *testing.T) {
 	got := benchmarkImpactScope(context.Background(), nil)
 	if got.DeviceType != impact.DeviceTypeAny {
@@ -93,5 +43,19 @@ func TestBenchmarkImpactScopeNilModel(t *testing.T) {
 	}
 	if !got.Empty() {
 		t.Fatalf("a nil model must yield an empty scope, got %+v", got)
+	}
+}
+
+func TestBenchmarkImpactScopeUnknownPluralIsPending(t *testing.T) {
+	// An unknown set references groups this same plan creates, so the audience
+	// cannot be totalled and the path is recorded as pending instead.
+	got := benchmarkImpactScope(context.Background(), &BenchmarkResourceModel{
+		TargetDeviceGroups: types.SetUnknown(types.StringType),
+	})
+	if len(got.PlatformGroupIDs) != 0 {
+		t.Fatalf("an unknown target must not be counted, got %v", got.PlatformGroupIDs)
+	}
+	if len(got.PendingPaths) != 1 || got.PendingPaths[0] != "target_device_groups" {
+		t.Fatalf("the unknown target must be pending, got %v", got.PendingPaths)
 	}
 }

--- a/internal/resources/cbengine/benchmark/input_builders.go
+++ b/internal/resources/cbengine/benchmark/input_builders.go
@@ -8,30 +8,25 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-// buildDeviceGroupsRequest extracts the device group IDs the user supplied. Plural
-// target_device_groups takes precedence when configured; otherwise the deprecated
-// singular target_device_group is wrapped into a single-element slice. Schema
-// validation guarantees exactly one is supplied so this never observes both.
+// buildDeviceGroupsRequest extracts the device group IDs the user supplied.
 func buildDeviceGroupsRequest(data *BenchmarkResourceModel) []string {
-	if !data.TargetDeviceGroups.IsNull() && !data.TargetDeviceGroups.IsUnknown() {
-		elements := data.TargetDeviceGroups.Elements()
-		out := make([]string, 0, len(elements))
-		for _, el := range elements {
-			s, ok := el.(types.String)
-			if !ok || s.IsNull() || s.IsUnknown() {
-				continue
-			}
-			out = append(out, s.ValueString())
-		}
-		return out
+	if data.TargetDeviceGroups.IsNull() || data.TargetDeviceGroups.IsUnknown() {
+		return nil
 	}
-	return []string{data.TargetDeviceGroup.ValueString()}
+	elements := data.TargetDeviceGroups.Elements()
+	out := make([]string, 0, len(elements))
+	for _, el := range elements {
+		s, ok := el.(types.String)
+		if !ok || s.IsNull() || s.IsUnknown() {
+			continue
+		}
+		out = append(out, s.ValueString())
+	}
+	return out
 }
 
 // buildBenchmarkRequest constructs the API request body from the Terraform plan model.
-// Device group targeting accepts either the deprecated singular target_device_group
-// or the preferred plural target_device_groups set; ConflictsWith + AtLeastOneOf on
-// the schema guarantee exactly one is configured. Sources are omitted deliberately:
+// Sources are omitted deliberately:
 // the server always derives the full source set from the baseline, so the request
 // carries no sources field. Selected OS versions are sent only when configured;
 // when omitted the server defaults the benchmark to every available version.

--- a/internal/resources/cbengine/benchmark/input_builders_test.go
+++ b/internal/resources/cbengine/benchmark/input_builders_test.go
@@ -53,8 +53,7 @@ func TestBuildBenchmarkRequest_Full(t *testing.T) {
 				ODVValue: types.StringNull(),
 			},
 		},
-		TargetDeviceGroup:  types.StringValue("group-1"),
-		TargetDeviceGroups: types.SetNull(types.StringType),
+		TargetDeviceGroups: types.SetValueMust(types.StringType, []attr.Value{types.StringValue("group-1")}),
 		EnforcementMode:    types.StringValue("audit"),
 	}
 
@@ -119,7 +118,6 @@ func TestBuildBenchmarkRequest_EmptyRulesAndOmittedOsVersions(t *testing.T) {
 		SourceBaselineID:   types.StringValue("bl-1"),
 		SelectedOsVersions: types.SetNull(osVersionObjectType),
 		Rules:              nil,
-		TargetDeviceGroup:  types.StringValue("dg-1"),
 		TargetDeviceGroups: types.SetNull(types.StringType),
 		EnforcementMode:    types.StringValue("audit"),
 	}
@@ -162,7 +160,6 @@ func TestBuildBenchmarkRequest_ODVNull(t *testing.T) {
 				ODVValue: types.StringNull(),
 			},
 		},
-		TargetDeviceGroup:  types.StringValue("dg-1"),
 		TargetDeviceGroups: types.SetNull(types.StringType),
 		EnforcementMode:    types.StringValue("audit"),
 	}
@@ -185,7 +182,6 @@ func TestBuildBenchmarkRequest_ODVEmpty(t *testing.T) {
 				ODVValue: types.StringValue(""),
 			},
 		},
-		TargetDeviceGroup:  types.StringValue("dg-1"),
 		TargetDeviceGroups: types.SetNull(types.StringType),
 		EnforcementMode:    types.StringValue("audit"),
 	}
@@ -202,7 +198,6 @@ func TestBuildBenchmarkRequest_PluralTargetDeviceGroups(t *testing.T) {
 		Title:              types.StringValue("Plural Scope"),
 		SourceBaselineID:   types.StringValue("bl-1"),
 		Rules:              nil,
-		TargetDeviceGroup:  types.StringNull(),
 		TargetDeviceGroups: setOfStrings("group-a", "group-b", "group-c"),
 		EnforcementMode:    types.StringValue("audit"),
 	}
@@ -230,7 +225,6 @@ func TestBuildBenchmarkRequest_PluralWinsOverSingular(t *testing.T) {
 	data := &BenchmarkResourceModel{
 		Title:              types.StringValue("Both"),
 		SourceBaselineID:   types.StringValue("bl-1"),
-		TargetDeviceGroup:  types.StringValue("should-be-ignored"),
 		TargetDeviceGroups: setOfStrings("kept"),
 		EnforcementMode:    types.StringValue("audit"),
 	}

--- a/internal/resources/cbengine/benchmark/model_types.go
+++ b/internal/resources/cbengine/benchmark/model_types.go
@@ -25,7 +25,6 @@ type BenchmarkResourceModel struct {
 	SelectedOsVersions  types.Set              `tfsdk:"selected_os_versions"`
 	AvailableOsVersions types.List             `tfsdk:"available_os_versions"`
 	Rules               []RuleModel            `tfsdk:"rules"`
-	TargetDeviceGroup   types.String           `tfsdk:"target_device_group"`
 	TargetDeviceGroups  types.Set              `tfsdk:"target_device_groups"`
 	EnforcementMode     types.String           `tfsdk:"enforcement_mode"`
 	TenantID            types.String           `tfsdk:"tenant_id"`
@@ -47,7 +46,6 @@ type BenchmarkDataSourceModel struct {
 	SelectedOsVersions  types.Set                `tfsdk:"selected_os_versions"`
 	AvailableOsVersions types.List               `tfsdk:"available_os_versions"`
 	Rules               []RuleModel              `tfsdk:"rules"`
-	TargetDeviceGroup   types.String             `tfsdk:"target_device_group"`
 	TargetDeviceGroups  types.Set                `tfsdk:"target_device_groups"`
 	EnforcementMode     types.String             `tfsdk:"enforcement_mode"`
 	Deleted             types.Bool               `tfsdk:"deleted"`

--- a/internal/resources/cbengine/benchmark/resource.go
+++ b/internal/resources/cbengine/benchmark/resource.go
@@ -13,7 +13,6 @@ import (
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/impact"
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/providerdata"
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
-	"github.com/hashicorp/terraform-plugin-framework-validators/resourcevalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -43,7 +42,6 @@ type BenchmarkResource struct {
 var _ resource.Resource = &BenchmarkResource{}
 var _ resource.ResourceWithImportState = &BenchmarkResource{}
 var _ resource.ResourceWithIdentity = &BenchmarkResource{}
-var _ resource.ResourceWithConfigValidators = &BenchmarkResource{}
 var _ resource.ResourceWithModifyPlan = &BenchmarkResource{}
 
 const (
@@ -79,8 +77,16 @@ func (r *BenchmarkResource) IdentitySchema(ctx context.Context, req resource.Ide
 
 // Schema returns the Terraform schema for the benchmark resource.
 func (r *BenchmarkResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
-	resp.Schema = schema.Schema{
-		Version:             0,
+	resp.Schema = benchmarkResourceSchema(ctx)
+}
+
+// benchmarkResourceSchema builds the current resource schema. Factored out of Schema
+// so the state upgrader can derive the prior version from it (adding back the one
+// attribute that was removed) instead of transcribing 160 lines of nested rule
+// attributes, which would then drift from the real schema on the next change.
+func benchmarkResourceSchema(ctx context.Context) schema.Schema {
+	return schema.Schema{
+		Version:             1,
 		MarkdownDescription: "Creates a Jamf Compliance Benchmark. Creation is asynchronous: the API accepts the request and deploys associated artifacts to the MDM. The provider will poll the benchmark sync state until it reaches `SYNCED` or a terminal failure. Requires **Compliance Benchmarks API** access." + resourcePrivileges,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
@@ -335,26 +341,13 @@ func (r *BenchmarkResource) Schema(ctx context.Context, req resource.SchemaReque
 					listplanmodifier.RequiresReplace(),
 				},
 			},
-			"target_device_group": schema.StringAttribute{
-				MarkdownDescription: "**Deprecated** — use `target_device_groups` instead. Single device group Platform ID targeted by this benchmark, in UUID format. Mutually exclusive with `target_device_groups`. Immutable (replace on change).",
-				DeprecationMessage:  "Use target_device_groups (set of UUIDs) instead. The singular attribute is retained for backwards compatibility and will be removed in a future major release.",
-				Optional:            true,
-				Validators: []validator.String{
-					stringvalidator.RegexMatches(uuidRegex, "Device group ID must be a valid UUID"),
-					stringvalidator.ConflictsWith(path.MatchRoot("target_device_groups")),
-				},
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
-				},
-			},
 			"target_device_groups": schema.SetAttribute{
-				MarkdownDescription: "Device groups this benchmark targets, as a set of group UUIDs. Read them from the `jamfplatform_device_group` or `jamfplatform_device_groups` data sources rather than hand-copying. Mutually exclusive with the deprecated `target_device_group`. Immutable (replace on change).",
+				MarkdownDescription: "Device groups this benchmark targets, as a set of group UUIDs. Read them from the `jamfplatform_device_group` or `jamfplatform_device_groups` data sources rather than hand-copying. Immutable (replace on change).",
 				ElementType:         types.StringType,
-				Optional:            true,
+				Required:            true,
 				Validators: []validator.Set{
 					setvalidator.SizeAtLeast(1),
 					setvalidator.ValueStringsAre(stringvalidator.RegexMatches(uuidRegex, "Each device group ID must be a valid UUID")),
-					setvalidator.ConflictsWith(path.MatchRoot("target_device_group")),
 				},
 				PlanModifiers: []planmodifier.Set{
 					setplanmodifier.RequiresReplace(),
@@ -404,18 +397,6 @@ func (r *BenchmarkResource) Schema(ctx context.Context, req resource.SchemaReque
 				Delete: true,
 			}),
 		},
-	}
-}
-
-// ConfigValidators enforces that callers supply exactly one of the singular or
-// plural device-group attributes. ConflictsWith on each attribute already rejects
-// the both-set case; AtLeastOneOf adds the neither-set case.
-func (r *BenchmarkResource) ConfigValidators(ctx context.Context) []resource.ConfigValidator {
-	return []resource.ConfigValidator{
-		resourcevalidator.AtLeastOneOf(
-			path.MatchRoot("target_device_group"),
-			path.MatchRoot("target_device_groups"),
-		),
 	}
 }
 

--- a/internal/resources/cbengine/benchmark/resource_acceptance_test.go
+++ b/internal/resources/cbengine/benchmark/resource_acceptance_test.go
@@ -158,6 +158,8 @@ func TestAccResource_Benchmark_AllRules_Monitor(t *testing.T) {
 					resource.TestCheckResourceAttr("jamfplatform_cbengine_benchmark.test_all_rules", "title", benchmarkTitle),
 					resource.TestCheckResourceAttr("jamfplatform_cbengine_benchmark.test_all_rules", "enforcement_mode", "MONITOR"),
 					resource.TestCheckResourceAttr("jamfplatform_cbengine_benchmark.test_all_rules", "target_device_groups.#", "2"),
+					// Removed at schema v1 once its 90-day deprecation window closed; assert
+					// it stays gone rather than silently reappearing in state.
 					resource.TestCheckNoResourceAttr("jamfplatform_cbengine_benchmark.test_all_rules", "target_device_group"),
 					// selected_os_versions omitted → computed to the full available set (omit == all).
 					resource.TestCheckResourceAttr("jamfplatform_cbengine_benchmark.test_all_rules", "available_os_versions.#", fmt.Sprintf("%d", len(rules.AvailableOsVersions))),
@@ -346,7 +348,7 @@ func TestAccResource_Benchmark_SelectedOsVersionsOrderIndependent(t *testing.T) 
 				source_baseline_id   = %q
 				rules                = [%s]
 				selected_os_versions = [%s]
-				target_device_group  = jamfplatform_device_group.scope.id
+				target_device_groups = [jamfplatform_device_group.scope.id]
 				enforcement_mode     = "MONITOR"
 			}
 		`, scopeName, benchmarkTitle, baselineID, ruleBlock, osBlock)
@@ -368,89 +370,6 @@ func TestAccResource_Benchmark_SelectedOsVersionsOrderIndependent(t *testing.T) 
 				// would plan a replace here, failing the empty-plan assertion.
 				Config:   config(osBA),
 				PlanOnly: true,
-			},
-		},
-	})
-}
-
-// TestAccResource_Benchmark_DeprecatedSingularTarget verifies the deprecated
-// target_device_group attribute still functions end-to-end. Keep this until the
-// attribute is removed in a future major release.
-func TestAccResource_Benchmark_DeprecatedSingularTarget(t *testing.T) {
-	testhelpers.AccPreCheck(t)
-	suffix := testhelpers.RunSuffix()
-
-	ctx := context.Background()
-	c := testhelpers.NewAcceptanceClient(t)
-	cbClient := cbSDK.New(c)
-	baselines, err := cbClient.ListBaselines(ctx)
-	if err != nil {
-		t.Fatalf("Failed to check baselines: %v", err)
-	}
-	if len(baselines.Baselines) == 0 {
-		t.Skip("No baselines available — CB Engine may not be enabled")
-	}
-
-	baselineID := baselines.Baselines[0].BaselineID
-	rules, err := cbClient.GetBaselineRules(ctx, baselineID)
-	if err != nil {
-		t.Fatalf("Failed to get rules: %v", err)
-	}
-	if len(rules.Rules) == 0 {
-		t.Skip("No rules found for baseline")
-	}
-
-	var ruleBlocks []string
-	for i := 0; i < 1 && i < len(rules.Rules); i++ {
-		r := rules.Rules[i]
-		block := fmt.Sprintf(`{ id = %q, enabled = true`, r.ID)
-		if r.ODV != nil {
-			block += fmt.Sprintf(`, odv_value = %q`, r.ODV.Value)
-		}
-		block += " }"
-		ruleBlocks = append(ruleBlocks, block)
-	}
-
-	benchmarkTitle := "tf-acc-benchmark-deprecated-singular-" + suffix
-	scopeName := "tf-acc-benchmark-scope-deprecated-" + suffix
-
-	ensureBenchmarkCleanup(t, benchmarkTitle)
-
-	config := fmt.Sprintf(`
-		resource "jamfplatform_device_group" "scope" {
-			name        = %q
-			group_type  = "smart"
-			device_type = "computer"
-			criteria = [{
-				criteria = "Serial Number"
-				operator = "like"
-				value    = ""
-			}]
-		}
-
-		resource "jamfplatform_cbengine_benchmark" "test_deprecated" {
-			title              = %q
-			description        = "Backwards-compatibility regression — uses deprecated singular target."
-			source_baseline_id = %q
-
-			rules = [%s]
-
-			target_device_group = jamfplatform_device_group.scope.id
-			enforcement_mode    = "MONITOR"
-		}
-	`, scopeName, benchmarkTitle, baselineID, strings.Join(ruleBlocks, ",\n"))
-
-	resource.Test(t, resource.TestCase{
-		ProtoV6ProviderFactories: testhelpers.AccTestProtoV6ProviderFactories,
-		CheckDestroy:             testAccCheckBenchmarkResourcesDestroy(t),
-		Steps: []resource.TestStep{
-			{
-				Config: config,
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttrSet("jamfplatform_cbengine_benchmark.test_deprecated", "id"),
-					resource.TestCheckResourceAttrSet("jamfplatform_cbengine_benchmark.test_deprecated", "target_device_group"),
-					resource.TestCheckNoResourceAttr("jamfplatform_cbengine_benchmark.test_deprecated", "target_device_groups"),
-				),
 			},
 		},
 	})

--- a/internal/resources/cbengine/benchmark/schema_test.go
+++ b/internal/resources/cbengine/benchmark/schema_test.go
@@ -36,8 +36,8 @@ func TestBenchmarkResource_Schema(t *testing.T) {
 	}
 
 	s := resp.Schema
-	if s.Version != 0 {
-		t.Errorf("expected schema version 0, got %d", s.Version)
+	if s.Version != 1 {
+		t.Errorf("expected schema version 1, got %d", s.Version)
 	}
 
 	requiredAttrs := []string{"title", "rules", "enforcement_mode"}
@@ -76,7 +76,7 @@ func TestBenchmarkResource_Schema(t *testing.T) {
 		}
 	}
 
-	optionalAttrs := []string{"description", "source_baseline_id", "timeouts", "target_device_group", "target_device_groups"}
+	optionalAttrs := []string{"description", "source_baseline_id", "timeouts"}
 	for _, name := range optionalAttrs {
 		attr, ok := s.Attributes[name]
 		if !ok {
@@ -88,17 +88,18 @@ func TestBenchmarkResource_Schema(t *testing.T) {
 		}
 	}
 
-	singular, _ := s.Attributes["target_device_group"].(resourceschema.StringAttribute)
-	if singular.DeprecationMessage == "" {
-		t.Errorf("target_device_group should carry a DeprecationMessage")
+	// The deprecated singular attribute was removed once its 90-day window closed
+	// (deprecated 2026-05-21, removable from 2026-08-19). Assert it is gone rather
+	// than deprecated, so it cannot come back by accident.
+	if _, ok := s.Attributes["target_device_group"]; ok {
+		t.Error("target_device_group was removed at v1 and must not be reintroduced; use target_device_groups")
 	}
-}
-
-func TestBenchmarkResource_ConfigValidators(t *testing.T) {
-	r := NewBenchmarkResource().(*BenchmarkResource)
-	got := r.ConfigValidators(context.Background())
-	if len(got) != 1 {
-		t.Fatalf("expected 1 resource-level config validator, got %d", len(got))
+	plural, ok := s.Attributes["target_device_groups"]
+	if !ok {
+		t.Fatal("missing target_device_groups")
+	}
+	if !plural.IsRequired() {
+		t.Error("target_device_groups is the only way to target a benchmark now, so it must be Required")
 	}
 }
 

--- a/internal/resources/cbengine/benchmark/state_builders.go
+++ b/internal/resources/cbengine/benchmark/state_builders.go
@@ -35,32 +35,17 @@ func assignBenchmarkModelFromResponse(model *BenchmarkResourceModel, bench *comp
 	model.EnforcementMode = types.StringValue(bench.EnforcementMode)
 }
 
-// assignTargetDeviceGroups populates whichever of the two target-device-group attributes
-// the user configured. Singular path: keep TargetDeviceGroup populated, leave plural null.
-// Plural path: keep TargetDeviceGroups populated, leave singular null. If neither is
-// currently set (e.g. import), default to the plural representation.
+// assignTargetDeviceGroups populates the benchmark's device-group targeting from
+// the API response.
 func assignTargetDeviceGroups(model *BenchmarkResourceModel, bench *compliancebenchmarks.BenchmarkResponseV2) {
 	var apiGroups []string
 	if bench.Target != nil {
 		apiGroups = bench.Target.DeviceGroups
 	}
-
-	usedSingular := !model.TargetDeviceGroup.IsNull() && !model.TargetDeviceGroup.IsUnknown()
-	usedPlural := !model.TargetDeviceGroups.IsNull() && !model.TargetDeviceGroups.IsUnknown()
-
-	switch {
-	case usedSingular && !usedPlural:
-		model.TargetDeviceGroup = buildTargetDeviceGroup(apiGroups)
-		model.TargetDeviceGroups = types.SetNull(types.StringType)
-	default:
-		// Plural path, neither configured (import / drift), or both (impossible per schema).
-		model.TargetDeviceGroups = buildTargetDeviceGroupsSet(apiGroups)
-		model.TargetDeviceGroup = types.StringNull()
-	}
+	model.TargetDeviceGroups = buildTargetDeviceGroupsSet(apiGroups)
 }
 
 // assignBenchmarkDataSourceFromResponse maps the API response into the Terraform benchmark data source model.
-// Data sources always populate both attributes — readers can use whichever shape they prefer.
 func assignBenchmarkDataSourceFromResponse(model *BenchmarkDataSourceModel, bench *compliancebenchmarks.BenchmarkResponseV2) {
 	if model == nil || bench == nil {
 		return
@@ -78,7 +63,6 @@ func assignBenchmarkDataSourceFromResponse(model *BenchmarkDataSourceModel, benc
 	if bench.Target != nil {
 		apiGroups = bench.Target.DeviceGroups
 	}
-	model.TargetDeviceGroup = buildTargetDeviceGroup(apiGroups)
 	model.TargetDeviceGroups = buildTargetDeviceGroupsSet(apiGroups)
 	model.EnforcementMode = types.StringValue(bench.EnforcementMode)
 	model.Deleted = types.BoolValue(bench.Deleted)
@@ -177,14 +161,6 @@ func buildRuleModel(r compliancebenchmarks.RuleInfo) RuleModel {
 		Reportable:              types.BoolValue(r.Reportable),
 		SmartCard:               types.BoolValue(r.SmartCard),
 	}
-}
-
-// buildTargetDeviceGroup extracts the first device group ID or returns null.
-func buildTargetDeviceGroup(deviceGroups []string) types.String {
-	if len(deviceGroups) > 0 {
-		return types.StringValue(deviceGroups[0])
-	}
-	return types.StringNull()
 }
 
 // buildTargetDeviceGroupsSet converts the API slice into a Terraform set of strings,

--- a/internal/resources/cbengine/benchmark/state_builders_test.go
+++ b/internal/resources/cbengine/benchmark/state_builders_test.go
@@ -14,10 +14,8 @@ import (
 
 func TestAssignBenchmarkModelFromResponse_Full(t *testing.T) {
 	// Pre-populate the singular slot so assignTargetDeviceGroups takes the
-	// backwards-compat path and writes the API value into TargetDeviceGroup
-	// rather than the plural set.
+	// plural set from the API response.
 	model := &BenchmarkResourceModel{
-		TargetDeviceGroup:  types.StringValue("placeholder"),
 		TargetDeviceGroups: types.SetNull(types.StringType),
 	}
 	lastUpdated, _ := time.Parse(time.RFC3339, "2025-06-15T10:30:00Z")
@@ -109,8 +107,8 @@ func TestAssignBenchmarkModelFromResponse_Full(t *testing.T) {
 	if model.LastUpdatedAt.ValueString() != "2025-06-15T10:30:00Z" {
 		t.Errorf("expected LastUpdatedAt '2025-06-15T10:30:00Z', got %q", model.LastUpdatedAt.ValueString())
 	}
-	if model.TargetDeviceGroup.ValueString() != "group-1" {
-		t.Errorf("expected TargetDeviceGroup 'group-1', got %q", model.TargetDeviceGroup.ValueString())
+	if got := setStrings(model.TargetDeviceGroups); len(got) != 1 || got[0] != "group-1" {
+		t.Errorf("expected TargetDeviceGroups [group-1], got %v", got)
 	}
 	if l := len(model.Sources.Elements()); l != 1 {
 		t.Fatalf("expected 1 source, got %d", l)
@@ -358,11 +356,10 @@ func TestBuildRuleModel_ODVWithoutValidation(t *testing.T) {
 
 func TestAssignBenchmarkModelFromResponse_PluralPath(t *testing.T) {
 	// Model carries TargetDeviceGroups pre-set (the plural-path signal).
-	// State assignment must keep singular null and populate the plural set
-	// with every group the API returned.
+	// State assignment must populate the plural set with every group the API
+	// returned.
 	preset, _ := types.SetValue(types.StringType, []attr.Value{types.StringValue("placeholder")})
 	model := &BenchmarkResourceModel{
-		TargetDeviceGroup:  types.StringNull(),
 		TargetDeviceGroups: preset,
 	}
 	bench := &compliancebenchmarks.BenchmarkResponseV2{
@@ -372,9 +369,6 @@ func TestAssignBenchmarkModelFromResponse_PluralPath(t *testing.T) {
 
 	assignBenchmarkModelFromResponse(model, bench)
 
-	if !model.TargetDeviceGroup.IsNull() {
-		t.Errorf("expected TargetDeviceGroup null when plural path active, got %q", model.TargetDeviceGroup.ValueString())
-	}
 	if model.TargetDeviceGroups.IsNull() {
 		t.Fatal("expected TargetDeviceGroups populated")
 	}
@@ -387,7 +381,6 @@ func TestAssignBenchmarkModelFromResponse_ImportDefaultsToPlural(t *testing.T) {
 	// Both attribute slots null/unknown (typical import). State builder should
 	// default to populating the plural set so imports surface every group.
 	model := &BenchmarkResourceModel{
-		TargetDeviceGroup:  types.StringNull(),
 		TargetDeviceGroups: types.SetNull(types.StringType),
 	}
 	bench := &compliancebenchmarks.BenchmarkResponseV2{
@@ -397,18 +390,8 @@ func TestAssignBenchmarkModelFromResponse_ImportDefaultsToPlural(t *testing.T) {
 
 	assignBenchmarkModelFromResponse(model, bench)
 
-	if !model.TargetDeviceGroup.IsNull() {
-		t.Errorf("expected singular null on import, got %q", model.TargetDeviceGroup.ValueString())
-	}
 	if model.TargetDeviceGroups.IsNull() || len(model.TargetDeviceGroups.Elements()) != 1 {
 		t.Errorf("expected plural populated on import")
-	}
-}
-
-func TestBuildTargetDeviceGroup(t *testing.T) {
-	result := buildTargetDeviceGroup([]string{"group-a", "group-b"})
-	if result.ValueString() != "group-a" {
-		t.Errorf("expected 'group-a', got %q", result.ValueString())
 	}
 }
 
@@ -426,13 +409,6 @@ func TestBuildTargetDeviceGroupsSet_Empty(t *testing.T) {
 	result := buildTargetDeviceGroupsSet(nil)
 	if !result.IsNull() {
 		t.Error("expected null set for empty input")
-	}
-}
-
-func TestBuildTargetDeviceGroup_Empty(t *testing.T) {
-	result := buildTargetDeviceGroup(nil)
-	if !result.IsNull() {
-		t.Error("expected null for empty device groups")
 	}
 }
 
@@ -655,3 +631,14 @@ func TestBuildODVValidationMax_NilChain(t *testing.T) {
 
 // suppress unused import warning for types package
 var _ = types.StringNull
+
+// setStrings flattens a types.Set of strings for assertion purposes.
+func setStrings(set types.Set) []string {
+	out := make([]string, 0, len(set.Elements()))
+	for _, el := range set.Elements() {
+		if v, ok := el.(types.String); ok {
+			out = append(out, v.ValueString())
+		}
+	}
+	return out
+}

--- a/internal/resources/cbengine/benchmark/state_upgrader.go
+++ b/internal/resources/cbengine/benchmark/state_upgrader.go
@@ -1,0 +1,113 @@
+// Copyright Jamf Software LLC 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package benchmark
+
+import (
+	"context"
+
+	resourceTimeouts "github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var _ resource.ResourceWithUpgradeState = &BenchmarkResource{}
+
+// benchmarkResourceModelV0 is the v0 resource model: the current one plus the
+// removed singular target_device_group. State written by v0 carries that
+// attribute, so decoding it needs a struct that declares it — the framework
+// errors rather than ignoring an attribute the target struct does not define.
+type benchmarkResourceModelV0 struct {
+	ID                  types.String           `tfsdk:"id"`
+	Title               types.String           `tfsdk:"title"`
+	Description         types.String           `tfsdk:"description"`
+	SourceBaselineID    types.String           `tfsdk:"source_baseline_id"`
+	Sources             types.List             `tfsdk:"sources"`
+	SelectedOsVersions  types.Set              `tfsdk:"selected_os_versions"`
+	AvailableOsVersions types.List             `tfsdk:"available_os_versions"`
+	Rules               []RuleModel            `tfsdk:"rules"`
+	TargetDeviceGroup   types.String           `tfsdk:"target_device_group"`
+	TargetDeviceGroups  types.Set              `tfsdk:"target_device_groups"`
+	EnforcementMode     types.String           `tfsdk:"enforcement_mode"`
+	TenantID            types.String           `tfsdk:"tenant_id"`
+	Deleted             types.Bool             `tfsdk:"deleted"`
+	UpdateAvailable     types.Bool             `tfsdk:"update_available"`
+	CanSwitchToEnforce  types.Bool             `tfsdk:"can_switch_to_enforce"`
+	LastUpdatedAt       types.String           `tfsdk:"last_updated_at"`
+	Timeouts            resourceTimeouts.Value `tfsdk:"timeouts"`
+}
+
+// benchmarkSchemaV0 returns the v0 schema: the current one with the removed
+// singular target_device_group added back, and target_device_groups relaxed to
+// Optional as it was then. Deriving it from benchmarkResourceSchema rather than
+// transcribing it keeps the prior schema honest as the rest of the resource
+// changes — a hand-copied 160-line rules block would drift on the next edit and
+// fail to decode real state.
+func benchmarkSchemaV0(ctx context.Context) *schema.Schema {
+	s := benchmarkResourceSchema(ctx)
+	s.Version = 0
+	s.Attributes["target_device_group"] = schema.StringAttribute{Optional: true}
+	s.Attributes["target_device_groups"] = schema.SetAttribute{Optional: true, ElementType: types.StringType}
+	return &s
+}
+
+// UpgradeState migrates v0 state, which could target device groups through either
+// the singular target_device_group or the plural target_device_groups, onto v1,
+// where only the plural survives.
+//
+// The singular value is folded into the plural set rather than dropped: a user who
+// targeted through the deprecated attribute keeps the same device group after the
+// upgrade, so the removal costs them a config edit and never a re-scope. The
+// upgrader fixes state only — their .tf still has to change, which is what the
+// deprecation window was for.
+func (r *BenchmarkResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: benchmarkSchemaV0(ctx),
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				var old benchmarkResourceModelV0
+				resp.Diagnostics.Append(req.State.Get(ctx, &old)...)
+				if resp.Diagnostics.HasError() {
+					return
+				}
+
+				upgraded := BenchmarkResourceModel{
+					ID:                  old.ID,
+					Title:               old.Title,
+					Description:         old.Description,
+					SourceBaselineID:    old.SourceBaselineID,
+					Sources:             old.Sources,
+					SelectedOsVersions:  old.SelectedOsVersions,
+					AvailableOsVersions: old.AvailableOsVersions,
+					Rules:               old.Rules,
+					TargetDeviceGroups:  upgradeTargetDeviceGroups(old),
+					EnforcementMode:     old.EnforcementMode,
+					TenantID:            old.TenantID,
+					Deleted:             old.Deleted,
+					UpdateAvailable:     old.UpdateAvailable,
+					CanSwitchToEnforce:  old.CanSwitchToEnforce,
+					LastUpdatedAt:       old.LastUpdatedAt,
+					Timeouts:            old.Timeouts,
+				}
+
+				resp.Diagnostics.Append(resp.State.Set(ctx, &upgraded)...)
+			},
+		},
+	}
+}
+
+// upgradeTargetDeviceGroups resolves v0's two targeting attributes into v1's one.
+// The plural wins when it is set, because v0's schema validation made the two
+// mutually exclusive; the singular is promoted to a one-element set when it is the
+// one that was used.
+func upgradeTargetDeviceGroups(old benchmarkResourceModelV0) types.Set {
+	if !old.TargetDeviceGroups.IsNull() && !old.TargetDeviceGroups.IsUnknown() {
+		return old.TargetDeviceGroups
+	}
+	if !old.TargetDeviceGroup.IsNull() && !old.TargetDeviceGroup.IsUnknown() && old.TargetDeviceGroup.ValueString() != "" {
+		return types.SetValueMust(types.StringType, []attr.Value{types.StringValue(old.TargetDeviceGroup.ValueString())})
+	}
+	return types.SetNull(types.StringType)
+}

--- a/internal/resources/cbengine/benchmark/state_upgrader_test.go
+++ b/internal/resources/cbengine/benchmark/state_upgrader_test.go
@@ -1,0 +1,96 @@
+// Copyright Jamf Software LLC 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package benchmark
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// State upgraders are unit-tested rather than acceptance-tested: the acceptance
+// harness always writes state with the current schema version, so the v0→v1 path
+// is unreachable from it.
+
+func TestUpgradeTargetDeviceGroups_PromotesTheSingular(t *testing.T) {
+	// The whole point of the upgrader. Without it the singular value is dropped,
+	// target_device_groups reads null, and the user's first plan after editing
+	// their config to the plural attribute sees null -> ["dg-1"] on an attribute
+	// carrying RequiresReplace — destroying and recreating a live benchmark.
+	got := upgradeTargetDeviceGroups(benchmarkResourceModelV0{
+		TargetDeviceGroup:  types.StringValue("dg-1"),
+		TargetDeviceGroups: types.SetNull(types.StringType),
+	})
+	if got.IsNull() {
+		t.Fatal("the singular value must survive the upgrade, not be dropped")
+	}
+	if elems := setStrings(got); len(elems) != 1 || elems[0] != "dg-1" {
+		t.Errorf("expected [dg-1], got %v", elems)
+	}
+}
+
+func TestUpgradeTargetDeviceGroups_KeepsThePlural(t *testing.T) {
+	got := upgradeTargetDeviceGroups(benchmarkResourceModelV0{
+		TargetDeviceGroup:  types.StringNull(),
+		TargetDeviceGroups: types.SetValueMust(types.StringType, nil),
+	})
+	if got.IsNull() {
+		t.Fatal("an explicitly set plural must be preserved as-is")
+	}
+}
+
+func TestUpgradeTargetDeviceGroups_PluralWinsOverSingular(t *testing.T) {
+	// v0 validation made the two mutually exclusive, so this state should not
+	// exist — but if it does, the preferred attribute is the one to trust rather
+	// than silently merging a value the user did not intend to keep.
+	got := upgradeTargetDeviceGroups(benchmarkResourceModelV0{
+		TargetDeviceGroup:  types.StringValue("singular"),
+		TargetDeviceGroups: types.SetValueMust(types.StringType, nil),
+	})
+	if elems := setStrings(got); len(elems) != 0 {
+		t.Errorf("the plural attribute should win, got %v", elems)
+	}
+}
+
+func TestUpgradeTargetDeviceGroups_NeitherSetStaysNull(t *testing.T) {
+	got := upgradeTargetDeviceGroups(benchmarkResourceModelV0{
+		TargetDeviceGroup:  types.StringNull(),
+		TargetDeviceGroups: types.SetNull(types.StringType),
+	})
+	if !got.IsNull() {
+		t.Errorf("nothing to migrate should stay null, got %v", got)
+	}
+}
+
+func TestUpgradeTargetDeviceGroups_EmptySingularIsNotPromoted(t *testing.T) {
+	got := upgradeTargetDeviceGroups(benchmarkResourceModelV0{
+		TargetDeviceGroup:  types.StringValue(""),
+		TargetDeviceGroups: types.SetNull(types.StringType),
+	})
+	if !got.IsNull() {
+		t.Errorf("an empty singular is not a device group, got %v", got)
+	}
+}
+
+// TestUpgradeState_DeclaresTheV0Path guards the wiring: a missing entry for
+// version 0 makes every v0 state unreadable at v1 with a framework error, which
+// is worse than the forced replacement the upgrader exists to prevent.
+func TestUpgradeState_DeclaresTheV0Path(t *testing.T) {
+	r := NewBenchmarkResource().(*BenchmarkResource)
+	upgraders := r.UpgradeState(context.Background())
+	u, ok := upgraders[0]
+	if !ok {
+		t.Fatalf("no upgrader registered for schema version 0, got versions %v", upgraders)
+	}
+	if u.PriorSchema == nil {
+		t.Fatal("the v0 upgrader needs a PriorSchema to decode state that still carries target_device_group")
+	}
+	if _, ok := u.PriorSchema.Attributes["target_device_group"]; !ok {
+		t.Error("the v0 PriorSchema must still declare target_device_group, or v0 state cannot be decoded")
+	}
+	if u.PriorSchema.Version != 0 {
+		t.Errorf("PriorSchema version should be 0, got %d", u.PriorSchema.Version)
+	}
+}


### PR DESCRIPTION
# Pull Request

## Description

Removes the deprecated singular `target_device_group` attribute from the compliance benchmark resource and its data source, now that its deprecation window has closed.

Deprecated 2026-05-21 in `d2c944a1` in favour of the plural `target_device_groups` set. [STYLE_GUIDE §Platform Services *Terraform schema* deprecation](../blob/main/STYLE_GUIDE.md#platform-services-terraform-schema-deprecation--90-day-window) gives Platform Services schema deprecations a 90-day window, which closed **2026-08-19**. The attribute carried no `PLATFORM-DEPRECATED remove-after=` marker, so it was invisible to the batch-removal grep the STYLE_GUIDE prescribes — which is how it survived past its own expiry.

Kept deliberately narrow: one attribute, one release. No other deprecated attribute or SDK method is touched.

### Two decisions worth reviewing

**1. `target_device_groups` becomes `Required`.** It was `Optional` only because a resource-level `AtLeastOneOf` validator enforced "one of the two". With the singular gone that validator disappears, and leaving the survivor `Optional` would silently permit an untargeted benchmark that the schema previously rejected at plan time. `ConfigValidators` and its framework interface assertion go with it.

**2. The state upgrader is not there for the reason you would expect, and I checked rather than assumed.** The framework does **not** need an upgrader to read v0 state: `fwserver.UpgradeResourceState` unmarshals prior state with `IgnoreUndefinedAttributes: true`, and on a version match it round-trips through the current schema, so a removed attribute is silently dropped.

The upgrader exists to prevent a **forced replacement**. Without it:

1. v0 state loses the singular value silently.
2. `target_device_groups` therefore reads `null`.
3. The user edits their config to the plural attribute (they must — the old one is gone).
4. That plan sees `null` → `["dg-1"]` on an attribute carrying `RequiresReplace`.
5. A live benchmark is destroyed and recreated — asynchronously, redeploying artifacts to real devices.

The upgrader folds the singular value into the set so step 4 is a no-op. It fixes **state only**; the `.tf` edit is still on the user, which is what the deprecation window was for.

**The v0 prior schema is derived, not transcribed.** `benchmarkResourceSchema` is factored out of `Schema`, and `benchmarkSchemaV0` adds the removed attribute back and relaxes the plural to `Optional` as it was. Hand-copying the prior schema would mean duplicating a 160-line nested `rules` block that then drifts on the next edit and fails to decode real state.

## Type of Change

- [ ] New resource
- [ ] New data source
- [ ] Bug fix
- [ ] Enhancement to existing resource/data source
- [x] Documentation update
- [x] Refactoring/code cleanup
- [x] Other (please describe): **breaking removal** of a deprecated attribute whose 90-day window closed, with schema `Version` 0 → 1 and a state upgrader

## Resources/Data Sources Modified

- `jamfplatform_cbengine_benchmark` — `target_device_group` removed; `target_device_groups` now `Required`; schema `Version` 1
- `data.jamfplatform_cbengine_benchmark` — `target_device_group` removed

## Testing

### Automated Tests

- [x] Added Go unit tests — `state_upgrader_test.go` covers the singular→plural promotion, plural-wins, neither-set, empty-singular and the v0 wiring (a missing version-0 entry makes every v0 state unreadable, which is worse than the replacement the upgrader prevents). Upgraders are unit-tested because the acceptance harness always writes current-version state, so the v0 path is unreachable from it.
- [x] Go acceptance tests updated — the deprecated-attribute test is deleted with the attribute; the OS-version-order test moves to `target_device_groups`. No new tests added.
- [x] `make fix fmt lint test` passes locally — `lint` reports 4 issues, **all pre-existing and all in gitignored `local-testing/` scratch files** never touched here, so CI will not see them
- [x] `make generate` run and regenerated `docs/` committed alongside the source
- [x] `go vet ./...` and `go vet -tags acceptance ./...` clean

**Regression guards, since this is a removal:** `schema_test.go` now asserts the attribute is **gone** and that `Version` is 1, rather than asserting it carries a `DeprecationMessage`; the acceptance suite keeps its `TestCheckNoResourceAttr` guard. Between them the attribute cannot reappear silently.

### Manual Testing

- [x] Tested `terraform apply` against a test Jamf instance — via the acceptance suite below
- [x] Tested resource/data source CRUD operations (Create, Read, Update, Delete)
- [ ] Verified resources appear correctly in Jamf Pro UI

**Acceptance suite green against a live EU tenant — 6/6 pass, no skips, ~59s:**

```
--- PASS: TestAccResource_Benchmark_AllRules_Monitor (20.19s)
--- PASS: TestAccResource_Benchmark_CustomRules_MonitorAndEnforce (15.63s)
--- PASS: TestAccResource_Benchmark_SelectedOsVersionsOrderIndependent (15.24s)
--- PASS: TestAccDataSource_Baselines (3.26s)
--- PASS: TestAccDataSource_Benchmarks (2.09s)
--- PASS: TestAccDataSource_Rules (2.43s)
ok   .../internal/resources/cbengine/benchmark  59.420s
```

`SelectedOsVersionsOrderIndependent` drives `target_device_groups` end-to-end with its config rewritten to the plural form, and `AllRules_Monitor` confirms `target_device_group` is absent from real state.

The **upgrade path itself is not acceptance-tested** and cannot be — see the note above. It rests on the unit tests plus the framework behaviour cited in the description.

### Screenshots

Not applicable — no resource is added or changed in the Jamf Pro UI.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing Go unit and acceptance tests pass locally with my changes
- [x] Any dependent changes have been merged and published — none

## Additional Context

**This is a breaking change and needs a line in the GA migration guide.** The config edit is `target_device_group = X` → `target_device_groups = [X]`. The state upgrader means no re-scope and no replacement, so the user's cost is the edit and nothing else — worth saying explicitly, because a removal that forces a replacement and one that does not look identical from the changelog.

Two follow-ups deliberately **not** done here:

- `blueprints_blueprint` carries 14 `DeprecationMessage` sites with `PLATFORM-DEPRECATED remove-after=2026-10-22`. That date has **not** passed, so those stay.
- The deprecated SDK methods (#311) are a separate sweep. Note that three `//nolint:staticcheck` suppressions there are **deliberate** and must not be swept: classic `/patchsoftwaretitles` (the v2 create is unusable), the patch-policy list endpoint (only list is deprecated), and the Security Cloud device-group v2 successor (unrouted).

One housekeeping note for whoever merges the GA branch: a sibling branch (`chore/sdk-ff08380-withdrawn-endpoints`) adds a `PLATFORM-DEPRECATED remove-after=2026-08-19` marker for this same attribute. Once this PR merges, that marker describes an attribute that no longer exists — drop that hunk at merge.

## Related Issues

Relates to the Platform API GA epic (targets `feat/platform-api-ga`, not `main`).
Relates to #311 (deprecated SDK methods — separate sweep, not included here).
