### PR TITLE
docs(security_cloud): add a Jamf Security Cloud guide, wire-verified

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,8 +139,8 @@ resources translate that code into a named diagnostic instead of surfacing the r
 Second, **cross-namespace references are server-enforced in both directions**: a DNS
 zone's name servers each name a gateway by ID — a shared, dedicated or grouped gateway, all
 three accepted — and a zone cannot be written before its gateway exists
-(`422 GATEWAY_NOT_FOUND`), so that diagnostic points at `name_servers` rather than the zone;
-conversely a gateway that anything still references refuses to be deleted with a bare
+(`422 GATEWAY_NOT_FOUND`), so that diagnostic points at `authoritative_name_servers` rather than
+the zone; conversely a gateway that anything still references refuses to be deleted with a bare
 `409 CONFLICT` naming nothing, which is a Terraform destroy-ordering trap and gets its own
 diagnostic. That last behaviour is **per construct, not a namespace rule** — a device group
 that a ZTNA app still names deletes cleanly and silently empties the app's assignment instead

--- a/docs/data-sources/security_cloud_content_categories.md
+++ b/docs/data-sources/security_cloud_content_categories.md
@@ -5,7 +5,7 @@ subcategory: ""
 description: |-
   Reads the content categories available in Jamf Security Cloud — Jamf's own classification of web and app traffic, such as Social or Cloud & File Storage. The catalogue is curated by Jamf, identical for every entitled tenant, and cannot be changed.
   Use this to reference a category without hard-coding a name Jamf may revise — in an output, or to pre-stage an identifier. Note that a category has two names: reference display_name, not name.
-  Zero Trust Network Access apps, which are what match a category, are not yet managed by this provider, so today the value read here is for reference rather than for wiring into another resource.
+  A jamfplatform_security_cloud_ztna_app is what matches a category, so resolve the category here and wire display_name into its category rather than writing the name out.
   Required Jamf permissions
   Grant the API integration the following permissions in Jamf Account — see Getting started with the Platform API https://developer.jamf.com/platform-api/reference/getting-started-with-platform-api. Category and Permission name the section and row of the permission picker; Actions are the boxes to tick within that row.
   | Category | Permission | Actions | API capability |
@@ -19,7 +19,7 @@ Reads the content categories available in Jamf Security Cloud — Jamf's own cla
 
 Use this to reference a category without hard-coding a name Jamf may revise — in an output, or to pre-stage an identifier. Note that a category has two names: reference `display_name`, not `name`.
 
-Zero Trust Network Access apps, which are what match a category, are not yet managed by this provider, so today the value read here is for reference rather than for wiring into another resource.
+A `jamfplatform_security_cloud_ztna_app` is what matches a category, so resolve the category here and wire `display_name` into its `category` rather than writing the name out.
 
 **Required Jamf permissions**
 
@@ -77,6 +77,6 @@ Optional:
 
 Read-Only:
 
-- `display_name` (String) The category name as shown in Jamf Security Cloud, for example `Social`. **This is the name that identifies the category** — a Zero Trust Network Access app's category matches on it, and it is the name to reference. Zero Trust Network Access apps are not yet managed by this provider.
+- `display_name` (String) The category name as shown in Jamf Security Cloud, for example `Social`. **This is the name that identifies the category** — a Zero Trust Network Access app's category matches on it, and it is the name to reference. Wire it into a `jamfplatform_security_cloud_ztna_app`'s `category`.
 - `id` (String) Content category identifier.
 - `name` (String) Jamf's internal label for the category, for example `Category - Social`. Informational only — reference `display_name` instead.

--- a/docs/data-sources/security_cloud_ztna_predefined_apps.md
+++ b/docs/data-sources/security_cloud_ztna_predefined_apps.md
@@ -5,7 +5,7 @@ subcategory: ""
 description: |-
   Reads the predefined Zero Trust Network Access app templates available in Jamf Security Cloud — Jamf's own definitions of well-known applications such as Slack or Salesforce, each bundling the hostnames that application uses. The catalogue is curated by Jamf, identical for every entitled tenant, and cannot be changed.
   Use this to read a template's identifier without hard-coding it, and to review the hostnames the template brings with it.
-  Zero Trust Network Access apps are not yet managed by this provider, so the identifier read here is for reference today — an output, or a value to pre-stage a configuration on — rather than something another resource can be wired to.
+  Wire the identifier into a jamfplatform_security_cloud_ztna_app's predefined_app_id to manage an application based on the definition. Only one application per definition is allowed on a tenant.
   Required Jamf permissions
   Grant the API integration the following permissions in Jamf Account — see Getting started with the Platform API https://developer.jamf.com/platform-api/reference/getting-started-with-platform-api. Category and Permission name the section and row of the permission picker; Actions are the boxes to tick within that row.
   | Category | Permission | Actions | API capability |
@@ -19,7 +19,7 @@ Reads the predefined Zero Trust Network Access app templates available in Jamf S
 
 Use this to read a template's identifier without hard-coding it, and to review the hostnames the template brings with it.
 
-Zero Trust Network Access apps are not yet managed by this provider, so the identifier read here is for reference today — an output, or a value to pre-stage a configuration on — rather than something another resource can be wired to.
+Wire the identifier into a `jamfplatform_security_cloud_ztna_app`'s `predefined_app_id` to manage an application based on the definition. Only one application per definition is allowed on a tenant.
 
 **Required Jamf permissions**
 

--- a/docs/guides/security-cloud.md
+++ b/docs/guides/security-cloud.md
@@ -14,16 +14,28 @@ This guide is the Terraform half: which portal pages the provider reaches, the o
 
 | In the portal | Constructs |
 |---|---|
-| **Devices > Device groups** | `jamfplatform_security_cloud_device_group` (resource, data source, list resource), `..._device_groups` |
+| **Devices > Device groups** | `jamfplatform_security_cloud_device_group` (resource, data source, list resource), `..._device_groups` (data source) |
 | **Devices > Activation profiles > Deployment** | `jamfplatform_security_cloud_activation_profile_deploy` (action) |
-| **Policies > Access > Access policy** | `jamfplatform_security_cloud_ztna_app`, `..._ztna_predefined_apps`, `..._content_categories` |
-| **Integrations > Access gateways** | `jamfplatform_security_cloud_ztna_gateway`, `..._ztna_grouped_gateway`, `..._ztna_shared_gateways` |
-| **Integrations > Custom DNS > DNS zones** | `jamfplatform_security_cloud_dns_zone` |
-| **Integrations > Custom DNS > Search domain** | `jamfplatform_security_cloud_dns_search_domain` |
-| **Integrations > Custom DNS > Hostname mapping** | `jamfplatform_security_cloud_dns_hostname_mappings` |
-| **Integrations > UEM Connect** | `jamfplatform_security_cloud_uem_connect`, `..._uem_connect_synchronize` (action) |
+| **Policies > Access > Access policy** | `jamfplatform_security_cloud_ztna_app` (resource, data source, list resource), `..._ztna_apps` (data source), `..._ztna_predefined_apps` (data source), `..._content_categories` (data source) |
+| **Integrations > Access gateways** | `jamfplatform_security_cloud_ztna_gateway` (resource, data source, list resource), `..._ztna_gateways` (data source), `..._ztna_grouped_gateway` (resource, data source, list resource), `..._ztna_grouped_gateways` (data source), `..._ztna_shared_gateways` (data source) |
+| **Integrations > Custom DNS > DNS zones** | `jamfplatform_security_cloud_dns_zone` (resource, data source, list resource), `..._dns_zones` (data source) |
+| **Integrations > Custom DNS > Search domain** | `jamfplatform_security_cloud_dns_search_domain` (resource, data source) |
+| **Integrations > Custom DNS > Hostname mapping** | `jamfplatform_security_cloud_dns_hostname_mappings` (resource, data source) |
+| **Integrations > UEM Connect** | `jamfplatform_security_cloud_uem_connect` (resource, data source, list resource), `..._uem_connect_synchronize` (action) |
 
 Three things next door to this are **not** managed here. **Activation profiles** themselves are created in the portal — most of their settings cannot be edited after creation, so Jamf treats them as immutable and the provider offers only the action that deploys one to Jamf Pro. **Content filtering and network security policies** (Jamf Protect's half of the portal) have no constructs yet. And **devices** arrive by enrolling with Jamf Trust or by syncing from a UEM; nothing here enrols one.
+
+## Build it in this order
+
+The sections below are ordered for reading. A rollout goes in a different order, because each step depends on the one above it:
+
+1. **UEM Connect** — device inventory and group membership have to be syncing before anything downstream is accurate.
+2. **Device groups** — or map them from Jamf Pro groups in step 1.
+3. **Gateways, then custom DNS** — a zone cannot be written before the gateway its name servers name. Written the other way round, Jamf Security Cloud refuses it with `422 GATEWAY_NOT_FOUND`, and the provider reports that against `authoritative_name_servers` rather than against the zone as a whole.
+4. **Access policy** — applications reference the groups, categories and gateways above.
+5. **Activation profile deploy** — nothing above reaches a device until this runs.
+
+Terraform derives most of that from the references between resources, so the order is yours to get right only where there is no reference to derive it from — a zone naming a gateway ID that arrived as a variable, say.
 
 ## End to end: publishing one enterprise app over ZTNA
 
@@ -36,17 +48,13 @@ resource "jamfplatform_security_cloud_device_group" "engineering" {
   name = "Engineering"
 }
 
-# Categories and gateways are both Jamf-maintained catalogues, so resolve them
-# rather than hard-coding an ID or guessing a category's spelling.
+# A gateway is named by an opaque ID, so resolve it from the catalogue rather than
+# hard-coding one. A category is named by its display name, so there is nothing to
+# resolve — the content_categories data source is how you confirm a spelling.
 data "jamfplatform_security_cloud_content_categories" "all" {}
 data "jamfplatform_security_cloud_ztna_shared_gateways" "all" {}
 
 locals {
-  business_category = one([
-    for category in data.jamfplatform_security_cloud_content_categories.all.content_categories :
-    category.display_name if category.display_name == "Business & Industry"
-  ])
-
   nearest_data_center = one([
     for gateway in data.jamfplatform_security_cloud_ztna_shared_gateways.all.shared_gateways :
     gateway.id if gateway.name == "Nearest Data Center"
@@ -54,8 +62,11 @@ locals {
 }
 
 resource "jamfplatform_security_cloud_ztna_app" "wiki" {
-  name     = "Engineering Wiki"
-  category = local.business_category
+  name = "Engineering Wiki"
+
+  # Matched on the category's display name, so the spelling has to be exact —
+  # check it against the content_categories data source above.
+  category = "Business & Industry"
 
   # Traffic matching. A wildcard may replace the whole leading label, and entries
   # must be mutually exclusive — "*.wiki.example.com" already covers a subdomain
@@ -113,7 +124,9 @@ resource "jamfplatform_security_cloud_ztna_app" "github" {
   routing = {
     traffic_routing = "Encrypt and route via ZTNA"
     routing_mode    = "Standard"
-    gateway_id      = local.nearest_data_center
+
+    # Declared in the end-to-end example above.
+    gateway_id = local.nearest_data_center
   }
 }
 ```
@@ -135,6 +148,9 @@ resource "jamfplatform_security_cloud_dns_zone" "internal" {
   domains = ["example.corp", "*.example.corp"]
 
   # Each name server is paired with the gateway it is reachable through.
+  # local.nearest_data_center comes from the locals block in the end-to-end
+  # example above, and is the shared egress — a name server on your own network
+  # is not reachable through it and needs a dedicated gateway instead.
   authoritative_name_servers = [
     { ip_address = "203.0.113.53", gateway_id = local.nearest_data_center },
     { ip_address = "203.0.113.54", gateway_id = local.nearest_data_center },
@@ -145,7 +161,7 @@ resource "jamfplatform_security_cloud_dns_zone" "internal" {
 Queries matching the zone's domains go to one of its name servers by pseudo-random load balancing. Four rules here are Jamf's, not the provider's, and each one is a plan that applies and then fails to work:
 
 - A **domain belongs to exactly one zone**, tenant-wide, and a name server IP address may appear only once per zone.
-- The name server has to be reachable **through the gateway you name**, and **its address must be publicly routable**. Jamf Security Cloud refuses a reserved address — private, loopback and similar — with `Name server IP address not allowed`. Jamf's own documentation attaches that restriction to the shared "Nearest Data Center" egress, but a dedicated *internet* gateway refuses a private address just the same, so do not plan on one lifting the rule. A name server on an internal address needs a gateway that actually reaches your network, which means the IPsec form below.
+- The name server has to be reachable **through the gateway you name**, and **its address must not be in a reserved range** — Jamf Security Cloud refuses a private or loopback address with `Name server IP address not allowed`. Not every unrouted address is refused: a documentation range such as `203.0.113.0/24` is accepted, which is why the example above uses one. Jamf's own documentation attaches the restriction to the shared "Nearest Data Center" egress, but a dedicated *internet* gateway refuses a private address just the same, so do not plan on one lifting the rule. A name server on an internal address needs a gateway that actually reaches your network, which means the IPsec form below.
 - Reverse lookups work by adding the `.in-addr.arpa` and `.ipv6.arpa` domains to the zone.
 - **Changes to your own infrastructure need the zone changed too** — a new or renumbered name server, or an application on a domain the zone does not match.
 
@@ -171,7 +187,9 @@ resource "jamfplatform_security_cloud_ztna_gateway" "frankfurt" {
   }
 
   # Omitted here, so this is a dedicated internet gateway. Adding or removing the
-  # block replaces the gateway — see "Immutable forms" below.
+  # block replaces the gateway — see "Immutable forms" below. The full IPsec form,
+  # with its jamf_side and customer_side blocks, is on the
+  # jamfplatform_security_cloud_ztna_gateway resource page.
   # ipsec = { ... }
 }
 ```
@@ -248,6 +266,12 @@ Three resources are one-per-tenant, and each behaves slightly differently when y
 - `dns_hostname_mappings` — owns the **whole set**; destroying it removes every mapping, and any mapping added outside Terraform is removed on the next apply.
 - `uem_connect` — creating a second is refused, so **import** where one already exists rather than declaring a new one.
 
+The integration's ID is not a value anyone would have written down, so read it off the data source — `data "jamfplatform_security_cloud_uem_connect" "existing" {}` reports it as `id` — or let `terraform query -generate-config-out=uem_connect.tf` write the import block for you from the list resource:
+
+```shell
+terraform import jamfplatform_security_cloud_uem_connect.jamf_pro 6a91b958619ef153a5a63d72
+```
+
 Declare each of them once. A second instance of any of them in one configuration will fight itself on every apply.
 
 ## Immutable forms
@@ -303,7 +327,7 @@ action "jamfplatform_security_cloud_uem_connect_synchronize" "now" {
 }
 ```
 
-Jamf Security Cloud does not check that either side of a mapping exists, so a wrong group number is accepted and simply never matches. Declaring `group_membership_mapping` at all replaces what it does not mention — an omitted or empty `mappings` clears every mapping.
+Jamf Security Cloud does not check that either side of a mapping exists, so a wrong group number is accepted and simply never matches. The group configuration is replaced wholesale on every apply, so there is no way to leave it unmanaged: declaring `group_membership_mapping` replaces what it does not mention — an omitted or empty `mappings` clears every mapping — and **omitting the block entirely resets the whole group configuration to its defaults**. Manage it, or expect it cleared.
 
 Importing an existing integration has one wrinkle worth knowing in advance: `user_data_field_mapping` and `group_membership_mapping` are captured from the tenant even though your configuration may not declare them, so run `terraform plan` straight after the import and write in what the plan shows you rather than letting the next apply clear them.
 
@@ -329,7 +353,7 @@ Jamf Security Cloud is reached under **either** scope: set `environment_id` (pre
 
 Two things about authorisation are specific to this namespace:
 
-- **Entitlement is not authentication.** A valid API integration can still be refused with `403 NOT_ENTITLED` when the tenant does not hold the product behind the construct — dedicated gateways, for instance, are a paid add-on. The provider translates that into a named diagnostic rather than surfacing the raw error.
+- **Entitlement is not authentication.** A valid API integration can still be refused with `403 NOT_ENTITLED` when the tenant does not hold the product behind the construct — dedicated gateways, for instance, are a paid add-on. Every resource and action translates that into a named diagnostic; the three read-only catalogues — `..._content_categories`, `..._ztna_predefined_apps` and `..._ztna_shared_gateways` — surface the raw error instead.
 - **Permissions are per construct**, granted in Jamf Account's permission picker. Each resource, data source and action page carries its own table naming the category, the row and the boxes to tick; the capabilities across this namespace are `ztna`, `device-groups`, `content-categories`, `custom-hostname-mappings`, `search-domains` and `uem-connect`.
 
 ## Further reading

--- a/docs/guides/security-cloud.md
+++ b/docs/guides/security-cloud.md
@@ -6,9 +6,17 @@ description: |-
 
 # Jamf Security Cloud
 
-Jamf Security Cloud is the portal at [radar.jamf.com](https://radar.jamf.com) where content controls, network security and Zero Trust Network Access are configured. Jamf's own documentation is split across two guides, and both are worth having open: the [Jamf Security Cloud Portal Setup Guide](https://learn.jamf.com/r/en-US/jamf-security-cloud-setup-guide/RADAR_Portal) covers device groups, activation profiles and the portal's integrations, and the [Zero Trust Network Access](https://learn.jamf.com/r/en-US/jamf-connect-documentation-current/Private_Access) section of the Jamf Connect Documentation covers access policy and gateways. See [Further reading](#further-reading) below.
+Jamf Security Cloud is the portal at [radar.jamf.com](https://radar.jamf.com) where content
+controls, network security and Zero Trust Network Access are configured. This guide is the
+Terraform half: which portal pages the provider reaches, what order to build in, and the
+behaviours that will surprise you.
 
-This guide is the Terraform half: which portal pages the provider reaches, the order things have to be created in, and the handful of behaviours that will surprise you.
+Jamf splits its own documentation across the [Portal Setup
+Guide](https://learn.jamf.com/r/en-US/jamf-security-cloud-setup-guide/RADAR_Portal) (device groups,
+activation profiles, integrations) and the [Zero Trust Network
+Access](https://learn.jamf.com/r/en-US/jamf-connect-documentation-current/Private_Access) section
+of the Jamf Connect Documentation (access policy, gateways). See [Further
+reading](#further-reading).
 
 ## What the provider manages
 
@@ -23,34 +31,45 @@ This guide is the Terraform half: which portal pages the provider reaches, the o
 | **Integrations > Custom DNS > Hostname mapping** | `jamfplatform_security_cloud_dns_hostname_mappings` (resource, data source) |
 | **Integrations > UEM Connect** | `jamfplatform_security_cloud_uem_connect` (resource, data source, list resource), `..._uem_connect_synchronize` (action) |
 
-Three things next door to this are **not** managed here. **Activation profiles** themselves are created in the portal — most of their settings cannot be edited after creation, so Jamf treats them as immutable and the provider offers only the action that deploys one to Jamf Pro. **Content filtering and network security policies** (Jamf Protect's half of the portal) have no constructs yet. And **devices** arrive by enrolling with Jamf Trust or by syncing from a UEM; nothing here enrols one.
+Three neighbouring things are **not** managed here:
+
+- **Activation profiles** are created in the portal. Most of their settings cannot be edited after
+  creation, so the provider offers only the action that deploys one to Jamf Pro.
+- **Content filtering and network security policies** — Jamf Protect's half of the portal — have no
+  constructs yet.
+- **Devices** arrive by enrolling with Jamf Trust or syncing from a UEM.
 
 ## Build it in this order
 
-The sections below are ordered for reading. A rollout goes in a different order, because each step depends on the one above it:
+The sections below are ordered for reading. A rollout goes in this order instead:
 
-1. **UEM Connect** — device inventory and group membership have to be syncing before anything downstream is accurate.
+1. **UEM Connect** — inventory and group membership have to be syncing before anything downstream
+   is accurate.
 2. **Device groups** — or map them from Jamf Pro groups in step 1.
-3. **Gateways, then custom DNS** — a zone cannot be written before the gateway its name servers name. Written the other way round, Jamf Security Cloud refuses it with `422 GATEWAY_NOT_FOUND`, and the provider reports that against `authoritative_name_servers` rather than against the zone as a whole.
-4. **Access policy** — applications reference the groups, categories and gateways above.
+3. **Gateways, then custom DNS** — a zone cannot be written before the gateway its name servers
+   name. The other way round is refused with `422 GATEWAY_NOT_FOUND`, reported against
+   `authoritative_name_servers`.
+4. **Access policy** — apps reference the groups, categories and gateways above.
 5. **Activation profile deploy** — nothing above reaches a device until this runs.
 
-Terraform derives most of that from the references between resources, so the order is yours to get right only where there is no reference to derive it from — a zone naming a gateway ID that arrived as a variable, say.
+Terraform derives most of that from the references between resources. The order is yours to get
+right only where there is no reference — a zone naming a gateway ID that arrived as a variable, say.
 
 ## End to end: publishing one enterprise app over ZTNA
 
-An entry on the **Access policy** page is what makes Jamf Security Cloud recognise traffic as belonging to an application, decide who may reach it, and route it. Two resources are enough for a public-facing app:
+An **Access policy** entry tells Jamf Security Cloud which traffic belongs to an application, who
+may reach it, and how to route it. Two resources cover a public-facing app:
 
 ```hcl
-# Who may reach it. A device group holds nothing but a name — membership is decided
-# by whatever references the group, never on the group itself.
+# A device group holds nothing but a name. Membership is decided by whatever
+# references the group, never on the group itself.
 resource "jamfplatform_security_cloud_device_group" "engineering" {
   name = "Engineering"
 }
 
-# A gateway is named by an opaque ID, so resolve it from the catalogue rather than
-# hard-coding one. A category is named by its display name, so there is nothing to
-# resolve — the content_categories data source is how you confirm a spelling.
+# A gateway is named by an opaque ID, so resolve it from the catalogue. A category
+# is named by its display name, so there is nothing to resolve — content_categories
+# is how you confirm a spelling.
 data "jamfplatform_security_cloud_content_categories" "all" {}
 data "jamfplatform_security_cloud_ztna_shared_gateways" "all" {}
 
@@ -64,29 +83,26 @@ locals {
 resource "jamfplatform_security_cloud_ztna_app" "wiki" {
   name = "Engineering Wiki"
 
-  # Matched on the category's display name, so the spelling has to be exact —
-  # check it against the content_categories data source above.
+  # Matched on display name, so the spelling has to be exact.
   category = "Business & Industry"
 
-  # Traffic matching. A wildcard may replace the whole leading label, and entries
-  # must be mutually exclusive — "*.wiki.example.com" already covers a subdomain
-  # under it, so the parent domain is listed separately.
+  # A wildcard may replace the whole leading label, and entries must be mutually
+  # exclusive — "*.wiki.example.com" does not cover "wiki.example.com", so the
+  # parent is listed separately.
   hostnames = ["wiki.example.com", "*.wiki.example.com"]
 
-  # Device group permissions.
   all_device_groups = false
   device_group_ids  = [jamfplatform_security_cloud_device_group.engineering.id]
 
-  # Application traffic routing.
   routing = {
     traffic_routing = "Encrypt and route via ZTNA"
     routing_mode    = "Standard"
     gateway_id      = local.nearest_data_center
   }
 
-  # The Security tab. A block left out is one Jamf Security Cloud keeps its own
-  # setting for; set enabled = false to lift a requirement rather than removing
-  # the block, which only stops Terraform managing it.
+  # A Security card left out is one Jamf keeps its own setting for. Set
+  # enabled = false to lift a requirement; removing the block only stops
+  # Terraform managing it.
   security = {
     managed_device = {
       enabled                   = true
@@ -103,11 +119,15 @@ resource "jamfplatform_security_cloud_ztna_app" "wiki" {
 }
 ```
 
-Two notes on that configuration that come from Jamf's own documentation rather than from Terraform. The **security requirements need a Jamf Protect licence** — they are the portal's "Access requires device to be managed / device risk validation / Jamf Trust to be enabled" cards. And the managed-device requirement is only as accurate as UEM Connect: a device counts as managed because the sync says so, which is one reason [UEM Connect](#uem-connect) comes before access policy in a real rollout.
+Two of Jamf's rules govern that `security` block. It **needs a Jamf Protect licence** — these are
+the portal's "Access requires device to be managed / device risk validation / Jamf Trust to be
+enabled" cards. And the managed-device requirement is only as accurate as UEM Connect: a device
+counts as managed because [the sync](#uem-connect) says so.
 
 ### Predefined applications
 
-An application is either **custom**, as above, or **predefined** — based on one of Jamf's own definitions, which brings its own host names with it:
+An application is either **custom**, as above, or **predefined** — built from one of Jamf's
+definitions, which brings its own host names:
 
 ```hcl
 data "jamfplatform_security_cloud_ztna_predefined_apps" "all" {}
@@ -125,19 +145,26 @@ resource "jamfplatform_security_cloud_ztna_app" "github" {
     traffic_routing = "Encrypt and route via ZTNA"
     routing_mode    = "Standard"
 
-    # Declared in the end-to-end example above.
+    # Declared in the example above.
     gateway_id = local.nearest_data_center
   }
 }
 ```
 
-A predefined application takes its name from the definition, so `name` is not accepted; `hostnames` become *additions* to the definition's own rather than a replacement for them; and only one application per definition is allowed on a tenant. The choice between the two forms is fixed — changing `predefined_app_id` in either direction replaces the application.
+A predefined application takes its name from the definition, so `name` is not accepted; `hostnames`
+are *added to* the definition's rather than replacing them; and only one application per definition
+is allowed on a tenant.
 
-Jamf draws one further line here that decides which form you need: **a predefined application requires every host name to be publicly resolvable**. An application whose names resolve only on your own network — split-brain DNS — has to be a custom application, paired with a custom DNS zone below. See [Adding a New Predefined Application](https://learn.jamf.com/r/en-US/jamf-connect-documentation-current/Adding_a_New_SaaS_Application).
+**One line decides which form you need: a predefined application requires every host name to be
+publicly resolvable.** Names that resolve only on your own network — split-brain DNS — have to be a
+custom application paired with a custom DNS zone. See [Adding a New Predefined
+Application](https://learn.jamf.com/r/en-US/jamf-connect-documentation-current/Adding_a_New_SaaS_Application).
 
 ## Reaching private applications: custom DNS
 
-An app on an internal network is not reachable just because an access policy names it. Its host names have to resolve, and public DNS will not resolve them — so Jamf Security Cloud needs a **custom DNS zone** naming your own authoritative name servers, and a gateway through which those name servers can be reached.
+An app on an internal network is not reachable just because an access policy names it — its host
+names have to resolve, and public DNS will not resolve them. That needs a **custom DNS zone**
+naming your own authoritative name servers, and a gateway those name servers are reachable through.
 
 ```hcl
 resource "jamfplatform_security_cloud_dns_zone" "internal" {
@@ -147,10 +174,9 @@ resource "jamfplatform_security_cloud_dns_zone" "internal" {
   # covers only the parent, "*.example.corp" only the subdomains.
   domains = ["example.corp", "*.example.corp"]
 
-  # Each name server is paired with the gateway it is reachable through.
-  # local.nearest_data_center comes from the locals block in the end-to-end
-  # example above, and is the shared egress — a name server on your own network
-  # is not reachable through it and needs a dedicated gateway instead.
+  # local.nearest_data_center comes from the example above and is the shared
+  # egress. A name server on your own network is not reachable through it and
+  # needs a dedicated gateway.
   authoritative_name_servers = [
     { ip_address = "203.0.113.53", gateway_id = local.nearest_data_center },
     { ip_address = "203.0.113.54", gateway_id = local.nearest_data_center },
@@ -158,22 +184,41 @@ resource "jamfplatform_security_cloud_dns_zone" "internal" {
 }
 ```
 
-Queries matching the zone's domains go to one of its name servers by pseudo-random load balancing. Four rules here are Jamf's, not the provider's, and each one is a plan that applies and then fails to work:
+Queries matching the zone's domains go to one of its name servers by pseudo-random load balancing.
+Four of Jamf's rules each produce a plan that applies and then fails to work:
 
-- A **domain belongs to exactly one zone**, tenant-wide, and a name server IP address may appear only once per zone.
-- The name server has to be reachable **through the gateway you name**, and **its address must not be in a reserved range** — Jamf Security Cloud refuses a private or loopback address with `Name server IP address not allowed`. Not every unrouted address is refused: a documentation range such as `203.0.113.0/24` is accepted, which is why the example above uses one. Jamf's own documentation attaches the restriction to the shared "Nearest Data Center" egress, but a dedicated *internet* gateway refuses a private address just the same, so do not plan on one lifting the rule. A name server on an internal address needs a gateway that actually reaches your network, which means the IPsec form below.
-- Reverse lookups work by adding the `.in-addr.arpa` and `.ipv6.arpa` domains to the zone.
-- **Changes to your own infrastructure need the zone changed too** — a new or renumbered name server, or an application on a domain the zone does not match.
+- **A domain belongs to exactly one zone**, tenant-wide, and an IP address may appear only once per
+  zone.
+- **Reserved addresses are refused** — a private or loopback name server fails with
+  `Name server IP address not allowed`. Unrouted is not the same as reserved: a documentation range
+  such as `203.0.113.0/24` is accepted, which is why the example uses one.
+- **A dedicated *internet* gateway refuses a private address too**, though Jamf's documentation
+  attaches the restriction only to the shared egress. Reaching a name server on an internal address
+  means the IPsec form below.
+- **Reverse lookups** work by adding the `.in-addr.arpa` and `.ipv6.arpa` domains, and **changes to
+  your own infrastructure need the zone changed too** — a renumbered name server, or an app on a
+  domain the zone does not match.
 
-Misconfiguring a zone cuts users off from the applications behind it, so the resource page says the same thing in stronger words. Jamf's [Configuring Custom DNS Zones](https://learn.jamf.com/r/en-US/jamf-security-cloud-setup-guide/Configuring_Custom_DNS_Zones) and [Troubleshooting Custom DNS Zones](https://learn.jamf.com/r/en-US/jamf-security-cloud-setup-guide/Troubleshooting_Custom_DNS_Zones) are the pages to read before and after.
+Misconfiguring a zone cuts users off from everything behind it. Jamf's [Configuring Custom DNS
+Zones](https://learn.jamf.com/r/en-US/jamf-security-cloud-setup-guide/Configuring_Custom_DNS_Zones)
+and [Troubleshooting Custom DNS
+Zones](https://learn.jamf.com/r/en-US/jamf-security-cloud-setup-guide/Troubleshooting_Custom_DNS_Zones)
+are the pages to read before and after.
 
 ### Gateways
 
-Three kinds of gateway can be named as a zone's `gateway_id` or an app's routing target, and only two of them are yours to create:
+Three kinds can be named as a zone's `gateway_id` or an app's routing target, and only two are
+yours to create:
 
-- **Shared gateways** are Jamf-operated and available to every entitled tenant — "Nearest Data Center", which routes through whichever data centre is closest to the device, and a set of regional shared IP pools. Read them with the `..._ztna_shared_gateways` data source; they cannot be modified, deleted, or made a member of a group.
-- A **dedicated gateway** is your own egress point, and a paid add-on. Setting the `ipsec` block builds a tunnel to your own VPN concentrator; omitting it provisions a pair of private egress IP addresses, reported back in `dedicated_egress_ip_addresses`.
-- A **grouped gateway** is a failover and routing group over two or more dedicated gateways of the *same* form — all IPsec or all internet. Shared gateways are refused as members.
+- **Shared** — Jamf-operated, available to every entitled tenant: "Nearest Data Center", which
+  routes through whichever data centre is closest to the device, plus a set of regional shared IP
+  pools. Read them with `..._ztna_shared_gateways`; they cannot be modified, deleted, or made a
+  member of a group.
+- **Dedicated** — your own egress point, and a paid add-on. An `ipsec` block builds a tunnel to your
+  VPN concentrator; omitting it provisions a pair of private egress IPs, reported in
+  `dedicated_egress_ip_addresses`.
+- **Grouped** — a failover and routing group over two or more dedicated gateways of the *same* form,
+  all IPsec or all internet. Shared gateways are refused as members.
 
 ```hcl
 resource "jamfplatform_security_cloud_ztna_gateway" "frankfurt" {
@@ -186,26 +231,30 @@ resource "jamfplatform_security_cloud_ztna_gateway" "frankfurt" {
     email = "netops@example.com"
   }
 
-  # Omitted here, so this is a dedicated internet gateway. Adding or removing the
-  # block replaces the gateway — see "Immutable forms" below. The full IPsec form,
-  # with its jamf_side and customer_side blocks, is on the
-  # jamfplatform_security_cloud_ztna_gateway resource page.
+  # Omitted, so this is a dedicated internet gateway. The full IPsec form, with
+  # its jamf_side and customer_side blocks, is on this resource's own page.
   # ipsec = { ... }
 }
 ```
 
-`tenant_ids` is mandatory and every tenant named in it must belong to the same organization as the provider's credentials. Because no API lists an environment's tenants, an environment-scoped configuration has no way to fill it in from data — supply the tenant ID as an input, or configure the provider with `tenant_id`.
+`tenant_ids` is mandatory, and every tenant in it must belong to the same organization as the
+provider's credentials. No API lists an environment's tenants, so an environment-scoped
+configuration cannot fill it in from data — supply it as an input, or configure the provider with
+`tenant_id`.
 
-A gateway reports `PENDING` the moment it is created and carries no `dedicated_egress_ip_addresses` until Jamf has finished provisioning it, so an apply completing is not the same as a gateway being usable. Changing `egress_region` later re-provisions it: connectivity drops, the status returns to `PENDING`, and the egress addresses stay stale until it settles.
+**A completed apply is not a usable gateway.** A new one reports `PENDING` and carries no
+`dedicated_egress_ip_addresses` until Jamf finishes provisioning. Changing `egress_region`
+re-provisions it: connectivity drops, status returns to `PENDING`, and the egress addresses stay
+stale until it settles.
 
 ### Short names and fixed addresses
 
-Two tenant-wide settings sit alongside the zones, both under **Custom DNS** in the portal, and both are single-instance resources:
+Two more **Custom DNS** settings, both one-per-tenant:
 
 ```hcl
-# Completes an incomplete host name for apps that only accept short names: a user
-# asking for "wiki" is directed to "wiki.example.corp". Setting this is also what
-# lets an access policy's hostnames be written as short names.
+# Completes a short host name: a user asking for "wiki" is directed to
+# "wiki.example.corp". Setting this is also what lets an access policy's
+# hostnames be written as short names.
 resource "jamfplatform_security_cloud_dns_search_domain" "corp" {
   domain_name = "example.corp"
 }
@@ -218,9 +267,9 @@ resource "jamfplatform_security_cloud_dns_hostname_mappings" "internal" {
       hostname       = "build.example.corp"
       ipv4_addresses = ["10.10.5.20"]
 
-      # Traffic vectoring. Both are required on every mapping — note that the
-      # admin UI's add dialog pre-selects Connect to ZTNA, so a mapping added
-      # there and one written here do not start from the same value.
+      # Both are required on every mapping. The admin UI's add dialog
+      # pre-selects Connect to ZTNA, so a mapping added there and one written
+      # here do not start from the same value.
       connect_to_ztna       = true
       connect_to_secure_dns = false
     },
@@ -234,57 +283,64 @@ resource "jamfplatform_security_cloud_dns_hostname_mappings" "internal" {
 }
 ```
 
-Between 1 and 500 mappings, each host name once, and at least one of `ipv4_addresses` or `ipv6_addresses` per entry. An empty `mappings` collection is not accepted: to remove them all, destroy the resource.
+Between 1 and 500 mappings, each host name once, and at least one of `ipv4_addresses` or
+`ipv6_addresses` per entry. `mappings = []` is not accepted — destroy the resource to remove them
+all. Destroying the search domain clears it for the tenant. Declare each of these once: a second
+instance of either will fight itself on every apply.
 
 ## Traffic matching is tenant-unique
 
-A host name or address range belongs to **one** application across the whole tenant. Declaring one that another application already claims is rejected at apply, which makes a rename-by-replacement land badly: Terraform creates the new application before destroying the old one, and the create is refused because the old one still holds the names. Split such a change into two applies, or use `terraform state` to move the resource rather than replacing it.
+A host name or address range belongs to **one** application across the whole tenant, and claiming
+one another application holds is rejected at apply. **That makes rename-by-replacement fail:**
+Terraform creates the new application before destroying the old one, so the create hits the old
+one's names. Split it across two applies, or move the resource with `terraform state` instead of
+replacing it.
 
-Within one tenant Jamf resolves overlaps by specificity — the most granularly defined host name wins, so `images.app.example.com` matches an application declaring it ahead of one declaring `*.example.com`, and a custom application's host name takes precedence over the same name inside a predefined definition. That is what makes the pattern Jamf recommends work: start with one wildcard application to get traffic flowing, then carve specific applications out of it without touching the wildcard. See the [Network Engineer's Guide to Jamf Connect ZTNA](https://trusted.jamf.com/docs/network-engineers-guide-to-private-access).
+Within a tenant Jamf resolves overlaps by specificity — the most granular host name wins, so
+`images.app.example.com` beats `*.example.com`, and a custom application's host name beats the same
+name inside a predefined definition. That is what makes Jamf's recommended pattern work: start with
+one wildcard application to get traffic flowing, then carve specific applications out of it without
+touching the wildcard. See the [Network Engineer's Guide to Jamf Connect
+ZTNA](https://trusted.jamf.com/docs/network-engineers-guide-to-private-access).
 
-Two further limits on `direct_ips_and_subnets`, both Jamf's: it needs the Jamf Trust app on the device, and direct-IP traffic does not appear in the access reports. Prefer host names where the application supports them.
+`direct_ips_and_subnets` carries two further limits, both Jamf's: it needs the Jamf Trust app on the
+device, and direct-IP traffic does not appear in the access reports. Prefer host names where the
+application supports them.
 
 ## Delete ordering
 
-Jamf Security Cloud enforces references on delete in three different ways, and knowing which is which saves a confusing destroy:
+Jamf enforces references on delete three different ways:
 
 | Destroying | What happens |
 |---|---|
 | A **gateway** a DNS zone, grouped gateway or app still references | Refused, naming what holds it. |
 | A **grouped gateway's member** while it is still in the group | Refused. |
-| A **device group** an app assignment or UEM mapping still names | **Succeeds silently**, and quietly drops the group from every assignment that named it — which can leave an application assigned to nobody. |
+| A **device group** an app assignment or UEM mapping still names | **Succeeds silently**, dropping the group from every assignment that named it — which can leave an application assigned to nobody. |
 
-The first has a Terraform-specific trap on top of the API's refusal. Dropping the reference *and* the gateway in a single apply does not work either, because Terraform sequences the destroy before the update that would have released the gateway — so the destroy still hits a live reference. Release it in one apply, destroy the gateway in the next.
+**The first carries a Terraform trap on top of the refusal.** Dropping the reference *and* the
+gateway in one apply does not work either, because Terraform sequences the destroy before the
+update that would have released it. Release in one apply, destroy in the next.
 
-The third is the dangerous one, because nothing fails. Check what references a device group before removing it. Note also that the built-in **Default Group** cannot be managed here at all: Jamf gives it no identifier and reserves the name. It shows up in the `..._device_groups` data source with `built_in = true` and a null `id`.
-
-## Tenant-wide singletons
-
-Three resources are one-per-tenant, and each behaves slightly differently when you destroy it:
-
-- `dns_search_domain` — destroying it clears the search domain for the tenant.
-- `dns_hostname_mappings` — owns the **whole set**; destroying it removes every mapping, and any mapping added outside Terraform is removed on the next apply.
-- `uem_connect` — creating a second is refused, so **import** where one already exists rather than declaring a new one.
-
-The integration's ID is not a value anyone would have written down, so read it off the data source — `data "jamfplatform_security_cloud_uem_connect" "existing" {}` reports it as `id` — or let `terraform query -generate-config-out=uem_connect.tf` write the import block for you from the list resource:
-
-```shell
-terraform import jamfplatform_security_cloud_uem_connect.jamf_pro 6a91b958619ef153a5a63d72
-```
-
-Declare each of them once. A second instance of any of them in one configuration will fight itself on every apply.
+**The third is the dangerous one, because nothing fails** — check what references a device group
+before removing it. The built-in **Default Group** cannot be managed here at all: Jamf gives it no
+identifier and reserves the name. It appears in `..._device_groups` with `built_in = true` and a
+null `id`.
 
 ## Immutable forms
 
-Three constructs pick a shape at create time that Jamf will not convert afterwards, so Terraform replaces the object instead:
+Three constructs pick a shape at create time that Jamf will not convert, so Terraform replaces the
+object:
 
-- A **gateway** is IPsec or internet, decided by whether the `ipsec` block is present.
+- A **gateway** is IPsec or internet, decided by whether `ipsec` is present.
 - A **ZTNA app** is predefined or custom, decided by whether `predefined_app_id` is set.
-- A **UEM Connect** integration's vendor, address and authentication method are fixed; changing any of them replaces the integration, which briefly interrupts syncing.
+- A **UEM Connect** integration's vendor, address and authentication method are fixed. Changing any
+  of them replaces the integration, briefly interrupting syncing.
 
 ## UEM Connect
 
-UEM Connect syncs device inventory and group membership from Jamf Pro into Jamf Security Cloud, and signals device risk back. It is what makes the managed-device security requirement above mean anything, and what lets you keep deciding group membership in Jamf Pro.
+UEM Connect syncs device inventory and group membership from Jamf Pro into Jamf Security Cloud and
+signals device risk back. It is what makes the managed-device requirement mean anything, and what
+lets you keep deciding group membership in Jamf Pro.
 
 ```hcl
 # The Jamf Pro tenant identifier is the one value here you cannot read off the
@@ -296,9 +352,9 @@ resource "jamfplatform_security_cloud_uem_connect" "jamf_pro" {
   enabled    = true
 
   # Prefer platform_tenant: Jamf Security Cloud creates and manages its own
-  # credentials on the named Jamf Pro tenant, so no secret is configured here.
-  # The alternative, oauth, takes the client ID and secret of an API integration
-  # you created on the Jamf Pro instance yourself, plus uem_server_url.
+  # credentials on the named tenant, so no secret is configured here. The
+  # alternative, oauth, takes the client ID and secret of an API integration you
+  # created on the Jamf Pro instance yourself, plus uem_server_url.
   platform_tenant = {
     tenant_id = data.jamfplatform_pro_tenant_id.jamf_pro.tenant_id
   }
@@ -306,13 +362,13 @@ resource "jamfplatform_security_cloud_uem_connect" "jamf_pro" {
   group_membership_mapping = {
     enabled = true
 
-    # Order matters. Jamf evaluates the list in order and a device joins the
-    # group of the first entry it matches, so put the most specific first. A
-    # device matching nothing joins the default group.
+    # Evaluated in order: a device joins the group of the first entry it
+    # matches, so put the most specific first. A device matching nothing joins
+    # the default group.
     mappings = [
       {
-        # A Jamf Pro group is written as computer_ or mobile_ followed by the
-        # group's number. This composes out of a jamfplatform_device_group:
+        # A Jamf Pro group is computer_ or mobile_ followed by its number, which
+        # composes out of a jamfplatform_device_group:
         #   "${jamfplatform_device_group.x.device_type}_${jamfplatform_device_group.x.jamf_pro_id}"
         uem_group_id            = "computer_12"
         security_cloud_group_id = jamfplatform_security_cloud_device_group.engineering.id
@@ -321,8 +377,8 @@ resource "jamfplatform_security_cloud_uem_connect" "jamf_pro" {
   }
 }
 
-# Starts a sync immediately instead of waiting for the scheduled one. Jamf runs it
-# in the background, so this returns as soon as the run has started and reports
+# Starts a sync immediately rather than waiting for the scheduled one. Jamf runs
+# it in the background, so this returns once the run has started and reports
 # nothing about what it did — read latest_sync from the data source afterwards.
 action "jamfplatform_security_cloud_uem_connect_synchronize" "now" {
   config {
@@ -331,15 +387,39 @@ action "jamfplatform_security_cloud_uem_connect_synchronize" "now" {
 }
 ```
 
-`jamfplatform_pro_tenant_id` reaches the Jamf Pro namespace, so it works under a platform environment — where it resolves the Jamf Pro tenant in that environment — and under tenant scope pointed at the Jamf Pro tenant. It does **not** work under tenant scope pointed at the Security Cloud tenant, because Jamf Pro does not answer under that scope; supply the identifier as an input there. Note this is a different identifier from a gateway's `tenant_ids` above, which names Security Cloud tenants and has no data source to read it from.
+`jamfplatform_pro_tenant_id` reaches the Jamf Pro namespace, so it works under a platform
+environment — resolving the Jamf Pro tenant in that environment — and under tenant scope pointed at
+the Jamf Pro tenant. It does **not** work under tenant scope pointed at the Security Cloud tenant,
+where Jamf Pro does not answer; supply the identifier as an input there. This is not the same
+identifier as a gateway's `tenant_ids`, which names Security Cloud tenants and has no data source
+to read.
 
-Jamf Security Cloud does not check that either side of a mapping exists, so a wrong group number is accepted and simply never matches. The group configuration is replaced wholesale on every apply, so there is no way to leave it unmanaged: declaring `group_membership_mapping` replaces what it does not mention — an omitted or empty `mappings` clears every mapping — and **omitting the block entirely resets the whole group configuration to its defaults**. Manage it, or expect it cleared.
+Jamf checks neither side of a mapping, so a wrong group number is accepted and simply never
+matches. **The group configuration is replaced wholesale on every apply, so there is no way to leave
+it unmanaged.** Declaring `group_membership_mapping` replaces what it does not mention — an omitted
+or empty `mappings` clears every mapping — and omitting the block entirely resets the whole group
+configuration to its defaults. Manage it, or expect it cleared.
 
-Importing an existing integration has one wrinkle worth knowing in advance: `user_data_field_mapping` and `group_membership_mapping` are captured from the tenant even though your configuration may not declare them, so run `terraform plan` straight after the import and write in what the plan shows you rather than letting the next apply clear them.
+A tenant holds one integration and a second create is refused, so **import** where one already
+exists. The ID is not a value anyone would have written down: read it off the data source
+(`data "jamfplatform_security_cloud_uem_connect" "existing" {}` reports it as `id`), or let
+`terraform query -generate-config-out=uem_connect.tf` write the import block from the list resource.
+
+```shell
+terraform import jamfplatform_security_cloud_uem_connect.jamf_pro 6a91b958619ef153a5a63d72
+```
+
+**Import has one wrinkle worth knowing in advance.** `user_data_field_mapping` and
+`group_membership_mapping` are captured from the tenant even though your configuration may not
+declare them. Run `terraform plan` straight afterwards and write in what it shows, rather than
+letting the next apply clear them.
 
 ## Getting the configuration onto devices
 
-Nothing above reaches a device on its own. Devices enrol with Jamf Security Cloud through an **activation profile** distributed alongside the Jamf Trust app, and the provider covers exactly one step of that: the portal's **Deploy to Jamf Pro** button, which creates the activation profile's configuration profile in Jamf Pro and scopes it.
+Nothing above reaches a device on its own. Devices enrol through an **activation profile**
+distributed alongside the Jamf Trust app, and the provider covers one step of that: the portal's
+**Deploy to Jamf Pro** button, which creates the activation profile's configuration profile in Jamf
+Pro and scopes it.
 
 ```hcl
 action "jamfplatform_security_cloud_activation_profile_deploy" "macos" {
@@ -351,28 +431,44 @@ action "jamfplatform_security_cloud_activation_profile_deploy" "macos" {
 }
 ```
 
-Three things about it. The **activation profile code** is issued by Jamf Security Cloud during activation profile setup and cannot be created or looked up from Terraform — it is the last path segment of the activation profile's deployment page — so it is an input. There is **one deployment per operating system** (`macos`, `ios_byod`, `ios_supervised`, `ios_unsupervised`), so cover more than one by invoking the action once for each, and name computer groups for `macos` and mobile device groups otherwise. And **scope only ever accumulates** — `jamf_pro_group_ids` adds groups and never removes one, and omitting it on a *first* deployment scopes the configuration profile to nothing while still reporting success. Narrow or clear a scope in Jamf Pro.
+- The **activation profile code** is issued during activation profile setup and cannot be created or
+  looked up from Terraform. It is the last path segment of the profile's deployment page, so it is
+  an input.
+- There is **one deployment per operating system** (`macos`, `ios_byod`, `ios_supervised`,
+  `ios_unsupervised`). Cover more than one by invoking the action once each, naming computer groups
+  for `macos` and mobile device groups otherwise.
+- **Scope only accumulates.** `jamf_pro_group_ids` adds groups and never removes one, and omitting
+  it on a *first* deployment scopes the profile to nothing while still reporting success. Narrow or
+  clear a scope in Jamf Pro.
 
 ## Requirements
 
-Jamf Security Cloud is reached under **either** scope: set `environment_id` (preferred) or `tenant_id` on the provider. Unlike the Platform Services constructs there is no version gate — Jamf Security Cloud is continuously deployed and a tenant can hold it without holding Jamf Pro.
+Jamf Security Cloud is reached under **either** scope: set `environment_id` (preferred) or
+`tenant_id` on the provider. There is no version gate — it is continuously deployed, and a tenant
+can hold it without holding Jamf Pro.
 
 Two things about authorisation are specific to this namespace:
 
-- **Entitlement is not authentication.** A valid API integration can still be refused with `403 NOT_ENTITLED` when the tenant does not hold the product behind the construct — dedicated gateways, for instance, are a paid add-on. Every resource and action translates that into a named diagnostic; the three read-only catalogues — `..._content_categories`, `..._ztna_predefined_apps` and `..._ztna_shared_gateways` — surface the raw error instead.
-- **Permissions are per construct**, granted in Jamf Account's permission picker. Each resource, data source and action page carries its own table naming the category, the row and the boxes to tick; the capabilities across this namespace are `ztna`, `device-groups`, `content-categories`, `custom-hostname-mappings`, `search-domains` and `uem-connect`.
+- **Entitlement is not authentication.** A valid API integration can still be refused with
+  `403 NOT_ENTITLED` when the tenant does not hold the product behind the construct — dedicated
+  gateways, for instance, are a paid add-on. Every resource and action translates that into a named
+  diagnostic; the three read-only catalogues (`..._content_categories`, `..._ztna_predefined_apps`,
+  `..._ztna_shared_gateways`) surface the raw error instead.
+- **Permissions are per construct**, granted in Jamf Account's permission picker. Every resource,
+  data source and action page carries its own table naming the category, row and boxes to tick. The
+  capabilities across this namespace are `ztna`, `device-groups`, `content-categories`,
+  `custom-hostname-mappings`, `search-domains` and `uem-connect`.
 
 ## Further reading
 
 | Topic | Page |
 |---|---|
-| The portal, end to end, in Jamf's words | [Jamf Security Cloud Portal Setup Guide](https://learn.jamf.com/r/en-US/jamf-security-cloud-setup-guide/RADAR_Portal) |
+| The portal, end to end, in Jamf's words | [Portal Setup Guide](https://learn.jamf.com/r/en-US/jamf-security-cloud-setup-guide/RADAR_Portal) |
 | What an access policy is made of | [Access Policy](https://learn.jamf.com/r/en-US/jamf-connect-documentation-current/Access_Policies) |
-| Predefined and custom applications | [Adding a New Predefined Application](https://learn.jamf.com/r/en-US/jamf-connect-documentation-current/Adding_a_New_SaaS_Application), [Adding a New Custom Application](https://learn.jamf.com/r/en-US/jamf-connect-documentation-current/Adding_a_New_Enterprise_Application) |
-| Gateway types, and what a shared gateway is | [Shared Internet Gateways](https://learn.jamf.com/r/en-US/jamf-connect-documentation-current/Internet_Cloud_Gateways), [Grouped Gateways](https://learn.jamf.com/r/en-US/jamf-connect-documentation-current/Grouped_Gateways) |
-| Grouping gateways, and the routing strategies | [Creating a Group of Gateways](https://learn.jamf.com/r/en-US/jamf-connect-documentation-current/Creating_a_Grouped_Gateway) |
-| Custom DNS zones | [DNS Zones](https://learn.jamf.com/r/en-US/jamf-security-cloud-setup-guide/Custom_DNS_Zones), [Configuring Custom DNS Zones](https://learn.jamf.com/r/en-US/jamf-security-cloud-setup-guide/Configuring_Custom_DNS_Zones), [Troubleshooting Custom DNS Zones](https://learn.jamf.com/r/en-US/jamf-security-cloud-setup-guide/Troubleshooting_Custom_DNS_Zones) |
-| UEM Connect, and its settings | [UEM Connect](https://learn.jamf.com/r/en-US/jamf-security-cloud-setup-guide/UEM_Connect_Overview), [UEM Connect Settings Reference](https://learn.jamf.com/r/en-US/jamf-security-cloud-setup-guide/UEM_Connect_Settings), [UEM Connect Integration by Vendor](https://learn.jamf.com/r/en-US/jamf-security-cloud-setup-guide/UEM_Vendor_Integration) |
-| Activation profiles | [Activation Profiles](https://learn.jamf.com/r/en-US/jamf-security-cloud-setup-guide/Activation_Profiles), [Creating an Activation Profile](https://learn.jamf.com/r/en-US/jamf-security-cloud-setup-guide/Creating_Activation_Profiles) |
+| Predefined and custom applications | [Predefined](https://learn.jamf.com/r/en-US/jamf-connect-documentation-current/Adding_a_New_SaaS_Application), [Custom](https://learn.jamf.com/r/en-US/jamf-connect-documentation-current/Adding_a_New_Enterprise_Application) |
+| Gateway types, grouping and routing strategies | [Shared Internet Gateways](https://learn.jamf.com/r/en-US/jamf-connect-documentation-current/Internet_Cloud_Gateways), [Grouped Gateways](https://learn.jamf.com/r/en-US/jamf-connect-documentation-current/Grouped_Gateways), [Creating a Group of Gateways](https://learn.jamf.com/r/en-US/jamf-connect-documentation-current/Creating_a_Grouped_Gateway) |
+| Custom DNS zones | [DNS Zones](https://learn.jamf.com/r/en-US/jamf-security-cloud-setup-guide/Custom_DNS_Zones), [Configuring](https://learn.jamf.com/r/en-US/jamf-security-cloud-setup-guide/Configuring_Custom_DNS_Zones), [Troubleshooting](https://learn.jamf.com/r/en-US/jamf-security-cloud-setup-guide/Troubleshooting_Custom_DNS_Zones) |
+| UEM Connect, and its settings | [Overview](https://learn.jamf.com/r/en-US/jamf-security-cloud-setup-guide/UEM_Connect_Overview), [Settings Reference](https://learn.jamf.com/r/en-US/jamf-security-cloud-setup-guide/UEM_Connect_Settings), [Integration by Vendor](https://learn.jamf.com/r/en-US/jamf-security-cloud-setup-guide/UEM_Vendor_Integration) |
+| Activation profiles | [Activation Profiles](https://learn.jamf.com/r/en-US/jamf-security-cloud-setup-guide/Activation_Profiles), [Creating one](https://learn.jamf.com/r/en-US/jamf-security-cloud-setup-guide/Creating_Activation_Profiles) |
 | The policies this provider does not manage yet | [Policies](https://learn.jamf.com/r/en-US/jamf-security-cloud-setup-guide/Policies) |
 | How the routing fabric actually works | [Network Engineer's Guide to Jamf Connect ZTNA](https://trusted.jamf.com/docs/network-engineers-guide-to-private-access) |

--- a/docs/guides/security-cloud.md
+++ b/docs/guides/security-cloud.md
@@ -216,7 +216,9 @@ yours to create:
   member of a group.
 - **Dedicated** — your own egress point, and a paid add-on. An `ipsec` block builds a tunnel to your
   VPN concentrator; omitting it provisions a pair of private egress IPs, reported in
-  `dedicated_egress_ip_addresses`.
+  `dedicated_egress_ip_addresses`. The IPsec form here is Jamf's **Custom IPSec** gateway; its
+  **Quick Connect** kind, a Linux VM Jamf walks you through building, cannot be expressed in
+  Terraform.
 - **Grouped** — a failover and routing group over two or more dedicated gateways of the *same* form,
   all IPsec or all internet. Shared gateways are refused as members.
 
@@ -242,14 +244,16 @@ provider's credentials. No API lists an environment's tenants, so an environment
 configuration cannot fill it in from data — supply it as an input, or configure the provider with
 `tenant_id`.
 
-**A completed apply is not a usable gateway.** A new one reports `PENDING` and settles to `UP`
-roughly four and a half minutes later. The egress addresses arrive far sooner — within seconds — so
-`dedicated_egress_ip_addresses` is populated long before the gateway carries any traffic.
+**An apply waits for the gateway to settle**, so the one that returns is a gateway you can act on.
+A dedicated internet gateway takes about five minutes to report `UP` — **Available** in the portal —
+and an `egress_region` change re-provisions it and takes about as long again. Disabling one settles
+in seconds. Without the wait a first apply would hand downstream an empty
+`dedicated_egress_ip_addresses`, and a region change would hand it the *old* region's addresses.
 
-Changing `egress_region` re-provisions it: connectivity drops and the status returns to `PENDING`.
-For about half a minute the attribute still holds the **old** region's addresses, then the new ones
-replace them in place — it never empties, so a value read during that window is plausible and wrong.
-Both timings come from a single EU measurement; treat them as orders of magnitude.
+Creating an **IPsec** gateway is the exception: it settles at `DOWN`, because the tunnel's far end is
+configured from values the create returns, so it cannot be up yet. Build your side and the status
+reaches `UP` on a later refresh. If any wait runs out the apply still succeeds, with a warning naming
+the status reached; raise `create` or `update` in the `timeouts` block to wait longer.
 
 ### Short names and fixed addresses
 

--- a/docs/guides/security-cloud.md
+++ b/docs/guides/security-cloud.md
@@ -242,10 +242,14 @@ provider's credentials. No API lists an environment's tenants, so an environment
 configuration cannot fill it in from data — supply it as an input, or configure the provider with
 `tenant_id`.
 
-**A completed apply is not a usable gateway.** A new one reports `PENDING` and carries no
-`dedicated_egress_ip_addresses` until Jamf finishes provisioning. Changing `egress_region`
-re-provisions it: connectivity drops, status returns to `PENDING`, and the egress addresses stay
-stale until it settles.
+**A completed apply is not a usable gateway.** A new one reports `PENDING` and settles to `UP`
+roughly four and a half minutes later. The egress addresses arrive far sooner — within seconds — so
+`dedicated_egress_ip_addresses` is populated long before the gateway carries any traffic.
+
+Changing `egress_region` re-provisions it: connectivity drops and the status returns to `PENDING`.
+For about half a minute the attribute still holds the **old** region's addresses, then the new ones
+replace them in place — it never empties, so a value read during that window is plausible and wrong.
+Both timings come from a single EU measurement; treat them as orders of magnitude.
 
 ### Short names and fixed addresses
 

--- a/docs/guides/security-cloud.md
+++ b/docs/guides/security-cloud.md
@@ -1,0 +1,344 @@
+---
+page_title: "Jamf Security Cloud"
+description: |-
+  Manage Jamf Security Cloud from Terraform — ZTNA access policy, access gateways, custom DNS, device groups and the UEM Connect integration.
+---
+
+# Jamf Security Cloud
+
+Jamf Security Cloud is the portal at [radar.jamf.com](https://radar.jamf.com) where content controls, network security and Zero Trust Network Access are configured. Jamf's own documentation is split across two guides, and both are worth having open: the [Jamf Security Cloud Portal Setup Guide](https://learn.jamf.com/r/en-US/jamf-security-cloud-setup-guide/RADAR_Portal) covers device groups, activation profiles and the portal's integrations, and the [Zero Trust Network Access](https://learn.jamf.com/r/en-US/jamf-connect-documentation-current/Private_Access) section of the Jamf Connect Documentation covers access policy and gateways. See [Further reading](#further-reading) below.
+
+This guide is the Terraform half: which portal pages the provider reaches, the order things have to be created in, and the handful of behaviours that will surprise you.
+
+## What the provider manages
+
+| In the portal | Constructs |
+|---|---|
+| **Devices > Device groups** | `jamfplatform_security_cloud_device_group` (resource, data source, list resource), `..._device_groups` |
+| **Devices > Activation profiles > Deployment** | `jamfplatform_security_cloud_activation_profile_deploy` (action) |
+| **Policies > Access > Access policy** | `jamfplatform_security_cloud_ztna_app`, `..._ztna_predefined_apps`, `..._content_categories` |
+| **Integrations > Access gateways** | `jamfplatform_security_cloud_ztna_gateway`, `..._ztna_grouped_gateway`, `..._ztna_shared_gateways` |
+| **Integrations > Custom DNS > DNS zones** | `jamfplatform_security_cloud_dns_zone` |
+| **Integrations > Custom DNS > Search domain** | `jamfplatform_security_cloud_dns_search_domain` |
+| **Integrations > Custom DNS > Hostname mapping** | `jamfplatform_security_cloud_dns_hostname_mappings` |
+| **Integrations > UEM Connect** | `jamfplatform_security_cloud_uem_connect`, `..._uem_connect_synchronize` (action) |
+
+Three things next door to this are **not** managed here. **Activation profiles** themselves are created in the portal — most of their settings cannot be edited after creation, so Jamf treats them as immutable and the provider offers only the action that deploys one to Jamf Pro. **Content filtering and network security policies** (Jamf Protect's half of the portal) have no constructs yet. And **devices** arrive by enrolling with Jamf Trust or by syncing from a UEM; nothing here enrols one.
+
+## End to end: publishing one enterprise app over ZTNA
+
+An entry on the **Access policy** page is what makes Jamf Security Cloud recognise traffic as belonging to an application, decide who may reach it, and route it. Two resources are enough for a public-facing app:
+
+```hcl
+# Who may reach it. A device group holds nothing but a name — membership is decided
+# by whatever references the group, never on the group itself.
+resource "jamfplatform_security_cloud_device_group" "engineering" {
+  name = "Engineering"
+}
+
+# Categories and gateways are both Jamf-maintained catalogues, so resolve them
+# rather than hard-coding an ID or guessing a category's spelling.
+data "jamfplatform_security_cloud_content_categories" "all" {}
+data "jamfplatform_security_cloud_ztna_shared_gateways" "all" {}
+
+locals {
+  business_category = one([
+    for category in data.jamfplatform_security_cloud_content_categories.all.content_categories :
+    category.display_name if category.display_name == "Business & Industry"
+  ])
+
+  nearest_data_center = one([
+    for gateway in data.jamfplatform_security_cloud_ztna_shared_gateways.all.shared_gateways :
+    gateway.id if gateway.name == "Nearest Data Center"
+  ])
+}
+
+resource "jamfplatform_security_cloud_ztna_app" "wiki" {
+  name     = "Engineering Wiki"
+  category = local.business_category
+
+  # Traffic matching. A wildcard may replace the whole leading label, and entries
+  # must be mutually exclusive — "*.wiki.example.com" already covers a subdomain
+  # under it, so the parent domain is listed separately.
+  hostnames = ["wiki.example.com", "*.wiki.example.com"]
+
+  # Device group permissions.
+  all_device_groups = false
+  device_group_ids  = [jamfplatform_security_cloud_device_group.engineering.id]
+
+  # Application traffic routing.
+  routing = {
+    traffic_routing = "Encrypt and route via ZTNA"
+    routing_mode    = "Standard"
+    gateway_id      = local.nearest_data_center
+  }
+
+  # The Security tab. A block left out is one Jamf Security Cloud keeps its own
+  # setting for; set enabled = false to lift a requirement rather than removing
+  # the block, which only stops Terraform managing it.
+  security = {
+    managed_device = {
+      enabled                   = true
+      device_push_notifications = true
+    }
+    device_risk = {
+      enabled            = true
+      deny_at_risk_level = "High"
+    }
+    jamf_trust = {
+      enabled = true
+    }
+  }
+}
+```
+
+Two notes on that configuration that come from Jamf's own documentation rather than from Terraform. The **security requirements need a Jamf Protect licence** — they are the portal's "Access requires device to be managed / device risk validation / Jamf Trust to be enabled" cards. And the managed-device requirement is only as accurate as UEM Connect: a device counts as managed because the sync says so, which is one reason [UEM Connect](#uem-connect) comes before access policy in a real rollout.
+
+### Predefined applications
+
+An application is either **custom**, as above, or **predefined** — based on one of Jamf's own definitions, which brings its own host names with it:
+
+```hcl
+data "jamfplatform_security_cloud_ztna_predefined_apps" "all" {}
+
+resource "jamfplatform_security_cloud_ztna_app" "github" {
+  predefined_app_id = one([
+    for app in data.jamfplatform_security_cloud_ztna_predefined_apps.all.predefined_apps :
+    app.id if app.name == "GitHub"
+  ])
+
+  category          = "Communication"
+  all_device_groups = true
+
+  routing = {
+    traffic_routing = "Encrypt and route via ZTNA"
+    routing_mode    = "Standard"
+    gateway_id      = local.nearest_data_center
+  }
+}
+```
+
+A predefined application takes its name from the definition, so `name` is not accepted; `hostnames` become *additions* to the definition's own rather than a replacement for them; and only one application per definition is allowed on a tenant. The choice between the two forms is fixed — changing `predefined_app_id` in either direction replaces the application.
+
+Jamf draws one further line here that decides which form you need: **a predefined application requires every host name to be publicly resolvable**. An application whose names resolve only on your own network — split-brain DNS — has to be a custom application, paired with a custom DNS zone below. See [Adding a New Predefined Application](https://learn.jamf.com/r/en-US/jamf-connect-documentation-current/Adding_a_New_SaaS_Application).
+
+## Reaching private applications: custom DNS
+
+An app on an internal network is not reachable just because an access policy names it. Its host names have to resolve, and public DNS will not resolve them — so Jamf Security Cloud needs a **custom DNS zone** naming your own authoritative name servers, and a gateway through which those name servers can be reached.
+
+```hcl
+resource "jamfplatform_security_cloud_dns_zone" "internal" {
+  name = "Corp internal"
+
+  # A parent domain and its subdomains are separate entries: "example.corp"
+  # covers only the parent, "*.example.corp" only the subdomains.
+  domains = ["example.corp", "*.example.corp"]
+
+  # Each name server is paired with the gateway it is reachable through.
+  authoritative_name_servers = [
+    { ip_address = "203.0.113.53", gateway_id = local.nearest_data_center },
+    { ip_address = "203.0.113.54", gateway_id = local.nearest_data_center },
+  ]
+}
+```
+
+Queries matching the zone's domains go to one of its name servers by pseudo-random load balancing. Four rules here are Jamf's, not the provider's, and each one is a plan that applies and then fails to work:
+
+- A **domain belongs to exactly one zone**, tenant-wide, and a name server IP address may appear only once per zone.
+- The name server has to be reachable **through the gateway you name**, and **its address must be publicly routable when that gateway is shared**. Jamf Security Cloud refuses a reserved address — private, loopback and similar — behind the shared "Nearest Data Center" egress. A name server on an internal address needs a gateway of your own that reaches your network, which is what the dedicated gateways below are for.
+- Reverse lookups work by adding the `.in-addr.arpa` and `.ipv6.arpa` domains to the zone.
+- **Changes to your own infrastructure need the zone changed too** — a new or renumbered name server, or an application on a domain the zone does not match.
+
+Misconfiguring a zone cuts users off from the applications behind it, so the resource page says the same thing in stronger words. Jamf's [Configuring Custom DNS Zones](https://learn.jamf.com/r/en-US/jamf-security-cloud-setup-guide/Configuring_Custom_DNS_Zones) and [Troubleshooting Custom DNS Zones](https://learn.jamf.com/r/en-US/jamf-security-cloud-setup-guide/Troubleshooting_Custom_DNS_Zones) are the pages to read before and after.
+
+### Gateways
+
+Three kinds of gateway can be named as a zone's `gateway_id` or an app's routing target, and only two of them are yours to create:
+
+- **Shared gateways** are Jamf-operated and available to every entitled tenant — "Nearest Data Center", which routes through whichever data centre is closest to the device, and a set of regional shared IP pools. Read them with the `..._ztna_shared_gateways` data source; they cannot be modified, deleted, or made a member of a group.
+- A **dedicated gateway** is your own egress point, and a paid add-on. Setting the `ipsec` block builds a tunnel to your own VPN concentrator; omitting it provisions a pair of private egress IP addresses, reported back in `dedicated_egress_ip_addresses`.
+- A **grouped gateway** is a failover and routing group over two or more dedicated gateways of the *same* form — all IPsec or all internet. Shared gateways are refused as members.
+
+```hcl
+resource "jamfplatform_security_cloud_ztna_gateway" "frankfurt" {
+  name          = "Frankfurt DC"
+  egress_region = "Europe - Germany"
+  tenant_ids    = [var.security_cloud_tenant_id]
+
+  contact = {
+    name  = "Network Operations"
+    email = "netops@example.com"
+  }
+
+  # Omitted here, so this is a dedicated internet gateway. Adding or removing the
+  # block replaces the gateway — see "Immutable forms" below.
+  # ipsec = { ... }
+}
+```
+
+`tenant_ids` is mandatory and every tenant named in it must belong to the same organization as the provider's credentials. Because no API lists an environment's tenants, an environment-scoped configuration has no way to fill it in from data — supply the tenant ID as an input, or configure the provider with `tenant_id`.
+
+### Short names and fixed addresses
+
+Two tenant-wide settings sit alongside the zones, both under **Custom DNS** in the portal, and both are single-instance resources:
+
+```hcl
+# Completes an incomplete host name for apps that only accept short names: a user
+# asking for "wiki" is directed to "wiki.example.corp". Setting this is also what
+# lets an access policy's hostnames be written as short names.
+resource "jamfplatform_security_cloud_dns_search_domain" "corp" {
+  domain_name = "example.corp"
+}
+
+# Fixed answers for internal host names. This resource owns the tenant's ENTIRE
+# set: a mapping added elsewhere and absent here is removed on the next apply.
+resource "jamfplatform_security_cloud_dns_hostname_mappings" "internal" {
+  mappings = [
+    {
+      hostname       = "build.example.corp"
+      ipv4_addresses = ["10.10.5.20"]
+
+      # Traffic vectoring. Both are required on every mapping — note that the
+      # admin UI's add dialog pre-selects Connect to ZTNA, so a mapping added
+      # there and one written here do not start from the same value.
+      connect_to_ztna       = true
+      connect_to_secure_dns = false
+    },
+    {
+      hostname              = "artifacts.example.corp"
+      ipv4_addresses        = ["10.10.5.21"]
+      connect_to_ztna       = true
+      connect_to_secure_dns = false
+    },
+  ]
+}
+```
+
+Between 1 and 500 mappings, each host name once, and at least one of `ipv4_addresses` or `ipv6_addresses` per entry. An empty `mappings` collection is not accepted: to remove them all, destroy the resource.
+
+## Traffic matching is tenant-unique
+
+A host name or address range belongs to **one** application across the whole tenant. Declaring one that another application already claims is rejected at apply, which makes a rename-by-replacement land badly: Terraform creates the new application before destroying the old one, and the create is refused because the old one still holds the names. Split such a change into two applies, or use `terraform state` to move the resource rather than replacing it.
+
+Within one tenant Jamf resolves overlaps by specificity — the most granularly defined host name wins, so `images.app.example.com` matches an application declaring it ahead of one declaring `*.example.com`, and a custom application's host name takes precedence over the same name inside a predefined definition. That is what makes the pattern Jamf recommends work: start with one wildcard application to get traffic flowing, then carve specific applications out of it without touching the wildcard. See the [Network Engineer's Guide to Jamf Connect ZTNA](https://trusted.jamf.com/docs/network-engineers-guide-to-private-access).
+
+Two further limits on `direct_ips_and_subnets`, both Jamf's: it needs the Jamf Trust app on the device, and direct-IP traffic does not appear in the access reports. Prefer host names where the application supports them.
+
+## Delete ordering
+
+Jamf Security Cloud enforces references on delete in three different ways, and knowing which is which saves a confusing destroy:
+
+| Destroying | What happens |
+|---|---|
+| A **gateway** a DNS zone, grouped gateway or app still references | Refused. Drop the reference in an earlier apply. |
+| A **grouped gateway's member** while it is still in the group | Refused. |
+| A **device group** an app assignment or UEM mapping still names | **Succeeds silently**, and quietly drops the group from every assignment that named it — which can leave an application assigned to nobody. |
+
+The third is the dangerous one, because nothing fails. Check what references a device group before removing it. Note also that the built-in **Default Group** cannot be managed here at all: Jamf gives it no identifier and reserves the name. It shows up in the `..._device_groups` data source with `built_in = true` and a null `id`.
+
+## Tenant-wide singletons
+
+Three resources are one-per-tenant, and each behaves slightly differently when you destroy it:
+
+- `dns_search_domain` — destroying it clears the search domain for the tenant.
+- `dns_hostname_mappings` — owns the **whole set**; destroying it removes every mapping, and any mapping added outside Terraform is removed on the next apply.
+- `uem_connect` — creating a second is refused, so **import** where one already exists rather than declaring a new one.
+
+Declare each of them once. A second instance of any of them in one configuration will fight itself on every apply.
+
+## Immutable forms
+
+Three constructs pick a shape at create time that Jamf will not convert afterwards, so Terraform replaces the object instead:
+
+- A **gateway** is IPsec or internet, decided by whether the `ipsec` block is present.
+- A **ZTNA app** is predefined or custom, decided by whether `predefined_app_id` is set.
+- A **UEM Connect** integration's vendor, address and authentication method are fixed; changing any of them replaces the integration, which briefly interrupts syncing.
+
+## UEM Connect
+
+UEM Connect syncs device inventory and group membership from Jamf Pro into Jamf Security Cloud, and signals device risk back. It is what makes the managed-device security requirement above mean anything, and what lets you keep deciding group membership in Jamf Pro.
+
+```hcl
+resource "jamfplatform_security_cloud_uem_connect" "jamf_pro" {
+  uem_vendor = "JAMF_PRO"
+  enabled    = true
+
+  # Prefer platform_tenant: Jamf Security Cloud creates and manages its own
+  # credentials on the named Jamf Pro tenant, so no secret is configured here.
+  # The alternative, oauth, takes the client ID and secret of an API integration
+  # you created on the Jamf Pro instance yourself, plus uem_server_url.
+  platform_tenant = {
+    tenant_id = var.jamf_pro_tenant_id
+  }
+
+  group_membership_mapping = {
+    enabled = true
+
+    # Order matters. Jamf evaluates the list in order and a device joins the
+    # group of the first entry it matches, so put the most specific first. A
+    # device matching nothing joins the default group.
+    mappings = [
+      {
+        # A Jamf Pro group is written as computer_ or mobile_ followed by the
+        # group's number. This composes out of a jamfplatform_device_group:
+        #   "${jamfplatform_device_group.x.device_type}_${jamfplatform_device_group.x.jamf_pro_id}"
+        uem_group_id            = "computer_12"
+        security_cloud_group_id = jamfplatform_security_cloud_device_group.engineering.id
+      },
+    ]
+  }
+}
+
+# Starts a sync immediately instead of waiting for the scheduled one. Jamf runs it
+# in the background, so this returns as soon as the run has started and reports
+# nothing about what it did — read latest_sync from the data source afterwards.
+action "jamfplatform_security_cloud_uem_connect_synchronize" "now" {
+  config {
+    uem_connect_id = jamfplatform_security_cloud_uem_connect.jamf_pro.id
+  }
+}
+```
+
+Jamf Security Cloud does not check that either side of a mapping exists, so a wrong group number is accepted and simply never matches. Declaring `group_membership_mapping` at all replaces what it does not mention — an omitted or empty `mappings` clears every mapping.
+
+Importing an existing integration has one wrinkle worth knowing in advance: `user_data_field_mapping` and `group_membership_mapping` are captured from the tenant even though your configuration may not declare them, so run `terraform plan` straight after the import and write in what the plan shows you rather than letting the next apply clear them.
+
+## Getting the configuration onto devices
+
+Nothing above reaches a device on its own. Devices enrol with Jamf Security Cloud through an **activation profile** distributed alongside the Jamf Trust app, and the provider covers exactly one step of that: the portal's **Deploy to Jamf Pro** button, which creates the activation profile's configuration profile in Jamf Pro and scopes it.
+
+```hcl
+action "jamfplatform_security_cloud_activation_profile_deploy" "macos" {
+  config {
+    activation_profile_code = var.activation_profile_code
+    os                      = "macos"
+    jamf_pro_group_ids      = ["1", "2"]
+  }
+}
+```
+
+Three things about it. The **activation profile code** is issued by Jamf Security Cloud during activation profile setup and cannot be created or looked up from Terraform — it is the last path segment of the activation profile's deployment page — so it is an input. There is **one deployment per operating system** (`macos`, `ios_byod`, `ios_supervised`, `ios_unsupervised`), so cover more than one by invoking the action once for each, and name computer groups for `macos` and mobile device groups otherwise. And **scope only ever accumulates** — `jamf_pro_group_ids` adds groups and never removes one, and omitting it on a *first* deployment scopes the configuration profile to nothing while still reporting success. Narrow or clear a scope in Jamf Pro.
+
+## Requirements
+
+Jamf Security Cloud is reached under **either** scope: set `environment_id` (preferred) or `tenant_id` on the provider. Unlike the Platform Services constructs there is no version gate — Jamf Security Cloud is continuously deployed and a tenant can hold it without holding Jamf Pro.
+
+Two things about authorisation are specific to this namespace:
+
+- **Entitlement is not authentication.** A valid API integration can still be refused with `403 NOT_ENTITLED` when the tenant does not hold the product behind the construct — dedicated gateways, for instance, are a paid add-on. The provider translates that into a named diagnostic rather than surfacing the raw error.
+- **Permissions are per construct**, granted in Jamf Account's permission picker. Each resource, data source and action page carries its own table naming the category, the row and the boxes to tick; the capabilities across this namespace are `ztna`, `device-groups`, `content-categories`, `custom-hostname-mappings`, `search-domains` and `uem-connect`.
+
+## Further reading
+
+| Topic | Page |
+|---|---|
+| The portal, end to end, in Jamf's words | [Jamf Security Cloud Portal Setup Guide](https://learn.jamf.com/r/en-US/jamf-security-cloud-setup-guide/RADAR_Portal) |
+| What an access policy is made of | [Access Policy](https://learn.jamf.com/r/en-US/jamf-connect-documentation-current/Access_Policies) |
+| Predefined and custom applications | [Adding a New Predefined Application](https://learn.jamf.com/r/en-US/jamf-connect-documentation-current/Adding_a_New_SaaS_Application), [Adding a New Custom Application](https://learn.jamf.com/r/en-US/jamf-connect-documentation-current/Adding_a_New_Enterprise_Application) |
+| Gateway types, and what a shared gateway is | [Shared Internet Gateways](https://learn.jamf.com/r/en-US/jamf-connect-documentation-current/Internet_Cloud_Gateways), [Grouped Gateways](https://learn.jamf.com/r/en-US/jamf-connect-documentation-current/Grouped_Gateways) |
+| Grouping gateways, and the routing strategies | [Creating a Group of Gateways](https://learn.jamf.com/r/en-US/jamf-connect-documentation-current/Creating_a_Grouped_Gateway) |
+| Custom DNS zones | [DNS Zones](https://learn.jamf.com/r/en-US/jamf-security-cloud-setup-guide/Custom_DNS_Zones), [Configuring Custom DNS Zones](https://learn.jamf.com/r/en-US/jamf-security-cloud-setup-guide/Configuring_Custom_DNS_Zones), [Troubleshooting Custom DNS Zones](https://learn.jamf.com/r/en-US/jamf-security-cloud-setup-guide/Troubleshooting_Custom_DNS_Zones) |
+| UEM Connect, and its settings | [UEM Connect](https://learn.jamf.com/r/en-US/jamf-security-cloud-setup-guide/UEM_Connect_Overview), [UEM Connect Settings Reference](https://learn.jamf.com/r/en-US/jamf-security-cloud-setup-guide/UEM_Connect_Settings), [UEM Connect Integration by Vendor](https://learn.jamf.com/r/en-US/jamf-security-cloud-setup-guide/UEM_Vendor_Integration) |
+| Activation profiles | [Activation Profiles](https://learn.jamf.com/r/en-US/jamf-security-cloud-setup-guide/Activation_Profiles), [Creating an Activation Profile](https://learn.jamf.com/r/en-US/jamf-security-cloud-setup-guide/Creating_Activation_Profiles) |
+| The policies this provider does not manage yet | [Policies](https://learn.jamf.com/r/en-US/jamf-security-cloud-setup-guide/Policies) |
+| How the routing fabric actually works | [Network Engineer's Guide to Jamf Connect ZTNA](https://trusted.jamf.com/docs/network-engineers-guide-to-private-access) |

--- a/docs/guides/security-cloud.md
+++ b/docs/guides/security-cloud.md
@@ -287,6 +287,10 @@ Three constructs pick a shape at create time that Jamf will not convert afterwar
 UEM Connect syncs device inventory and group membership from Jamf Pro into Jamf Security Cloud, and signals device risk back. It is what makes the managed-device security requirement above mean anything, and what lets you keep deciding group membership in Jamf Pro.
 
 ```hcl
+# The Jamf Pro tenant identifier is the one value here you cannot read off the
+# UEM Connect screen, so read it rather than copying it between consoles.
+data "jamfplatform_pro_tenant_id" "jamf_pro" {}
+
 resource "jamfplatform_security_cloud_uem_connect" "jamf_pro" {
   uem_vendor = "JAMF_PRO"
   enabled    = true
@@ -296,7 +300,7 @@ resource "jamfplatform_security_cloud_uem_connect" "jamf_pro" {
   # The alternative, oauth, takes the client ID and secret of an API integration
   # you created on the Jamf Pro instance yourself, plus uem_server_url.
   platform_tenant = {
-    tenant_id = var.jamf_pro_tenant_id
+    tenant_id = data.jamfplatform_pro_tenant_id.jamf_pro.tenant_id
   }
 
   group_membership_mapping = {
@@ -326,6 +330,8 @@ action "jamfplatform_security_cloud_uem_connect_synchronize" "now" {
   }
 }
 ```
+
+`jamfplatform_pro_tenant_id` reaches the Jamf Pro namespace, so it works under a platform environment — where it resolves the Jamf Pro tenant in that environment — and under tenant scope pointed at the Jamf Pro tenant. It does **not** work under tenant scope pointed at the Security Cloud tenant, because Jamf Pro does not answer under that scope; supply the identifier as an input there. Note this is a different identifier from a gateway's `tenant_ids` above, which names Security Cloud tenants and has no data source to read it from.
 
 Jamf Security Cloud does not check that either side of a mapping exists, so a wrong group number is accepted and simply never matches. The group configuration is replaced wholesale on every apply, so there is no way to leave it unmanaged: declaring `group_membership_mapping` replaces what it does not mention — an omitted or empty `mappings` clears every mapping — and **omitting the block entirely resets the whole group configuration to its defaults**. Manage it, or expect it cleared.
 

--- a/docs/guides/security-cloud.md
+++ b/docs/guides/security-cloud.md
@@ -145,7 +145,7 @@ resource "jamfplatform_security_cloud_dns_zone" "internal" {
 Queries matching the zone's domains go to one of its name servers by pseudo-random load balancing. Four rules here are Jamf's, not the provider's, and each one is a plan that applies and then fails to work:
 
 - A **domain belongs to exactly one zone**, tenant-wide, and a name server IP address may appear only once per zone.
-- The name server has to be reachable **through the gateway you name**, and **its address must be publicly routable when that gateway is shared**. Jamf Security Cloud refuses a reserved address — private, loopback and similar — behind the shared "Nearest Data Center" egress. A name server on an internal address needs a gateway of your own that reaches your network, which is what the dedicated gateways below are for.
+- The name server has to be reachable **through the gateway you name**, and **its address must be publicly routable**. Jamf Security Cloud refuses a reserved address — private, loopback and similar — with `Name server IP address not allowed`. Jamf's own documentation attaches that restriction to the shared "Nearest Data Center" egress, but a dedicated *internet* gateway refuses a private address just the same, so do not plan on one lifting the rule. A name server on an internal address needs a gateway that actually reaches your network, which means the IPsec form below.
 - Reverse lookups work by adding the `.in-addr.arpa` and `.ipv6.arpa` domains to the zone.
 - **Changes to your own infrastructure need the zone changed too** — a new or renumbered name server, or an application on a domain the zone does not match.
 
@@ -177,6 +177,8 @@ resource "jamfplatform_security_cloud_ztna_gateway" "frankfurt" {
 ```
 
 `tenant_ids` is mandatory and every tenant named in it must belong to the same organization as the provider's credentials. Because no API lists an environment's tenants, an environment-scoped configuration has no way to fill it in from data — supply the tenant ID as an input, or configure the provider with `tenant_id`.
+
+A gateway reports `PENDING` the moment it is created and carries no `dedicated_egress_ip_addresses` until Jamf has finished provisioning it, so an apply completing is not the same as a gateway being usable. Changing `egress_region` later re-provisions it: connectivity drops, the status returns to `PENDING`, and the egress addresses stay stale until it settles.
 
 ### Short names and fixed addresses
 
@@ -230,9 +232,11 @@ Jamf Security Cloud enforces references on delete in three different ways, and k
 
 | Destroying | What happens |
 |---|---|
-| A **gateway** a DNS zone, grouped gateway or app still references | Refused. Drop the reference in an earlier apply. |
+| A **gateway** a DNS zone, grouped gateway or app still references | Refused, naming what holds it. |
 | A **grouped gateway's member** while it is still in the group | Refused. |
 | A **device group** an app assignment or UEM mapping still names | **Succeeds silently**, and quietly drops the group from every assignment that named it — which can leave an application assigned to nobody. |
+
+The first has a Terraform-specific trap on top of the API's refusal. Dropping the reference *and* the gateway in a single apply does not work either, because Terraform sequences the destroy before the update that would have released the gateway — so the destroy still hits a live reference. Release it in one apply, destroy the gateway in the next.
 
 The third is the dangerous one, because nothing fails. Check what references a device group before removing it. Note also that the built-in **Default Group** cannot be managed here at all: Jamf gives it no identifier and reserves the name. It shows up in the `..._device_groups` data source with `built_in = true` and a null `id`.
 

--- a/docs/resources/security_cloud_dns_zone.md
+++ b/docs/resources/security_cloud_dns_zone.md
@@ -5,6 +5,7 @@ subcategory: ""
 description: |-
   Manages a Jamf Security Cloud custom DNS zone. Hostnames belonging to the zone's domains are resolved through authoritative name servers of your choice instead of public DNS — Jamf calls this "split-brain DNS", and a custom DNS zone is required before enterprise apps on internal private networks become reachable over ZTNA.
   Misconfiguring a zone can cut end users off from some or all of your private applications and workloads.
+  See the Jamf Security Cloud guide ../guides/security-cloud for the rules a name server address has to satisfy, how to choose the gateway each one is reached through, and why the gateway has to exist before the zone that names it.
   Required Jamf permissions
   Grant the API integration the following permissions in Jamf Account — see Getting started with the Platform API https://developer.jamf.com/platform-api/reference/getting-started-with-platform-api. Category and Permission name the section and row of the permission picker; Actions are the boxes to tick within that row.
   | Category | Permission | Actions | API capability |
@@ -17,6 +18,8 @@ description: |-
 Manages a Jamf Security Cloud custom DNS zone. Hostnames belonging to the zone's domains are resolved through authoritative name servers of your choice instead of public DNS — Jamf calls this "split-brain DNS", and a custom DNS zone is required before enterprise apps on internal private networks become reachable over ZTNA.
 
 Misconfiguring a zone can cut end users off from some or all of your private applications and workloads.
+
+See the [Jamf Security Cloud guide](../guides/security-cloud) for the rules a name server address has to satisfy, how to choose the gateway each one is reached through, and why the gateway has to exist before the zone that names it.
 
 **Required Jamf permissions**
 

--- a/docs/resources/security_cloud_uem_connect.md
+++ b/docs/resources/security_cloud_uem_connect.md
@@ -8,6 +8,7 @@ description: |-
   Choose one of two ways to authenticate to Jamf Pro. With platform_tenant, Jamf Security Cloud creates and manages its own credentials on the named tenant and no secret is configured here — prefer it. With oauth, supply the client ID and secret of an API integration you created on the Jamf Pro instance yourself.
   The connection is fixed once created: changing the vendor, the address or the way it authenticates replaces the integration, which briefly interrupts syncing.
   After importing, run terraform plan: user_data_field_mapping and group_membership_mapping are captured from the tenant even though your configuration may not declare them, and the plan shows you what to write in to keep them.
+  See the Jamf Security Cloud guide ../guides/security-cloud for how a Jamf Pro group is named in a membership mapping, why the order of the mappings decides which group a device joins, and what an import leaves you to reconcile.
   Required Jamf permissions
   Grant the API integration the following permissions in Jamf Account — see Getting started with the Platform API https://developer.jamf.com/platform-api/reference/getting-started-with-platform-api. Category and Permission name the section and row of the permission picker; Actions are the boxes to tick within that row.
   | Category | Permission | Actions | API capability |
@@ -26,6 +27,8 @@ Choose one of two ways to authenticate to Jamf Pro. With `platform_tenant`, Jamf
 The connection is fixed once created: changing the vendor, the address or the way it authenticates replaces the integration, which briefly interrupts syncing.
 
 After importing, run `terraform plan`: `user_data_field_mapping` and `group_membership_mapping` are captured from the tenant even though your configuration may not declare them, and the plan shows you what to write in to keep them.
+
+See the [Jamf Security Cloud guide](../guides/security-cloud) for how a Jamf Pro group is named in a membership mapping, why the order of the mappings decides which group a device joins, and what an import leaves you to reconcile.
 
 **Required Jamf permissions**
 

--- a/docs/resources/security_cloud_ztna_app.md
+++ b/docs/resources/security_cloud_ztna_app.md
@@ -6,6 +6,7 @@ description: |-
   Manages a Jamf Security Cloud access policy application — one entry on the Access policy page. An application is defined by the host names and address ranges its traffic matches; defining one is what lets Jamf Security Cloud apply access policy and reporting to that traffic.
   An application is either predefined, based on one of the Jamf-maintained definitions the jamfplatform_security_cloud_ztna_predefined_apps data source lists, or custom, defined entirely by you. Set predefined_app_id for the first and name for the second. The choice cannot be changed afterwards — Terraform replaces the application instead.
   Host names and address ranges may belong to only one application across the whole tenant, so two applications cannot claim the same one. Misconfiguring an application can cut end users off from the resources it covers.
+  See the Jamf Security Cloud guide ../guides/security-cloud for what that tenant-wide uniqueness means in practice — how overlapping host names are resolved, and why renaming an application by replacing it fails — and for a worked example taking one internal application all the way from a device group to a device that can reach it.
   Required Jamf permissions
   Grant the API integration the following permissions in Jamf Account — see Getting started with the Platform API https://developer.jamf.com/platform-api/reference/getting-started-with-platform-api. Category and Permission name the section and row of the permission picker; Actions are the boxes to tick within that row.
   | Category | Permission | Actions | API capability |
@@ -20,6 +21,8 @@ Manages a Jamf Security Cloud access policy application — one entry on the **A
 An application is either **predefined**, based on one of the Jamf-maintained definitions the `jamfplatform_security_cloud_ztna_predefined_apps` data source lists, or **custom**, defined entirely by you. Set `predefined_app_id` for the first and `name` for the second. The choice cannot be changed afterwards — Terraform replaces the application instead.
 
 Host names and address ranges may belong to only one application across the whole tenant, so two applications cannot claim the same one. Misconfiguring an application can cut end users off from the resources it covers.
+
+See the [Jamf Security Cloud guide](../guides/security-cloud) for what that tenant-wide uniqueness means in practice — how overlapping host names are resolved, and why renaming an application by replacing it fails — and for a worked example taking one internal application all the way from a device group to a device that can reach it.
 
 **Required Jamf permissions**
 

--- a/internal/resources/security_cloud/content_categories/data_source.go
+++ b/internal/resources/security_cloud/content_categories/data_source.go
@@ -82,9 +82,9 @@ func (d *ContentCategoriesDataSource) Schema(ctx context.Context, _ datasource.S
 			"Use this to reference a category without hard-coding a name Jamf may revise — in an output, " +
 			"or to pre-stage an identifier. Note that a category has two names: reference `display_name`, " +
 			"not `name`.\n\n" +
-			"Zero Trust Network Access apps, which are what match a category, are not yet managed by this " +
-			"provider, so today the value read here is for reference rather than for wiring into another " +
-			"resource." + dataSourcePrivileges,
+			"A `jamfplatform_security_cloud_ztna_app` is what matches a category, so resolve the category " +
+			"here and wire `display_name` into its `category` rather than writing the name out." +
+			dataSourcePrivileges,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				MarkdownDescription: "Fixed identifier for this data source.",
@@ -104,8 +104,8 @@ func (d *ContentCategoriesDataSource) Schema(ctx context.Context, _ datasource.S
 							MarkdownDescription: "The category name as shown in Jamf Security Cloud, for " +
 								"example `Social`. **This is the name that identifies the category** — a " +
 								"Zero Trust Network Access app's category matches on it, and it is the name " +
-								"to reference. Zero Trust Network Access apps are not yet managed by this " +
-								"provider.",
+								"to reference. Wire it into a `jamfplatform_security_cloud_ztna_app`'s " +
+								"`category`.",
 							Computed: true,
 						},
 						"name": schema.StringAttribute{

--- a/internal/resources/security_cloud/content_categories/schema_test.go
+++ b/internal/resources/security_cloud/content_categories/schema_test.go
@@ -88,17 +88,23 @@ func TestContentCategoriesDataSource_PointsAtDisplayName(t *testing.T) {
 	}
 }
 
-// TestContentCategoriesDataSource_DisclaimsUnbuiltConsumer pins the honesty of the
-// schema description. The construct that consumes a category — a Zero Trust Network
-// Access app — is not shipped by this provider, so an operator reading the
-// description must not be sent looking for a resource that does not exist. Delete
-// this assertion when the app resource lands, not before.
-func TestContentCategoriesDataSource_DisclaimsUnbuiltConsumer(t *testing.T) {
+// TestContentCategoriesDataSource_NamesItsConsumer pins the honesty of the schema
+// description in the other direction. It used to disclaim that the construct
+// consuming a category was unbuilt; jamfplatform_security_cloud_ztna_app now ships,
+// so the description has to name it rather than send an operator looking for
+// nothing — and must not carry the retired disclaimer.
+func TestContentCategoriesDataSource_NamesItsConsumer(t *testing.T) {
 	d := NewContentCategoriesDataSource()
 	var resp datasource.SchemaResponse
 	d.(*ContentCategoriesDataSource).Schema(context.Background(), datasource.SchemaRequest{}, &resp)
 
-	if !strings.Contains(resp.Schema.GetMarkdownDescription(), "not yet managed by this provider") {
-		t.Errorf("schema description must say Zero Trust Network Access apps are not yet managed by this provider, got: %s", resp.Schema.GetMarkdownDescription())
+	description := resp.Schema.GetMarkdownDescription()
+
+	if !strings.Contains(description, "jamfplatform_security_cloud_ztna_app") {
+		t.Errorf("schema description must name the app resource that consumes a category, got: %s", description)
+	}
+
+	if strings.Contains(description, "not yet managed by this provider") {
+		t.Errorf("schema description still carries the retired unbuilt-consumer disclaimer, got: %s", description)
 	}
 }

--- a/internal/resources/security_cloud/dns_zone/helpers.go
+++ b/internal/resources/security_cloud/dns_zone/helpers.go
@@ -32,10 +32,10 @@ const (
 // The codes worth translating are the ones whose cause is not the field the
 // server names. GATEWAY_NOT_FOUND is the clearest case: the request that fails
 // is a zone write, but the thing that does not exist is a gateway, so the
-// diagnostic has to point at `name_servers` — a zone cannot be created before
-// the gateway its name servers are reachable through. NOT_ENTITLED is the other
-// one worth naming: the credentials are valid and the tenant simply does not
-// have the surface, which is invisible in a bare 403.
+// diagnostic has to point at `authoritative_name_servers` — a zone cannot be
+// created before the gateway its name servers are reachable through.
+// NOT_ENTITLED is the other one worth naming: the credentials are valid and the
+// tenant simply does not have the surface, which is invisible in a bare 403.
 func appendWriteDiagnostics(diags *diag.Diagnostics, err error) bool {
 	apiErr := jamfplatform.AsAPIError(err)
 	if apiErr == nil {
@@ -71,9 +71,9 @@ func appendWriteDiagnostics(diags *diag.Diagnostics, err error) bool {
 		case codeListSizeExceeded:
 			diags.AddError(
 				"DNS zone collection size out of range",
-				"A collection on this zone is outside the size Jamf Security Cloud accepts: `domains` takes 1 to 100 "+
-					"entries and `name_servers` takes 1 to 20. There is also a per-tenant cap on the number of "+
-					"zones. Reported by Jamf Security Cloud: "+detail.Description,
+				"A collection on this zone is outside the size Jamf Security Cloud accepts: `domains` takes 1 to "+
+					"100 entries and `authoritative_name_servers` takes 1 to 20. There is also a per-tenant cap "+
+					"on the number of zones. Reported by Jamf Security Cloud: "+detail.Description,
 			)
 		case codeNotEntitled:
 			diags.AddError(

--- a/internal/resources/security_cloud/dns_zone/helpers_test.go
+++ b/internal/resources/security_cloud/dns_zone/helpers_test.go
@@ -41,19 +41,19 @@ func TestAppendWriteDiagnostics_MapsCodesToAttributes(t *testing.T) {
 			wantText: "only one custom DNS zone",
 		},
 		{
-			name:     "gateway not found points at name_servers, not the zone",
+			name:     "gateway not found points at authoritative_name_servers, not the zone",
 			err:      apiError(422, codeGatewayNotFound, "", "Referenced gateway not found."),
 			wantPath: path.Root("authoritative_name_servers"),
 			wantText: "gateway must exist before the zone can reference it",
 		},
 		{
-			name:     "restricted ip points at name_servers",
+			name:     "restricted ip points at authoritative_name_servers",
 			err:      apiError(422, codeNameServerIPRestricted, "", "Name server IP is restricted."),
 			wantPath: path.Root("authoritative_name_servers"),
 			wantText: "Reserved ranges",
 		},
 		{
-			name:     "out of range ip points at name_servers",
+			name:     "out of range ip points at authoritative_name_servers",
 			err:      apiError(422, codeNameServerIPOutOfRange, "", "Name server IP out of range."),
 			wantPath: path.Root("authoritative_name_servers"),
 			wantText: "refuses this name server address",

--- a/internal/resources/security_cloud/dns_zone/resource.go
+++ b/internal/resources/security_cloud/dns_zone/resource.go
@@ -110,7 +110,10 @@ func (r *DNSZoneResource) Schema(ctx context.Context, _ resource.SchemaRequest, 
 			"are resolved through authoritative name servers of your choice instead of public DNS — Jamf calls this " +
 			"\"split-brain DNS\", and a custom DNS zone is required before enterprise apps on internal private networks " +
 			"become reachable over ZTNA.\n\n" +
-			"Misconfiguring a zone can cut end users off from some or all of your private applications and workloads." +
+			"Misconfiguring a zone can cut end users off from some or all of your private applications and workloads.\n\n" +
+			"See the [Jamf Security Cloud guide](../guides/security-cloud) for the rules a name server address has " +
+			"to satisfy, how to choose the gateway each one is reached through, and why the gateway has to exist " +
+			"before the zone that names it." +
 			resourcePrivileges,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{

--- a/internal/resources/security_cloud/dns_zone/schema_test.go
+++ b/internal/resources/security_cloud/dns_zone/schema_test.go
@@ -48,9 +48,9 @@ func TestDNSZoneResource_Schema(t *testing.T) {
 
 // TestDNSZoneResource_CollectionsAreSets pins the Set choice for both
 // collections. Jamf Security Cloud re-sorts `domains` on the wire, so a List
-// would fail "produced inconsistent result after apply"; `name_servers` carries
-// no ordering semantics, and the Set is what makes the per-IP uniqueness the
-// server enforces expressible at plan time.
+// would fail "produced inconsistent result after apply";
+// `authoritative_name_servers` carries no ordering semantics, and the Set is what
+// makes the per-IP uniqueness the server enforces expressible at plan time.
 func TestDNSZoneResource_CollectionsAreSets(t *testing.T) {
 	s := resourceSchema(t)
 
@@ -133,7 +133,7 @@ func TestDNSZoneDataSource_Schema(t *testing.T) {
 		t.Errorf("data source domains must be a ListAttribute, got %T", s.Attributes["domains"])
 	}
 	if _, ok := s.Attributes["authoritative_name_servers"].(dsschema.ListNestedAttribute); !ok {
-		t.Errorf("data source name_servers must be a ListNestedAttribute, got %T", s.Attributes["authoritative_name_servers"])
+		t.Errorf("data source authoritative_name_servers must be a ListNestedAttribute, got %T", s.Attributes["authoritative_name_servers"])
 	}
 }
 

--- a/internal/resources/security_cloud/dns_zone/schema_types.go
+++ b/internal/resources/security_cloud/dns_zone/schema_types.go
@@ -24,5 +24,6 @@ var nameServerAttributeTypes = map[string]attr.Type{
 	"gateway_id": types.StringType,
 }
 
-// nameServerObjectType is the element type of the name_servers collection.
+// nameServerObjectType is the element type of the authoritative_name_servers
+// collection.
 var nameServerObjectType = types.ObjectType{AttrTypes: nameServerAttributeTypes}

--- a/internal/resources/security_cloud/dns_zone/state_builders.go
+++ b/internal/resources/security_cloud/dns_zone/state_builders.go
@@ -16,10 +16,10 @@ import (
 //
 // Both collections are written straight from the response with no reconciliation
 // against the prior state. That is safe here because neither is order-sensitive
-// in Terraform: `domains` and `name_servers` are sets, so the comparison ignores
-// order. It also has to be that way for `domains` — Jamf Security Cloud sorts the
-// stored domain list byte-wise ascending, so the read never echoes the authored
-// order back (wire-probed 2026-08-27).
+// in Terraform: `domains` and `authoritative_name_servers` are sets, so the
+// comparison ignores order. It also has to be that way for `domains` — Jamf
+// Security Cloud sorts the stored domain list byte-wise ascending, so the read
+// never echoes the authored order back (wire-probed 2026-08-27).
 func assignDNSZoneResourceModel(ctx context.Context, state *DNSZoneResourceModel, z *securitycloud.Zone) diag.Diagnostics {
 	var diags diag.Diagnostics
 
@@ -92,7 +92,7 @@ func nameServerObjectValues(servers []securitycloud.NameServer) ([]attr.Value, d
 	return values, diags
 }
 
-// nameServerSetValue builds the resource-side name_servers set.
+// nameServerSetValue builds the resource-side authoritative_name_servers set.
 func nameServerSetValue(servers []securitycloud.NameServer) (types.Set, diag.Diagnostics) {
 	values, diags := nameServerObjectValues(servers)
 	if diags.HasError() {
@@ -103,7 +103,7 @@ func nameServerSetValue(servers []securitycloud.NameServer) (types.Set, diag.Dia
 	return set, diags
 }
 
-// nameServerListValue builds the data-source-side name_servers list.
+// nameServerListValue builds the data-source-side authoritative_name_servers list.
 func nameServerListValue(servers []securitycloud.NameServer) (types.List, diag.Diagnostics) {
 	values, diags := nameServerObjectValues(servers)
 	if diags.HasError() {

--- a/internal/resources/security_cloud/uem_connect/resource.go
+++ b/internal/resources/security_cloud/uem_connect/resource.go
@@ -210,7 +210,10 @@ func (r *UEMConnectResource) Schema(ctx context.Context, _ resource.SchemaReques
 			"replaces the integration, which briefly interrupts syncing.\n\n" +
 			"After importing, run `terraform plan`: `user_data_field_mapping` and `group_membership_mapping` are captured from " +
 			"the tenant even though your configuration may not declare them, and the plan shows you what to " +
-			"write in to keep them." +
+			"write in to keep them.\n\n" +
+			"See the [Jamf Security Cloud guide](../guides/security-cloud) for how a Jamf Pro group is named in a " +
+			"membership mapping, why the order of the mappings decides which group a device joins, and what an " +
+			"import leaves you to reconcile." +
 			resourcePrivileges,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{

--- a/internal/resources/security_cloud/ztna_app/resource.go
+++ b/internal/resources/security_cloud/ztna_app/resource.go
@@ -155,7 +155,12 @@ func (r *ZtnaAppResource) Schema(ctx context.Context, _ resource.SchemaRequest, 
 			"cannot be changed afterwards — Terraform replaces the application instead.\n\n" +
 			"Host names and address ranges may belong to only one application across the whole tenant, so two " +
 			"applications cannot claim the same one. Misconfiguring an application can cut end users off from " +
-			"the resources it covers." + resourcePrivileges,
+			"the resources it covers.\n\n" +
+			"See the [Jamf Security Cloud guide](../guides/security-cloud) for what that tenant-wide uniqueness " +
+			"means in practice — how overlapping host names are resolved, and why renaming an application by " +
+			"replacing it fails — and for a worked example taking one internal application all the way from a " +
+			"device group to a device that can reach it." +
+			resourcePrivileges,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				MarkdownDescription: "Application ID assigned by Jamf Security Cloud.",

--- a/internal/resources/security_cloud/ztna_gateway/helpers.go
+++ b/internal/resources/security_cloud/ztna_gateway/helpers.go
@@ -184,7 +184,7 @@ func referencedByDetail(code string) (summary, referrer string, ok bool) {
 	case codeReferencedByDNSZones:
 		return "Gateway is still referenced by a custom DNS zone",
 			"a custom DNS zone name server — a `jamfplatform_security_cloud_dns_zone` whose " +
-				"`name_servers[].gateway_id` names this gateway —", true
+				"`authoritative_name_servers[].gateway_id` names this gateway —", true
 	case codeReferencedByGroupedGateways:
 		return "Gateway is still a member of a grouped gateway",
 			"a grouped gateway — a `jamfplatform_security_cloud_ztna_grouped_gateway` whose `gateway_ids` " +

--- a/internal/resources/security_cloud/ztna_gateway/helpers_test.go
+++ b/internal/resources/security_cloud/ztna_gateway/helpers_test.go
@@ -231,7 +231,7 @@ func TestAppendDeleteDiagnostics_NamesTheReferrer(t *testing.T) {
 			code:        codeReferencedByDNSZones,
 			description: "The gateway could not be deleted because it is referenced by one or more Custom DNS Zones. Disconnect this gateway from all zones, then try again.",
 			wantSummary: "custom DNS zone",
-			wantDetail:  []string{"jamfplatform_security_cloud_dns_zone", "name_servers[].gateway_id"},
+			wantDetail:  []string{"jamfplatform_security_cloud_dns_zone", "authoritative_name_servers[].gateway_id"},
 			wantAbsent:  []string{"access policy application", "grouped gateway"},
 		},
 		{

--- a/internal/resources/security_cloud/ztna_grouped_gateway/helpers.go
+++ b/internal/resources/security_cloud/ztna_grouped_gateway/helpers.go
@@ -40,9 +40,11 @@ const (
 // the messages says which member is at fault.
 //
 // `MIXED_DEDICATED_IPS_TYPES` is the one that most needs it: the server's message
-// names `dedicatedIps.enabled`, a wire field with no counterpart on this schema at
-// all, so without a translation the operator has to know it means
-// `dedicated_egress_ips_enabled` on each member gateway.
+// names a wire field that has no counterpart on this schema and none on the
+// gateway resource either, because a gateway's form is derived from whether it
+// declares an `ipsec` block rather than set by a flag. The translation therefore
+// names the block, and the gateway data source as the way to read the form of a
+// member this configuration does not manage.
 //
 // `GATEWAY_NOT_FOUND` is the same ordering trap the DNS zone has for its name
 // servers: a member gateway must exist before the group can name it, and
@@ -71,9 +73,10 @@ func appendWriteDiagnostics(diags *diag.Diagnostics, err error) bool {
 				path.Root("gateway_ids"),
 				"Member gateways disagree about dedicated egress IPs",
 				"Every member of a grouped gateway must have the same dedicated egress IP setting — either all "+
-					"members have them or none does. The server names the wire field `dedicatedIps.enabled`; on a "+
-					"`jamfplatform_security_cloud_ztna_gateway` that is `dedicated_egress_ips_enabled`. Reported by "+
-					"Jamf Security Cloud: "+detail.Description,
+					"members have them or none does. A gateway's form is set by whether it declares an `ipsec` "+
+					"block, so make every member match; for a gateway this configuration does not manage, read its "+
+					"form with the `jamfplatform_security_cloud_ztna_gateway` data source. Reported by Jamf "+
+					"Security Cloud: "+detail.Description,
 			)
 		case codeSharedGatewayMember:
 			diags.AddAttributeError(

--- a/internal/resources/security_cloud/ztna_grouped_gateway/helpers_test.go
+++ b/internal/resources/security_cloud/ztna_grouped_gateway/helpers_test.go
@@ -149,7 +149,10 @@ func TestAppendWriteDiagnostics_NotEntitledIsNotAttributeScoped(t *testing.T) {
 
 // TestAppendWriteDiagnostics_MixedDedicatedIPs pins the member constraint whose
 // server message names a wire field with no counterpart on this schema, so the
-// translation is the only thing telling the operator which attribute to change.
+// translation is the only thing telling the operator what to change. It has to
+// name the `ipsec` block, which is what actually sets a gateway's form, and the
+// gateway data source, which is how the form of an unmanaged member is read —
+// and it must not restate the wire field name.
 func TestAppendWriteDiagnostics_MixedDedicatedIPs(t *testing.T) {
 	var diags diag.Diagnostics
 
@@ -165,12 +168,20 @@ func TestAppendWriteDiagnostics_MixedDedicatedIPs(t *testing.T) {
 			continue
 		}
 		if withPath.Path().Equal(path.Root("gateway_ids")) &&
-			strings.Contains(d.Detail(), "dedicated_egress_ips_enabled") {
+			strings.Contains(d.Detail(), "`ipsec`") &&
+			strings.Contains(d.Detail(), "jamfplatform_security_cloud_ztna_gateway") {
 			found = true
 		}
 	}
 	if !found {
-		t.Errorf("want a gateway_ids diagnostic naming dedicated_egress_ips_enabled; got %v", diags)
+		t.Errorf("want a gateway_ids diagnostic naming the ipsec block and the gateway data source; got %v", diags)
+	}
+	for _, d := range diags {
+		authored, _, _ := strings.Cut(d.Detail(), "Reported by Jamf Security Cloud:")
+		if strings.Contains(authored, "dedicatedIps") ||
+			strings.Contains(authored, "dedicated_egress_ips_enabled") {
+			t.Errorf("the diagnostic must not name a wire field or a nonexistent attribute: %v", d)
+		}
 	}
 }
 

--- a/internal/resources/security_cloud/ztna_predefined_apps/data_source.go
+++ b/internal/resources/security_cloud/ztna_predefined_apps/data_source.go
@@ -80,9 +80,9 @@ func (d *PredefinedAppsDataSource) Schema(ctx context.Context, _ datasource.Sche
 			"Jamf, identical for every entitled tenant, and cannot be changed.\n\n" +
 			"Use this to read a template's identifier without hard-coding it, and to review the hostnames the " +
 			"template brings with it.\n\n" +
-			"Zero Trust Network Access apps are not yet managed by this provider, so the identifier read here " +
-			"is for reference today — an output, or a value to pre-stage a configuration on — rather than " +
-			"something another resource can be wired to." + dataSourcePrivileges,
+			"Wire the identifier into a `jamfplatform_security_cloud_ztna_app`'s `predefined_app_id` to " +
+			"manage an application based on the definition. Only one application per definition is allowed " +
+			"on a tenant." + dataSourcePrivileges,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				MarkdownDescription: "Fixed identifier for this data source.",

--- a/internal/resources/security_cloud/ztna_predefined_apps/schema_test.go
+++ b/internal/resources/security_cloud/ztna_predefined_apps/schema_test.go
@@ -5,6 +5,7 @@ package ztna_predefined_apps
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -71,5 +72,35 @@ func TestPredefinedAppsDataSource_IsEntirelyReadOnly(t *testing.T) {
 		if attr.IsRequired() || attr.IsOptional() {
 			t.Errorf("%s must be computed-only; the catalogue takes no arguments", name)
 		}
+	}
+}
+
+// TestPredefinedAppsDataSource_NamesItsConsumer pins the honesty of the schema
+// description in the other direction. It used to disclaim that the construct
+// consuming a template was unbuilt; jamfplatform_security_cloud_ztna_app now ships,
+// so the description has to name it rather than send an operator looking for
+// nothing — and must not carry the retired disclaimer.
+//
+// The one-per-definition claim is pinned here too because it is a wire fact nothing
+// else guards: a second application built from a definition the tenant already uses
+// is refused with `409 CONFLICT "Resource already exists."`, and an operator who
+// reads this catalogue and picks a template freely meets that refusal at apply.
+func TestPredefinedAppsDataSource_NamesItsConsumer(t *testing.T) {
+	d := NewPredefinedAppsDataSource()
+	var resp datasource.SchemaResponse
+	d.(*PredefinedAppsDataSource).Schema(context.Background(), datasource.SchemaRequest{}, &resp)
+
+	description := resp.Schema.GetMarkdownDescription()
+
+	if !strings.Contains(description, "jamfplatform_security_cloud_ztna_app") {
+		t.Errorf("schema description must name the app resource that consumes a template, got: %s", description)
+	}
+
+	if strings.Contains(description, "not yet managed by this provider") {
+		t.Errorf("schema description still carries the retired unbuilt-consumer disclaimer, got: %s", description)
+	}
+
+	if !strings.Contains(description, "one application per definition") {
+		t.Errorf("schema description must say only one application per definition is allowed on a tenant, got: %s", description)
 	}
 }

--- a/templates/guides/security-cloud.md
+++ b/templates/guides/security-cloud.md
@@ -14,16 +14,28 @@ This guide is the Terraform half: which portal pages the provider reaches, the o
 
 | In the portal | Constructs |
 |---|---|
-| **Devices > Device groups** | `jamfplatform_security_cloud_device_group` (resource, data source, list resource), `..._device_groups` |
+| **Devices > Device groups** | `jamfplatform_security_cloud_device_group` (resource, data source, list resource), `..._device_groups` (data source) |
 | **Devices > Activation profiles > Deployment** | `jamfplatform_security_cloud_activation_profile_deploy` (action) |
-| **Policies > Access > Access policy** | `jamfplatform_security_cloud_ztna_app`, `..._ztna_predefined_apps`, `..._content_categories` |
-| **Integrations > Access gateways** | `jamfplatform_security_cloud_ztna_gateway`, `..._ztna_grouped_gateway`, `..._ztna_shared_gateways` |
-| **Integrations > Custom DNS > DNS zones** | `jamfplatform_security_cloud_dns_zone` |
-| **Integrations > Custom DNS > Search domain** | `jamfplatform_security_cloud_dns_search_domain` |
-| **Integrations > Custom DNS > Hostname mapping** | `jamfplatform_security_cloud_dns_hostname_mappings` |
-| **Integrations > UEM Connect** | `jamfplatform_security_cloud_uem_connect`, `..._uem_connect_synchronize` (action) |
+| **Policies > Access > Access policy** | `jamfplatform_security_cloud_ztna_app` (resource, data source, list resource), `..._ztna_apps` (data source), `..._ztna_predefined_apps` (data source), `..._content_categories` (data source) |
+| **Integrations > Access gateways** | `jamfplatform_security_cloud_ztna_gateway` (resource, data source, list resource), `..._ztna_gateways` (data source), `..._ztna_grouped_gateway` (resource, data source, list resource), `..._ztna_grouped_gateways` (data source), `..._ztna_shared_gateways` (data source) |
+| **Integrations > Custom DNS > DNS zones** | `jamfplatform_security_cloud_dns_zone` (resource, data source, list resource), `..._dns_zones` (data source) |
+| **Integrations > Custom DNS > Search domain** | `jamfplatform_security_cloud_dns_search_domain` (resource, data source) |
+| **Integrations > Custom DNS > Hostname mapping** | `jamfplatform_security_cloud_dns_hostname_mappings` (resource, data source) |
+| **Integrations > UEM Connect** | `jamfplatform_security_cloud_uem_connect` (resource, data source, list resource), `..._uem_connect_synchronize` (action) |
 
 Three things next door to this are **not** managed here. **Activation profiles** themselves are created in the portal — most of their settings cannot be edited after creation, so Jamf treats them as immutable and the provider offers only the action that deploys one to Jamf Pro. **Content filtering and network security policies** (Jamf Protect's half of the portal) have no constructs yet. And **devices** arrive by enrolling with Jamf Trust or by syncing from a UEM; nothing here enrols one.
+
+## Build it in this order
+
+The sections below are ordered for reading. A rollout goes in a different order, because each step depends on the one above it:
+
+1. **UEM Connect** — device inventory and group membership have to be syncing before anything downstream is accurate.
+2. **Device groups** — or map them from Jamf Pro groups in step 1.
+3. **Gateways, then custom DNS** — a zone cannot be written before the gateway its name servers name. Written the other way round, Jamf Security Cloud refuses it with `422 GATEWAY_NOT_FOUND`, and the provider reports that against `authoritative_name_servers` rather than against the zone as a whole.
+4. **Access policy** — applications reference the groups, categories and gateways above.
+5. **Activation profile deploy** — nothing above reaches a device until this runs.
+
+Terraform derives most of that from the references between resources, so the order is yours to get right only where there is no reference to derive it from — a zone naming a gateway ID that arrived as a variable, say.
 
 ## End to end: publishing one enterprise app over ZTNA
 
@@ -36,17 +48,13 @@ resource "jamfplatform_security_cloud_device_group" "engineering" {
   name = "Engineering"
 }
 
-# Categories and gateways are both Jamf-maintained catalogues, so resolve them
-# rather than hard-coding an ID or guessing a category's spelling.
+# A gateway is named by an opaque ID, so resolve it from the catalogue rather than
+# hard-coding one. A category is named by its display name, so there is nothing to
+# resolve — the content_categories data source is how you confirm a spelling.
 data "jamfplatform_security_cloud_content_categories" "all" {}
 data "jamfplatform_security_cloud_ztna_shared_gateways" "all" {}
 
 locals {
-  business_category = one([
-    for category in data.jamfplatform_security_cloud_content_categories.all.content_categories :
-    category.display_name if category.display_name == "Business & Industry"
-  ])
-
   nearest_data_center = one([
     for gateway in data.jamfplatform_security_cloud_ztna_shared_gateways.all.shared_gateways :
     gateway.id if gateway.name == "Nearest Data Center"
@@ -54,8 +62,11 @@ locals {
 }
 
 resource "jamfplatform_security_cloud_ztna_app" "wiki" {
-  name     = "Engineering Wiki"
-  category = local.business_category
+  name = "Engineering Wiki"
+
+  # Matched on the category's display name, so the spelling has to be exact —
+  # check it against the content_categories data source above.
+  category = "Business & Industry"
 
   # Traffic matching. A wildcard may replace the whole leading label, and entries
   # must be mutually exclusive — "*.wiki.example.com" already covers a subdomain
@@ -113,7 +124,9 @@ resource "jamfplatform_security_cloud_ztna_app" "github" {
   routing = {
     traffic_routing = "Encrypt and route via ZTNA"
     routing_mode    = "Standard"
-    gateway_id      = local.nearest_data_center
+
+    # Declared in the end-to-end example above.
+    gateway_id = local.nearest_data_center
   }
 }
 ```
@@ -135,6 +148,9 @@ resource "jamfplatform_security_cloud_dns_zone" "internal" {
   domains = ["example.corp", "*.example.corp"]
 
   # Each name server is paired with the gateway it is reachable through.
+  # local.nearest_data_center comes from the locals block in the end-to-end
+  # example above, and is the shared egress — a name server on your own network
+  # is not reachable through it and needs a dedicated gateway instead.
   authoritative_name_servers = [
     { ip_address = "203.0.113.53", gateway_id = local.nearest_data_center },
     { ip_address = "203.0.113.54", gateway_id = local.nearest_data_center },
@@ -145,7 +161,7 @@ resource "jamfplatform_security_cloud_dns_zone" "internal" {
 Queries matching the zone's domains go to one of its name servers by pseudo-random load balancing. Four rules here are Jamf's, not the provider's, and each one is a plan that applies and then fails to work:
 
 - A **domain belongs to exactly one zone**, tenant-wide, and a name server IP address may appear only once per zone.
-- The name server has to be reachable **through the gateway you name**, and **its address must be publicly routable**. Jamf Security Cloud refuses a reserved address — private, loopback and similar — with `Name server IP address not allowed`. Jamf's own documentation attaches that restriction to the shared "Nearest Data Center" egress, but a dedicated *internet* gateway refuses a private address just the same, so do not plan on one lifting the rule. A name server on an internal address needs a gateway that actually reaches your network, which means the IPsec form below.
+- The name server has to be reachable **through the gateway you name**, and **its address must not be in a reserved range** — Jamf Security Cloud refuses a private or loopback address with `Name server IP address not allowed`. Not every unrouted address is refused: a documentation range such as `203.0.113.0/24` is accepted, which is why the example above uses one. Jamf's own documentation attaches the restriction to the shared "Nearest Data Center" egress, but a dedicated *internet* gateway refuses a private address just the same, so do not plan on one lifting the rule. A name server on an internal address needs a gateway that actually reaches your network, which means the IPsec form below.
 - Reverse lookups work by adding the `.in-addr.arpa` and `.ipv6.arpa` domains to the zone.
 - **Changes to your own infrastructure need the zone changed too** — a new or renumbered name server, or an application on a domain the zone does not match.
 
@@ -171,7 +187,9 @@ resource "jamfplatform_security_cloud_ztna_gateway" "frankfurt" {
   }
 
   # Omitted here, so this is a dedicated internet gateway. Adding or removing the
-  # block replaces the gateway — see "Immutable forms" below.
+  # block replaces the gateway — see "Immutable forms" below. The full IPsec form,
+  # with its jamf_side and customer_side blocks, is on the
+  # jamfplatform_security_cloud_ztna_gateway resource page.
   # ipsec = { ... }
 }
 ```
@@ -248,6 +266,12 @@ Three resources are one-per-tenant, and each behaves slightly differently when y
 - `dns_hostname_mappings` — owns the **whole set**; destroying it removes every mapping, and any mapping added outside Terraform is removed on the next apply.
 - `uem_connect` — creating a second is refused, so **import** where one already exists rather than declaring a new one.
 
+The integration's ID is not a value anyone would have written down, so read it off the data source — `data "jamfplatform_security_cloud_uem_connect" "existing" {}` reports it as `id` — or let `terraform query -generate-config-out=uem_connect.tf` write the import block for you from the list resource:
+
+```shell
+terraform import jamfplatform_security_cloud_uem_connect.jamf_pro 6a91b958619ef153a5a63d72
+```
+
 Declare each of them once. A second instance of any of them in one configuration will fight itself on every apply.
 
 ## Immutable forms
@@ -303,7 +327,7 @@ action "jamfplatform_security_cloud_uem_connect_synchronize" "now" {
 }
 ```
 
-Jamf Security Cloud does not check that either side of a mapping exists, so a wrong group number is accepted and simply never matches. Declaring `group_membership_mapping` at all replaces what it does not mention — an omitted or empty `mappings` clears every mapping.
+Jamf Security Cloud does not check that either side of a mapping exists, so a wrong group number is accepted and simply never matches. The group configuration is replaced wholesale on every apply, so there is no way to leave it unmanaged: declaring `group_membership_mapping` replaces what it does not mention — an omitted or empty `mappings` clears every mapping — and **omitting the block entirely resets the whole group configuration to its defaults**. Manage it, or expect it cleared.
 
 Importing an existing integration has one wrinkle worth knowing in advance: `user_data_field_mapping` and `group_membership_mapping` are captured from the tenant even though your configuration may not declare them, so run `terraform plan` straight after the import and write in what the plan shows you rather than letting the next apply clear them.
 
@@ -329,7 +353,7 @@ Jamf Security Cloud is reached under **either** scope: set `environment_id` (pre
 
 Two things about authorisation are specific to this namespace:
 
-- **Entitlement is not authentication.** A valid API integration can still be refused with `403 NOT_ENTITLED` when the tenant does not hold the product behind the construct — dedicated gateways, for instance, are a paid add-on. The provider translates that into a named diagnostic rather than surfacing the raw error.
+- **Entitlement is not authentication.** A valid API integration can still be refused with `403 NOT_ENTITLED` when the tenant does not hold the product behind the construct — dedicated gateways, for instance, are a paid add-on. Every resource and action translates that into a named diagnostic; the three read-only catalogues — `..._content_categories`, `..._ztna_predefined_apps` and `..._ztna_shared_gateways` — surface the raw error instead.
 - **Permissions are per construct**, granted in Jamf Account's permission picker. Each resource, data source and action page carries its own table naming the category, the row and the boxes to tick; the capabilities across this namespace are `ztna`, `device-groups`, `content-categories`, `custom-hostname-mappings`, `search-domains` and `uem-connect`.
 
 ## Further reading

--- a/templates/guides/security-cloud.md
+++ b/templates/guides/security-cloud.md
@@ -6,9 +6,17 @@ description: |-
 
 # Jamf Security Cloud
 
-Jamf Security Cloud is the portal at [radar.jamf.com](https://radar.jamf.com) where content controls, network security and Zero Trust Network Access are configured. Jamf's own documentation is split across two guides, and both are worth having open: the [Jamf Security Cloud Portal Setup Guide](https://learn.jamf.com/r/en-US/jamf-security-cloud-setup-guide/RADAR_Portal) covers device groups, activation profiles and the portal's integrations, and the [Zero Trust Network Access](https://learn.jamf.com/r/en-US/jamf-connect-documentation-current/Private_Access) section of the Jamf Connect Documentation covers access policy and gateways. See [Further reading](#further-reading) below.
+Jamf Security Cloud is the portal at [radar.jamf.com](https://radar.jamf.com) where content
+controls, network security and Zero Trust Network Access are configured. This guide is the
+Terraform half: which portal pages the provider reaches, what order to build in, and the
+behaviours that will surprise you.
 
-This guide is the Terraform half: which portal pages the provider reaches, the order things have to be created in, and the handful of behaviours that will surprise you.
+Jamf splits its own documentation across the [Portal Setup
+Guide](https://learn.jamf.com/r/en-US/jamf-security-cloud-setup-guide/RADAR_Portal) (device groups,
+activation profiles, integrations) and the [Zero Trust Network
+Access](https://learn.jamf.com/r/en-US/jamf-connect-documentation-current/Private_Access) section
+of the Jamf Connect Documentation (access policy, gateways). See [Further
+reading](#further-reading).
 
 ## What the provider manages
 
@@ -23,34 +31,45 @@ This guide is the Terraform half: which portal pages the provider reaches, the o
 | **Integrations > Custom DNS > Hostname mapping** | `jamfplatform_security_cloud_dns_hostname_mappings` (resource, data source) |
 | **Integrations > UEM Connect** | `jamfplatform_security_cloud_uem_connect` (resource, data source, list resource), `..._uem_connect_synchronize` (action) |
 
-Three things next door to this are **not** managed here. **Activation profiles** themselves are created in the portal — most of their settings cannot be edited after creation, so Jamf treats them as immutable and the provider offers only the action that deploys one to Jamf Pro. **Content filtering and network security policies** (Jamf Protect's half of the portal) have no constructs yet. And **devices** arrive by enrolling with Jamf Trust or by syncing from a UEM; nothing here enrols one.
+Three neighbouring things are **not** managed here:
+
+- **Activation profiles** are created in the portal. Most of their settings cannot be edited after
+  creation, so the provider offers only the action that deploys one to Jamf Pro.
+- **Content filtering and network security policies** — Jamf Protect's half of the portal — have no
+  constructs yet.
+- **Devices** arrive by enrolling with Jamf Trust or syncing from a UEM.
 
 ## Build it in this order
 
-The sections below are ordered for reading. A rollout goes in a different order, because each step depends on the one above it:
+The sections below are ordered for reading. A rollout goes in this order instead:
 
-1. **UEM Connect** — device inventory and group membership have to be syncing before anything downstream is accurate.
+1. **UEM Connect** — inventory and group membership have to be syncing before anything downstream
+   is accurate.
 2. **Device groups** — or map them from Jamf Pro groups in step 1.
-3. **Gateways, then custom DNS** — a zone cannot be written before the gateway its name servers name. Written the other way round, Jamf Security Cloud refuses it with `422 GATEWAY_NOT_FOUND`, and the provider reports that against `authoritative_name_servers` rather than against the zone as a whole.
-4. **Access policy** — applications reference the groups, categories and gateways above.
+3. **Gateways, then custom DNS** — a zone cannot be written before the gateway its name servers
+   name. The other way round is refused with `422 GATEWAY_NOT_FOUND`, reported against
+   `authoritative_name_servers`.
+4. **Access policy** — apps reference the groups, categories and gateways above.
 5. **Activation profile deploy** — nothing above reaches a device until this runs.
 
-Terraform derives most of that from the references between resources, so the order is yours to get right only where there is no reference to derive it from — a zone naming a gateway ID that arrived as a variable, say.
+Terraform derives most of that from the references between resources. The order is yours to get
+right only where there is no reference — a zone naming a gateway ID that arrived as a variable, say.
 
 ## End to end: publishing one enterprise app over ZTNA
 
-An entry on the **Access policy** page is what makes Jamf Security Cloud recognise traffic as belonging to an application, decide who may reach it, and route it. Two resources are enough for a public-facing app:
+An **Access policy** entry tells Jamf Security Cloud which traffic belongs to an application, who
+may reach it, and how to route it. Two resources cover a public-facing app:
 
 ```hcl
-# Who may reach it. A device group holds nothing but a name — membership is decided
-# by whatever references the group, never on the group itself.
+# A device group holds nothing but a name. Membership is decided by whatever
+# references the group, never on the group itself.
 resource "jamfplatform_security_cloud_device_group" "engineering" {
   name = "Engineering"
 }
 
-# A gateway is named by an opaque ID, so resolve it from the catalogue rather than
-# hard-coding one. A category is named by its display name, so there is nothing to
-# resolve — the content_categories data source is how you confirm a spelling.
+# A gateway is named by an opaque ID, so resolve it from the catalogue. A category
+# is named by its display name, so there is nothing to resolve — content_categories
+# is how you confirm a spelling.
 data "jamfplatform_security_cloud_content_categories" "all" {}
 data "jamfplatform_security_cloud_ztna_shared_gateways" "all" {}
 
@@ -64,29 +83,26 @@ locals {
 resource "jamfplatform_security_cloud_ztna_app" "wiki" {
   name = "Engineering Wiki"
 
-  # Matched on the category's display name, so the spelling has to be exact —
-  # check it against the content_categories data source above.
+  # Matched on display name, so the spelling has to be exact.
   category = "Business & Industry"
 
-  # Traffic matching. A wildcard may replace the whole leading label, and entries
-  # must be mutually exclusive — "*.wiki.example.com" already covers a subdomain
-  # under it, so the parent domain is listed separately.
+  # A wildcard may replace the whole leading label, and entries must be mutually
+  # exclusive — "*.wiki.example.com" does not cover "wiki.example.com", so the
+  # parent is listed separately.
   hostnames = ["wiki.example.com", "*.wiki.example.com"]
 
-  # Device group permissions.
   all_device_groups = false
   device_group_ids  = [jamfplatform_security_cloud_device_group.engineering.id]
 
-  # Application traffic routing.
   routing = {
     traffic_routing = "Encrypt and route via ZTNA"
     routing_mode    = "Standard"
     gateway_id      = local.nearest_data_center
   }
 
-  # The Security tab. A block left out is one Jamf Security Cloud keeps its own
-  # setting for; set enabled = false to lift a requirement rather than removing
-  # the block, which only stops Terraform managing it.
+  # A Security card left out is one Jamf keeps its own setting for. Set
+  # enabled = false to lift a requirement; removing the block only stops
+  # Terraform managing it.
   security = {
     managed_device = {
       enabled                   = true
@@ -103,11 +119,15 @@ resource "jamfplatform_security_cloud_ztna_app" "wiki" {
 }
 ```
 
-Two notes on that configuration that come from Jamf's own documentation rather than from Terraform. The **security requirements need a Jamf Protect licence** — they are the portal's "Access requires device to be managed / device risk validation / Jamf Trust to be enabled" cards. And the managed-device requirement is only as accurate as UEM Connect: a device counts as managed because the sync says so, which is one reason [UEM Connect](#uem-connect) comes before access policy in a real rollout.
+Two of Jamf's rules govern that `security` block. It **needs a Jamf Protect licence** — these are
+the portal's "Access requires device to be managed / device risk validation / Jamf Trust to be
+enabled" cards. And the managed-device requirement is only as accurate as UEM Connect: a device
+counts as managed because [the sync](#uem-connect) says so.
 
 ### Predefined applications
 
-An application is either **custom**, as above, or **predefined** — based on one of Jamf's own definitions, which brings its own host names with it:
+An application is either **custom**, as above, or **predefined** — built from one of Jamf's
+definitions, which brings its own host names:
 
 ```hcl
 data "jamfplatform_security_cloud_ztna_predefined_apps" "all" {}
@@ -125,19 +145,26 @@ resource "jamfplatform_security_cloud_ztna_app" "github" {
     traffic_routing = "Encrypt and route via ZTNA"
     routing_mode    = "Standard"
 
-    # Declared in the end-to-end example above.
+    # Declared in the example above.
     gateway_id = local.nearest_data_center
   }
 }
 ```
 
-A predefined application takes its name from the definition, so `name` is not accepted; `hostnames` become *additions* to the definition's own rather than a replacement for them; and only one application per definition is allowed on a tenant. The choice between the two forms is fixed — changing `predefined_app_id` in either direction replaces the application.
+A predefined application takes its name from the definition, so `name` is not accepted; `hostnames`
+are *added to* the definition's rather than replacing them; and only one application per definition
+is allowed on a tenant.
 
-Jamf draws one further line here that decides which form you need: **a predefined application requires every host name to be publicly resolvable**. An application whose names resolve only on your own network — split-brain DNS — has to be a custom application, paired with a custom DNS zone below. See [Adding a New Predefined Application](https://learn.jamf.com/r/en-US/jamf-connect-documentation-current/Adding_a_New_SaaS_Application).
+**One line decides which form you need: a predefined application requires every host name to be
+publicly resolvable.** Names that resolve only on your own network — split-brain DNS — have to be a
+custom application paired with a custom DNS zone. See [Adding a New Predefined
+Application](https://learn.jamf.com/r/en-US/jamf-connect-documentation-current/Adding_a_New_SaaS_Application).
 
 ## Reaching private applications: custom DNS
 
-An app on an internal network is not reachable just because an access policy names it. Its host names have to resolve, and public DNS will not resolve them — so Jamf Security Cloud needs a **custom DNS zone** naming your own authoritative name servers, and a gateway through which those name servers can be reached.
+An app on an internal network is not reachable just because an access policy names it — its host
+names have to resolve, and public DNS will not resolve them. That needs a **custom DNS zone**
+naming your own authoritative name servers, and a gateway those name servers are reachable through.
 
 ```hcl
 resource "jamfplatform_security_cloud_dns_zone" "internal" {
@@ -147,10 +174,9 @@ resource "jamfplatform_security_cloud_dns_zone" "internal" {
   # covers only the parent, "*.example.corp" only the subdomains.
   domains = ["example.corp", "*.example.corp"]
 
-  # Each name server is paired with the gateway it is reachable through.
-  # local.nearest_data_center comes from the locals block in the end-to-end
-  # example above, and is the shared egress — a name server on your own network
-  # is not reachable through it and needs a dedicated gateway instead.
+  # local.nearest_data_center comes from the example above and is the shared
+  # egress. A name server on your own network is not reachable through it and
+  # needs a dedicated gateway.
   authoritative_name_servers = [
     { ip_address = "203.0.113.53", gateway_id = local.nearest_data_center },
     { ip_address = "203.0.113.54", gateway_id = local.nearest_data_center },
@@ -158,22 +184,41 @@ resource "jamfplatform_security_cloud_dns_zone" "internal" {
 }
 ```
 
-Queries matching the zone's domains go to one of its name servers by pseudo-random load balancing. Four rules here are Jamf's, not the provider's, and each one is a plan that applies and then fails to work:
+Queries matching the zone's domains go to one of its name servers by pseudo-random load balancing.
+Four of Jamf's rules each produce a plan that applies and then fails to work:
 
-- A **domain belongs to exactly one zone**, tenant-wide, and a name server IP address may appear only once per zone.
-- The name server has to be reachable **through the gateway you name**, and **its address must not be in a reserved range** — Jamf Security Cloud refuses a private or loopback address with `Name server IP address not allowed`. Not every unrouted address is refused: a documentation range such as `203.0.113.0/24` is accepted, which is why the example above uses one. Jamf's own documentation attaches the restriction to the shared "Nearest Data Center" egress, but a dedicated *internet* gateway refuses a private address just the same, so do not plan on one lifting the rule. A name server on an internal address needs a gateway that actually reaches your network, which means the IPsec form below.
-- Reverse lookups work by adding the `.in-addr.arpa` and `.ipv6.arpa` domains to the zone.
-- **Changes to your own infrastructure need the zone changed too** — a new or renumbered name server, or an application on a domain the zone does not match.
+- **A domain belongs to exactly one zone**, tenant-wide, and an IP address may appear only once per
+  zone.
+- **Reserved addresses are refused** — a private or loopback name server fails with
+  `Name server IP address not allowed`. Unrouted is not the same as reserved: a documentation range
+  such as `203.0.113.0/24` is accepted, which is why the example uses one.
+- **A dedicated *internet* gateway refuses a private address too**, though Jamf's documentation
+  attaches the restriction only to the shared egress. Reaching a name server on an internal address
+  means the IPsec form below.
+- **Reverse lookups** work by adding the `.in-addr.arpa` and `.ipv6.arpa` domains, and **changes to
+  your own infrastructure need the zone changed too** — a renumbered name server, or an app on a
+  domain the zone does not match.
 
-Misconfiguring a zone cuts users off from the applications behind it, so the resource page says the same thing in stronger words. Jamf's [Configuring Custom DNS Zones](https://learn.jamf.com/r/en-US/jamf-security-cloud-setup-guide/Configuring_Custom_DNS_Zones) and [Troubleshooting Custom DNS Zones](https://learn.jamf.com/r/en-US/jamf-security-cloud-setup-guide/Troubleshooting_Custom_DNS_Zones) are the pages to read before and after.
+Misconfiguring a zone cuts users off from everything behind it. Jamf's [Configuring Custom DNS
+Zones](https://learn.jamf.com/r/en-US/jamf-security-cloud-setup-guide/Configuring_Custom_DNS_Zones)
+and [Troubleshooting Custom DNS
+Zones](https://learn.jamf.com/r/en-US/jamf-security-cloud-setup-guide/Troubleshooting_Custom_DNS_Zones)
+are the pages to read before and after.
 
 ### Gateways
 
-Three kinds of gateway can be named as a zone's `gateway_id` or an app's routing target, and only two of them are yours to create:
+Three kinds can be named as a zone's `gateway_id` or an app's routing target, and only two are
+yours to create:
 
-- **Shared gateways** are Jamf-operated and available to every entitled tenant — "Nearest Data Center", which routes through whichever data centre is closest to the device, and a set of regional shared IP pools. Read them with the `..._ztna_shared_gateways` data source; they cannot be modified, deleted, or made a member of a group.
-- A **dedicated gateway** is your own egress point, and a paid add-on. Setting the `ipsec` block builds a tunnel to your own VPN concentrator; omitting it provisions a pair of private egress IP addresses, reported back in `dedicated_egress_ip_addresses`.
-- A **grouped gateway** is a failover and routing group over two or more dedicated gateways of the *same* form — all IPsec or all internet. Shared gateways are refused as members.
+- **Shared** — Jamf-operated, available to every entitled tenant: "Nearest Data Center", which
+  routes through whichever data centre is closest to the device, plus a set of regional shared IP
+  pools. Read them with `..._ztna_shared_gateways`; they cannot be modified, deleted, or made a
+  member of a group.
+- **Dedicated** — your own egress point, and a paid add-on. An `ipsec` block builds a tunnel to your
+  VPN concentrator; omitting it provisions a pair of private egress IPs, reported in
+  `dedicated_egress_ip_addresses`.
+- **Grouped** — a failover and routing group over two or more dedicated gateways of the *same* form,
+  all IPsec or all internet. Shared gateways are refused as members.
 
 ```hcl
 resource "jamfplatform_security_cloud_ztna_gateway" "frankfurt" {
@@ -186,26 +231,30 @@ resource "jamfplatform_security_cloud_ztna_gateway" "frankfurt" {
     email = "netops@example.com"
   }
 
-  # Omitted here, so this is a dedicated internet gateway. Adding or removing the
-  # block replaces the gateway — see "Immutable forms" below. The full IPsec form,
-  # with its jamf_side and customer_side blocks, is on the
-  # jamfplatform_security_cloud_ztna_gateway resource page.
+  # Omitted, so this is a dedicated internet gateway. The full IPsec form, with
+  # its jamf_side and customer_side blocks, is on this resource's own page.
   # ipsec = { ... }
 }
 ```
 
-`tenant_ids` is mandatory and every tenant named in it must belong to the same organization as the provider's credentials. Because no API lists an environment's tenants, an environment-scoped configuration has no way to fill it in from data — supply the tenant ID as an input, or configure the provider with `tenant_id`.
+`tenant_ids` is mandatory, and every tenant in it must belong to the same organization as the
+provider's credentials. No API lists an environment's tenants, so an environment-scoped
+configuration cannot fill it in from data — supply it as an input, or configure the provider with
+`tenant_id`.
 
-A gateway reports `PENDING` the moment it is created and carries no `dedicated_egress_ip_addresses` until Jamf has finished provisioning it, so an apply completing is not the same as a gateway being usable. Changing `egress_region` later re-provisions it: connectivity drops, the status returns to `PENDING`, and the egress addresses stay stale until it settles.
+**A completed apply is not a usable gateway.** A new one reports `PENDING` and carries no
+`dedicated_egress_ip_addresses` until Jamf finishes provisioning. Changing `egress_region`
+re-provisions it: connectivity drops, status returns to `PENDING`, and the egress addresses stay
+stale until it settles.
 
 ### Short names and fixed addresses
 
-Two tenant-wide settings sit alongside the zones, both under **Custom DNS** in the portal, and both are single-instance resources:
+Two more **Custom DNS** settings, both one-per-tenant:
 
 ```hcl
-# Completes an incomplete host name for apps that only accept short names: a user
-# asking for "wiki" is directed to "wiki.example.corp". Setting this is also what
-# lets an access policy's hostnames be written as short names.
+# Completes a short host name: a user asking for "wiki" is directed to
+# "wiki.example.corp". Setting this is also what lets an access policy's
+# hostnames be written as short names.
 resource "jamfplatform_security_cloud_dns_search_domain" "corp" {
   domain_name = "example.corp"
 }
@@ -218,9 +267,9 @@ resource "jamfplatform_security_cloud_dns_hostname_mappings" "internal" {
       hostname       = "build.example.corp"
       ipv4_addresses = ["10.10.5.20"]
 
-      # Traffic vectoring. Both are required on every mapping — note that the
-      # admin UI's add dialog pre-selects Connect to ZTNA, so a mapping added
-      # there and one written here do not start from the same value.
+      # Both are required on every mapping. The admin UI's add dialog
+      # pre-selects Connect to ZTNA, so a mapping added there and one written
+      # here do not start from the same value.
       connect_to_ztna       = true
       connect_to_secure_dns = false
     },
@@ -234,57 +283,64 @@ resource "jamfplatform_security_cloud_dns_hostname_mappings" "internal" {
 }
 ```
 
-Between 1 and 500 mappings, each host name once, and at least one of `ipv4_addresses` or `ipv6_addresses` per entry. An empty `mappings` collection is not accepted: to remove them all, destroy the resource.
+Between 1 and 500 mappings, each host name once, and at least one of `ipv4_addresses` or
+`ipv6_addresses` per entry. `mappings = []` is not accepted — destroy the resource to remove them
+all. Destroying the search domain clears it for the tenant. Declare each of these once: a second
+instance of either will fight itself on every apply.
 
 ## Traffic matching is tenant-unique
 
-A host name or address range belongs to **one** application across the whole tenant. Declaring one that another application already claims is rejected at apply, which makes a rename-by-replacement land badly: Terraform creates the new application before destroying the old one, and the create is refused because the old one still holds the names. Split such a change into two applies, or use `terraform state` to move the resource rather than replacing it.
+A host name or address range belongs to **one** application across the whole tenant, and claiming
+one another application holds is rejected at apply. **That makes rename-by-replacement fail:**
+Terraform creates the new application before destroying the old one, so the create hits the old
+one's names. Split it across two applies, or move the resource with `terraform state` instead of
+replacing it.
 
-Within one tenant Jamf resolves overlaps by specificity — the most granularly defined host name wins, so `images.app.example.com` matches an application declaring it ahead of one declaring `*.example.com`, and a custom application's host name takes precedence over the same name inside a predefined definition. That is what makes the pattern Jamf recommends work: start with one wildcard application to get traffic flowing, then carve specific applications out of it without touching the wildcard. See the [Network Engineer's Guide to Jamf Connect ZTNA](https://trusted.jamf.com/docs/network-engineers-guide-to-private-access).
+Within a tenant Jamf resolves overlaps by specificity — the most granular host name wins, so
+`images.app.example.com` beats `*.example.com`, and a custom application's host name beats the same
+name inside a predefined definition. That is what makes Jamf's recommended pattern work: start with
+one wildcard application to get traffic flowing, then carve specific applications out of it without
+touching the wildcard. See the [Network Engineer's Guide to Jamf Connect
+ZTNA](https://trusted.jamf.com/docs/network-engineers-guide-to-private-access).
 
-Two further limits on `direct_ips_and_subnets`, both Jamf's: it needs the Jamf Trust app on the device, and direct-IP traffic does not appear in the access reports. Prefer host names where the application supports them.
+`direct_ips_and_subnets` carries two further limits, both Jamf's: it needs the Jamf Trust app on the
+device, and direct-IP traffic does not appear in the access reports. Prefer host names where the
+application supports them.
 
 ## Delete ordering
 
-Jamf Security Cloud enforces references on delete in three different ways, and knowing which is which saves a confusing destroy:
+Jamf enforces references on delete three different ways:
 
 | Destroying | What happens |
 |---|---|
 | A **gateway** a DNS zone, grouped gateway or app still references | Refused, naming what holds it. |
 | A **grouped gateway's member** while it is still in the group | Refused. |
-| A **device group** an app assignment or UEM mapping still names | **Succeeds silently**, and quietly drops the group from every assignment that named it — which can leave an application assigned to nobody. |
+| A **device group** an app assignment or UEM mapping still names | **Succeeds silently**, dropping the group from every assignment that named it — which can leave an application assigned to nobody. |
 
-The first has a Terraform-specific trap on top of the API's refusal. Dropping the reference *and* the gateway in a single apply does not work either, because Terraform sequences the destroy before the update that would have released the gateway — so the destroy still hits a live reference. Release it in one apply, destroy the gateway in the next.
+**The first carries a Terraform trap on top of the refusal.** Dropping the reference *and* the
+gateway in one apply does not work either, because Terraform sequences the destroy before the
+update that would have released it. Release in one apply, destroy in the next.
 
-The third is the dangerous one, because nothing fails. Check what references a device group before removing it. Note also that the built-in **Default Group** cannot be managed here at all: Jamf gives it no identifier and reserves the name. It shows up in the `..._device_groups` data source with `built_in = true` and a null `id`.
-
-## Tenant-wide singletons
-
-Three resources are one-per-tenant, and each behaves slightly differently when you destroy it:
-
-- `dns_search_domain` — destroying it clears the search domain for the tenant.
-- `dns_hostname_mappings` — owns the **whole set**; destroying it removes every mapping, and any mapping added outside Terraform is removed on the next apply.
-- `uem_connect` — creating a second is refused, so **import** where one already exists rather than declaring a new one.
-
-The integration's ID is not a value anyone would have written down, so read it off the data source — `data "jamfplatform_security_cloud_uem_connect" "existing" {}` reports it as `id` — or let `terraform query -generate-config-out=uem_connect.tf` write the import block for you from the list resource:
-
-```shell
-terraform import jamfplatform_security_cloud_uem_connect.jamf_pro 6a91b958619ef153a5a63d72
-```
-
-Declare each of them once. A second instance of any of them in one configuration will fight itself on every apply.
+**The third is the dangerous one, because nothing fails** — check what references a device group
+before removing it. The built-in **Default Group** cannot be managed here at all: Jamf gives it no
+identifier and reserves the name. It appears in `..._device_groups` with `built_in = true` and a
+null `id`.
 
 ## Immutable forms
 
-Three constructs pick a shape at create time that Jamf will not convert afterwards, so Terraform replaces the object instead:
+Three constructs pick a shape at create time that Jamf will not convert, so Terraform replaces the
+object:
 
-- A **gateway** is IPsec or internet, decided by whether the `ipsec` block is present.
+- A **gateway** is IPsec or internet, decided by whether `ipsec` is present.
 - A **ZTNA app** is predefined or custom, decided by whether `predefined_app_id` is set.
-- A **UEM Connect** integration's vendor, address and authentication method are fixed; changing any of them replaces the integration, which briefly interrupts syncing.
+- A **UEM Connect** integration's vendor, address and authentication method are fixed. Changing any
+  of them replaces the integration, briefly interrupting syncing.
 
 ## UEM Connect
 
-UEM Connect syncs device inventory and group membership from Jamf Pro into Jamf Security Cloud, and signals device risk back. It is what makes the managed-device security requirement above mean anything, and what lets you keep deciding group membership in Jamf Pro.
+UEM Connect syncs device inventory and group membership from Jamf Pro into Jamf Security Cloud and
+signals device risk back. It is what makes the managed-device requirement mean anything, and what
+lets you keep deciding group membership in Jamf Pro.
 
 ```hcl
 # The Jamf Pro tenant identifier is the one value here you cannot read off the
@@ -296,9 +352,9 @@ resource "jamfplatform_security_cloud_uem_connect" "jamf_pro" {
   enabled    = true
 
   # Prefer platform_tenant: Jamf Security Cloud creates and manages its own
-  # credentials on the named Jamf Pro tenant, so no secret is configured here.
-  # The alternative, oauth, takes the client ID and secret of an API integration
-  # you created on the Jamf Pro instance yourself, plus uem_server_url.
+  # credentials on the named tenant, so no secret is configured here. The
+  # alternative, oauth, takes the client ID and secret of an API integration you
+  # created on the Jamf Pro instance yourself, plus uem_server_url.
   platform_tenant = {
     tenant_id = data.jamfplatform_pro_tenant_id.jamf_pro.tenant_id
   }
@@ -306,13 +362,13 @@ resource "jamfplatform_security_cloud_uem_connect" "jamf_pro" {
   group_membership_mapping = {
     enabled = true
 
-    # Order matters. Jamf evaluates the list in order and a device joins the
-    # group of the first entry it matches, so put the most specific first. A
-    # device matching nothing joins the default group.
+    # Evaluated in order: a device joins the group of the first entry it
+    # matches, so put the most specific first. A device matching nothing joins
+    # the default group.
     mappings = [
       {
-        # A Jamf Pro group is written as computer_ or mobile_ followed by the
-        # group's number. This composes out of a jamfplatform_device_group:
+        # A Jamf Pro group is computer_ or mobile_ followed by its number, which
+        # composes out of a jamfplatform_device_group:
         #   "${jamfplatform_device_group.x.device_type}_${jamfplatform_device_group.x.jamf_pro_id}"
         uem_group_id            = "computer_12"
         security_cloud_group_id = jamfplatform_security_cloud_device_group.engineering.id
@@ -321,8 +377,8 @@ resource "jamfplatform_security_cloud_uem_connect" "jamf_pro" {
   }
 }
 
-# Starts a sync immediately instead of waiting for the scheduled one. Jamf runs it
-# in the background, so this returns as soon as the run has started and reports
+# Starts a sync immediately rather than waiting for the scheduled one. Jamf runs
+# it in the background, so this returns once the run has started and reports
 # nothing about what it did — read latest_sync from the data source afterwards.
 action "jamfplatform_security_cloud_uem_connect_synchronize" "now" {
   config {
@@ -331,15 +387,39 @@ action "jamfplatform_security_cloud_uem_connect_synchronize" "now" {
 }
 ```
 
-`jamfplatform_pro_tenant_id` reaches the Jamf Pro namespace, so it works under a platform environment — where it resolves the Jamf Pro tenant in that environment — and under tenant scope pointed at the Jamf Pro tenant. It does **not** work under tenant scope pointed at the Security Cloud tenant, because Jamf Pro does not answer under that scope; supply the identifier as an input there. Note this is a different identifier from a gateway's `tenant_ids` above, which names Security Cloud tenants and has no data source to read it from.
+`jamfplatform_pro_tenant_id` reaches the Jamf Pro namespace, so it works under a platform
+environment — resolving the Jamf Pro tenant in that environment — and under tenant scope pointed at
+the Jamf Pro tenant. It does **not** work under tenant scope pointed at the Security Cloud tenant,
+where Jamf Pro does not answer; supply the identifier as an input there. This is not the same
+identifier as a gateway's `tenant_ids`, which names Security Cloud tenants and has no data source
+to read.
 
-Jamf Security Cloud does not check that either side of a mapping exists, so a wrong group number is accepted and simply never matches. The group configuration is replaced wholesale on every apply, so there is no way to leave it unmanaged: declaring `group_membership_mapping` replaces what it does not mention — an omitted or empty `mappings` clears every mapping — and **omitting the block entirely resets the whole group configuration to its defaults**. Manage it, or expect it cleared.
+Jamf checks neither side of a mapping, so a wrong group number is accepted and simply never
+matches. **The group configuration is replaced wholesale on every apply, so there is no way to leave
+it unmanaged.** Declaring `group_membership_mapping` replaces what it does not mention — an omitted
+or empty `mappings` clears every mapping — and omitting the block entirely resets the whole group
+configuration to its defaults. Manage it, or expect it cleared.
 
-Importing an existing integration has one wrinkle worth knowing in advance: `user_data_field_mapping` and `group_membership_mapping` are captured from the tenant even though your configuration may not declare them, so run `terraform plan` straight after the import and write in what the plan shows you rather than letting the next apply clear them.
+A tenant holds one integration and a second create is refused, so **import** where one already
+exists. The ID is not a value anyone would have written down: read it off the data source
+(`data "jamfplatform_security_cloud_uem_connect" "existing" {}` reports it as `id`), or let
+`terraform query -generate-config-out=uem_connect.tf` write the import block from the list resource.
+
+```shell
+terraform import jamfplatform_security_cloud_uem_connect.jamf_pro 6a91b958619ef153a5a63d72
+```
+
+**Import has one wrinkle worth knowing in advance.** `user_data_field_mapping` and
+`group_membership_mapping` are captured from the tenant even though your configuration may not
+declare them. Run `terraform plan` straight afterwards and write in what it shows, rather than
+letting the next apply clear them.
 
 ## Getting the configuration onto devices
 
-Nothing above reaches a device on its own. Devices enrol with Jamf Security Cloud through an **activation profile** distributed alongside the Jamf Trust app, and the provider covers exactly one step of that: the portal's **Deploy to Jamf Pro** button, which creates the activation profile's configuration profile in Jamf Pro and scopes it.
+Nothing above reaches a device on its own. Devices enrol through an **activation profile**
+distributed alongside the Jamf Trust app, and the provider covers one step of that: the portal's
+**Deploy to Jamf Pro** button, which creates the activation profile's configuration profile in Jamf
+Pro and scopes it.
 
 ```hcl
 action "jamfplatform_security_cloud_activation_profile_deploy" "macos" {
@@ -351,28 +431,44 @@ action "jamfplatform_security_cloud_activation_profile_deploy" "macos" {
 }
 ```
 
-Three things about it. The **activation profile code** is issued by Jamf Security Cloud during activation profile setup and cannot be created or looked up from Terraform — it is the last path segment of the activation profile's deployment page — so it is an input. There is **one deployment per operating system** (`macos`, `ios_byod`, `ios_supervised`, `ios_unsupervised`), so cover more than one by invoking the action once for each, and name computer groups for `macos` and mobile device groups otherwise. And **scope only ever accumulates** — `jamf_pro_group_ids` adds groups and never removes one, and omitting it on a *first* deployment scopes the configuration profile to nothing while still reporting success. Narrow or clear a scope in Jamf Pro.
+- The **activation profile code** is issued during activation profile setup and cannot be created or
+  looked up from Terraform. It is the last path segment of the profile's deployment page, so it is
+  an input.
+- There is **one deployment per operating system** (`macos`, `ios_byod`, `ios_supervised`,
+  `ios_unsupervised`). Cover more than one by invoking the action once each, naming computer groups
+  for `macos` and mobile device groups otherwise.
+- **Scope only accumulates.** `jamf_pro_group_ids` adds groups and never removes one, and omitting
+  it on a *first* deployment scopes the profile to nothing while still reporting success. Narrow or
+  clear a scope in Jamf Pro.
 
 ## Requirements
 
-Jamf Security Cloud is reached under **either** scope: set `environment_id` (preferred) or `tenant_id` on the provider. Unlike the Platform Services constructs there is no version gate — Jamf Security Cloud is continuously deployed and a tenant can hold it without holding Jamf Pro.
+Jamf Security Cloud is reached under **either** scope: set `environment_id` (preferred) or
+`tenant_id` on the provider. There is no version gate — it is continuously deployed, and a tenant
+can hold it without holding Jamf Pro.
 
 Two things about authorisation are specific to this namespace:
 
-- **Entitlement is not authentication.** A valid API integration can still be refused with `403 NOT_ENTITLED` when the tenant does not hold the product behind the construct — dedicated gateways, for instance, are a paid add-on. Every resource and action translates that into a named diagnostic; the three read-only catalogues — `..._content_categories`, `..._ztna_predefined_apps` and `..._ztna_shared_gateways` — surface the raw error instead.
-- **Permissions are per construct**, granted in Jamf Account's permission picker. Each resource, data source and action page carries its own table naming the category, the row and the boxes to tick; the capabilities across this namespace are `ztna`, `device-groups`, `content-categories`, `custom-hostname-mappings`, `search-domains` and `uem-connect`.
+- **Entitlement is not authentication.** A valid API integration can still be refused with
+  `403 NOT_ENTITLED` when the tenant does not hold the product behind the construct — dedicated
+  gateways, for instance, are a paid add-on. Every resource and action translates that into a named
+  diagnostic; the three read-only catalogues (`..._content_categories`, `..._ztna_predefined_apps`,
+  `..._ztna_shared_gateways`) surface the raw error instead.
+- **Permissions are per construct**, granted in Jamf Account's permission picker. Every resource,
+  data source and action page carries its own table naming the category, row and boxes to tick. The
+  capabilities across this namespace are `ztna`, `device-groups`, `content-categories`,
+  `custom-hostname-mappings`, `search-domains` and `uem-connect`.
 
 ## Further reading
 
 | Topic | Page |
 |---|---|
-| The portal, end to end, in Jamf's words | [Jamf Security Cloud Portal Setup Guide](https://learn.jamf.com/r/en-US/jamf-security-cloud-setup-guide/RADAR_Portal) |
+| The portal, end to end, in Jamf's words | [Portal Setup Guide](https://learn.jamf.com/r/en-US/jamf-security-cloud-setup-guide/RADAR_Portal) |
 | What an access policy is made of | [Access Policy](https://learn.jamf.com/r/en-US/jamf-connect-documentation-current/Access_Policies) |
-| Predefined and custom applications | [Adding a New Predefined Application](https://learn.jamf.com/r/en-US/jamf-connect-documentation-current/Adding_a_New_SaaS_Application), [Adding a New Custom Application](https://learn.jamf.com/r/en-US/jamf-connect-documentation-current/Adding_a_New_Enterprise_Application) |
-| Gateway types, and what a shared gateway is | [Shared Internet Gateways](https://learn.jamf.com/r/en-US/jamf-connect-documentation-current/Internet_Cloud_Gateways), [Grouped Gateways](https://learn.jamf.com/r/en-US/jamf-connect-documentation-current/Grouped_Gateways) |
-| Grouping gateways, and the routing strategies | [Creating a Group of Gateways](https://learn.jamf.com/r/en-US/jamf-connect-documentation-current/Creating_a_Grouped_Gateway) |
-| Custom DNS zones | [DNS Zones](https://learn.jamf.com/r/en-US/jamf-security-cloud-setup-guide/Custom_DNS_Zones), [Configuring Custom DNS Zones](https://learn.jamf.com/r/en-US/jamf-security-cloud-setup-guide/Configuring_Custom_DNS_Zones), [Troubleshooting Custom DNS Zones](https://learn.jamf.com/r/en-US/jamf-security-cloud-setup-guide/Troubleshooting_Custom_DNS_Zones) |
-| UEM Connect, and its settings | [UEM Connect](https://learn.jamf.com/r/en-US/jamf-security-cloud-setup-guide/UEM_Connect_Overview), [UEM Connect Settings Reference](https://learn.jamf.com/r/en-US/jamf-security-cloud-setup-guide/UEM_Connect_Settings), [UEM Connect Integration by Vendor](https://learn.jamf.com/r/en-US/jamf-security-cloud-setup-guide/UEM_Vendor_Integration) |
-| Activation profiles | [Activation Profiles](https://learn.jamf.com/r/en-US/jamf-security-cloud-setup-guide/Activation_Profiles), [Creating an Activation Profile](https://learn.jamf.com/r/en-US/jamf-security-cloud-setup-guide/Creating_Activation_Profiles) |
+| Predefined and custom applications | [Predefined](https://learn.jamf.com/r/en-US/jamf-connect-documentation-current/Adding_a_New_SaaS_Application), [Custom](https://learn.jamf.com/r/en-US/jamf-connect-documentation-current/Adding_a_New_Enterprise_Application) |
+| Gateway types, grouping and routing strategies | [Shared Internet Gateways](https://learn.jamf.com/r/en-US/jamf-connect-documentation-current/Internet_Cloud_Gateways), [Grouped Gateways](https://learn.jamf.com/r/en-US/jamf-connect-documentation-current/Grouped_Gateways), [Creating a Group of Gateways](https://learn.jamf.com/r/en-US/jamf-connect-documentation-current/Creating_a_Grouped_Gateway) |
+| Custom DNS zones | [DNS Zones](https://learn.jamf.com/r/en-US/jamf-security-cloud-setup-guide/Custom_DNS_Zones), [Configuring](https://learn.jamf.com/r/en-US/jamf-security-cloud-setup-guide/Configuring_Custom_DNS_Zones), [Troubleshooting](https://learn.jamf.com/r/en-US/jamf-security-cloud-setup-guide/Troubleshooting_Custom_DNS_Zones) |
+| UEM Connect, and its settings | [Overview](https://learn.jamf.com/r/en-US/jamf-security-cloud-setup-guide/UEM_Connect_Overview), [Settings Reference](https://learn.jamf.com/r/en-US/jamf-security-cloud-setup-guide/UEM_Connect_Settings), [Integration by Vendor](https://learn.jamf.com/r/en-US/jamf-security-cloud-setup-guide/UEM_Vendor_Integration) |
+| Activation profiles | [Activation Profiles](https://learn.jamf.com/r/en-US/jamf-security-cloud-setup-guide/Activation_Profiles), [Creating one](https://learn.jamf.com/r/en-US/jamf-security-cloud-setup-guide/Creating_Activation_Profiles) |
 | The policies this provider does not manage yet | [Policies](https://learn.jamf.com/r/en-US/jamf-security-cloud-setup-guide/Policies) |
 | How the routing fabric actually works | [Network Engineer's Guide to Jamf Connect ZTNA](https://trusted.jamf.com/docs/network-engineers-guide-to-private-access) |

--- a/templates/guides/security-cloud.md
+++ b/templates/guides/security-cloud.md
@@ -216,7 +216,9 @@ yours to create:
   member of a group.
 - **Dedicated** — your own egress point, and a paid add-on. An `ipsec` block builds a tunnel to your
   VPN concentrator; omitting it provisions a pair of private egress IPs, reported in
-  `dedicated_egress_ip_addresses`.
+  `dedicated_egress_ip_addresses`. The IPsec form here is Jamf's **Custom IPSec** gateway; its
+  **Quick Connect** kind, a Linux VM Jamf walks you through building, cannot be expressed in
+  Terraform.
 - **Grouped** — a failover and routing group over two or more dedicated gateways of the *same* form,
   all IPsec or all internet. Shared gateways are refused as members.
 
@@ -242,14 +244,16 @@ provider's credentials. No API lists an environment's tenants, so an environment
 configuration cannot fill it in from data — supply it as an input, or configure the provider with
 `tenant_id`.
 
-**A completed apply is not a usable gateway.** A new one reports `PENDING` and settles to `UP`
-roughly four and a half minutes later. The egress addresses arrive far sooner — within seconds — so
-`dedicated_egress_ip_addresses` is populated long before the gateway carries any traffic.
+**An apply waits for the gateway to settle**, so the one that returns is a gateway you can act on.
+A dedicated internet gateway takes about five minutes to report `UP` — **Available** in the portal —
+and an `egress_region` change re-provisions it and takes about as long again. Disabling one settles
+in seconds. Without the wait a first apply would hand downstream an empty
+`dedicated_egress_ip_addresses`, and a region change would hand it the *old* region's addresses.
 
-Changing `egress_region` re-provisions it: connectivity drops and the status returns to `PENDING`.
-For about half a minute the attribute still holds the **old** region's addresses, then the new ones
-replace them in place — it never empties, so a value read during that window is plausible and wrong.
-Both timings come from a single EU measurement; treat them as orders of magnitude.
+Creating an **IPsec** gateway is the exception: it settles at `DOWN`, because the tunnel's far end is
+configured from values the create returns, so it cannot be up yet. Build your side and the status
+reaches `UP` on a later refresh. If any wait runs out the apply still succeeds, with a warning naming
+the status reached; raise `create` or `update` in the `timeouts` block to wait longer.
 
 ### Short names and fixed addresses
 

--- a/templates/guides/security-cloud.md
+++ b/templates/guides/security-cloud.md
@@ -242,10 +242,14 @@ provider's credentials. No API lists an environment's tenants, so an environment
 configuration cannot fill it in from data — supply it as an input, or configure the provider with
 `tenant_id`.
 
-**A completed apply is not a usable gateway.** A new one reports `PENDING` and carries no
-`dedicated_egress_ip_addresses` until Jamf finishes provisioning. Changing `egress_region`
-re-provisions it: connectivity drops, status returns to `PENDING`, and the egress addresses stay
-stale until it settles.
+**A completed apply is not a usable gateway.** A new one reports `PENDING` and settles to `UP`
+roughly four and a half minutes later. The egress addresses arrive far sooner — within seconds — so
+`dedicated_egress_ip_addresses` is populated long before the gateway carries any traffic.
+
+Changing `egress_region` re-provisions it: connectivity drops and the status returns to `PENDING`.
+For about half a minute the attribute still holds the **old** region's addresses, then the new ones
+replace them in place — it never empties, so a value read during that window is plausible and wrong.
+Both timings come from a single EU measurement; treat them as orders of magnitude.
 
 ### Short names and fixed addresses
 

--- a/templates/guides/security-cloud.md
+++ b/templates/guides/security-cloud.md
@@ -1,0 +1,344 @@
+---
+page_title: "Jamf Security Cloud"
+description: |-
+  Manage Jamf Security Cloud from Terraform — ZTNA access policy, access gateways, custom DNS, device groups and the UEM Connect integration.
+---
+
+# Jamf Security Cloud
+
+Jamf Security Cloud is the portal at [radar.jamf.com](https://radar.jamf.com) where content controls, network security and Zero Trust Network Access are configured. Jamf's own documentation is split across two guides, and both are worth having open: the [Jamf Security Cloud Portal Setup Guide](https://learn.jamf.com/r/en-US/jamf-security-cloud-setup-guide/RADAR_Portal) covers device groups, activation profiles and the portal's integrations, and the [Zero Trust Network Access](https://learn.jamf.com/r/en-US/jamf-connect-documentation-current/Private_Access) section of the Jamf Connect Documentation covers access policy and gateways. See [Further reading](#further-reading) below.
+
+This guide is the Terraform half: which portal pages the provider reaches, the order things have to be created in, and the handful of behaviours that will surprise you.
+
+## What the provider manages
+
+| In the portal | Constructs |
+|---|---|
+| **Devices > Device groups** | `jamfplatform_security_cloud_device_group` (resource, data source, list resource), `..._device_groups` |
+| **Devices > Activation profiles > Deployment** | `jamfplatform_security_cloud_activation_profile_deploy` (action) |
+| **Policies > Access > Access policy** | `jamfplatform_security_cloud_ztna_app`, `..._ztna_predefined_apps`, `..._content_categories` |
+| **Integrations > Access gateways** | `jamfplatform_security_cloud_ztna_gateway`, `..._ztna_grouped_gateway`, `..._ztna_shared_gateways` |
+| **Integrations > Custom DNS > DNS zones** | `jamfplatform_security_cloud_dns_zone` |
+| **Integrations > Custom DNS > Search domain** | `jamfplatform_security_cloud_dns_search_domain` |
+| **Integrations > Custom DNS > Hostname mapping** | `jamfplatform_security_cloud_dns_hostname_mappings` |
+| **Integrations > UEM Connect** | `jamfplatform_security_cloud_uem_connect`, `..._uem_connect_synchronize` (action) |
+
+Three things next door to this are **not** managed here. **Activation profiles** themselves are created in the portal — most of their settings cannot be edited after creation, so Jamf treats them as immutable and the provider offers only the action that deploys one to Jamf Pro. **Content filtering and network security policies** (Jamf Protect's half of the portal) have no constructs yet. And **devices** arrive by enrolling with Jamf Trust or by syncing from a UEM; nothing here enrols one.
+
+## End to end: publishing one enterprise app over ZTNA
+
+An entry on the **Access policy** page is what makes Jamf Security Cloud recognise traffic as belonging to an application, decide who may reach it, and route it. Two resources are enough for a public-facing app:
+
+```hcl
+# Who may reach it. A device group holds nothing but a name — membership is decided
+# by whatever references the group, never on the group itself.
+resource "jamfplatform_security_cloud_device_group" "engineering" {
+  name = "Engineering"
+}
+
+# Categories and gateways are both Jamf-maintained catalogues, so resolve them
+# rather than hard-coding an ID or guessing a category's spelling.
+data "jamfplatform_security_cloud_content_categories" "all" {}
+data "jamfplatform_security_cloud_ztna_shared_gateways" "all" {}
+
+locals {
+  business_category = one([
+    for category in data.jamfplatform_security_cloud_content_categories.all.content_categories :
+    category.display_name if category.display_name == "Business & Industry"
+  ])
+
+  nearest_data_center = one([
+    for gateway in data.jamfplatform_security_cloud_ztna_shared_gateways.all.shared_gateways :
+    gateway.id if gateway.name == "Nearest Data Center"
+  ])
+}
+
+resource "jamfplatform_security_cloud_ztna_app" "wiki" {
+  name     = "Engineering Wiki"
+  category = local.business_category
+
+  # Traffic matching. A wildcard may replace the whole leading label, and entries
+  # must be mutually exclusive — "*.wiki.example.com" already covers a subdomain
+  # under it, so the parent domain is listed separately.
+  hostnames = ["wiki.example.com", "*.wiki.example.com"]
+
+  # Device group permissions.
+  all_device_groups = false
+  device_group_ids  = [jamfplatform_security_cloud_device_group.engineering.id]
+
+  # Application traffic routing.
+  routing = {
+    traffic_routing = "Encrypt and route via ZTNA"
+    routing_mode    = "Standard"
+    gateway_id      = local.nearest_data_center
+  }
+
+  # The Security tab. A block left out is one Jamf Security Cloud keeps its own
+  # setting for; set enabled = false to lift a requirement rather than removing
+  # the block, which only stops Terraform managing it.
+  security = {
+    managed_device = {
+      enabled                   = true
+      device_push_notifications = true
+    }
+    device_risk = {
+      enabled            = true
+      deny_at_risk_level = "High"
+    }
+    jamf_trust = {
+      enabled = true
+    }
+  }
+}
+```
+
+Two notes on that configuration that come from Jamf's own documentation rather than from Terraform. The **security requirements need a Jamf Protect licence** — they are the portal's "Access requires device to be managed / device risk validation / Jamf Trust to be enabled" cards. And the managed-device requirement is only as accurate as UEM Connect: a device counts as managed because the sync says so, which is one reason [UEM Connect](#uem-connect) comes before access policy in a real rollout.
+
+### Predefined applications
+
+An application is either **custom**, as above, or **predefined** — based on one of Jamf's own definitions, which brings its own host names with it:
+
+```hcl
+data "jamfplatform_security_cloud_ztna_predefined_apps" "all" {}
+
+resource "jamfplatform_security_cloud_ztna_app" "github" {
+  predefined_app_id = one([
+    for app in data.jamfplatform_security_cloud_ztna_predefined_apps.all.predefined_apps :
+    app.id if app.name == "GitHub"
+  ])
+
+  category          = "Communication"
+  all_device_groups = true
+
+  routing = {
+    traffic_routing = "Encrypt and route via ZTNA"
+    routing_mode    = "Standard"
+    gateway_id      = local.nearest_data_center
+  }
+}
+```
+
+A predefined application takes its name from the definition, so `name` is not accepted; `hostnames` become *additions* to the definition's own rather than a replacement for them; and only one application per definition is allowed on a tenant. The choice between the two forms is fixed — changing `predefined_app_id` in either direction replaces the application.
+
+Jamf draws one further line here that decides which form you need: **a predefined application requires every host name to be publicly resolvable**. An application whose names resolve only on your own network — split-brain DNS — has to be a custom application, paired with a custom DNS zone below. See [Adding a New Predefined Application](https://learn.jamf.com/r/en-US/jamf-connect-documentation-current/Adding_a_New_SaaS_Application).
+
+## Reaching private applications: custom DNS
+
+An app on an internal network is not reachable just because an access policy names it. Its host names have to resolve, and public DNS will not resolve them — so Jamf Security Cloud needs a **custom DNS zone** naming your own authoritative name servers, and a gateway through which those name servers can be reached.
+
+```hcl
+resource "jamfplatform_security_cloud_dns_zone" "internal" {
+  name = "Corp internal"
+
+  # A parent domain and its subdomains are separate entries: "example.corp"
+  # covers only the parent, "*.example.corp" only the subdomains.
+  domains = ["example.corp", "*.example.corp"]
+
+  # Each name server is paired with the gateway it is reachable through.
+  authoritative_name_servers = [
+    { ip_address = "203.0.113.53", gateway_id = local.nearest_data_center },
+    { ip_address = "203.0.113.54", gateway_id = local.nearest_data_center },
+  ]
+}
+```
+
+Queries matching the zone's domains go to one of its name servers by pseudo-random load balancing. Four rules here are Jamf's, not the provider's, and each one is a plan that applies and then fails to work:
+
+- A **domain belongs to exactly one zone**, tenant-wide, and a name server IP address may appear only once per zone.
+- The name server has to be reachable **through the gateway you name**, and **its address must be publicly routable when that gateway is shared**. Jamf Security Cloud refuses a reserved address — private, loopback and similar — behind the shared "Nearest Data Center" egress. A name server on an internal address needs a gateway of your own that reaches your network, which is what the dedicated gateways below are for.
+- Reverse lookups work by adding the `.in-addr.arpa` and `.ipv6.arpa` domains to the zone.
+- **Changes to your own infrastructure need the zone changed too** — a new or renumbered name server, or an application on a domain the zone does not match.
+
+Misconfiguring a zone cuts users off from the applications behind it, so the resource page says the same thing in stronger words. Jamf's [Configuring Custom DNS Zones](https://learn.jamf.com/r/en-US/jamf-security-cloud-setup-guide/Configuring_Custom_DNS_Zones) and [Troubleshooting Custom DNS Zones](https://learn.jamf.com/r/en-US/jamf-security-cloud-setup-guide/Troubleshooting_Custom_DNS_Zones) are the pages to read before and after.
+
+### Gateways
+
+Three kinds of gateway can be named as a zone's `gateway_id` or an app's routing target, and only two of them are yours to create:
+
+- **Shared gateways** are Jamf-operated and available to every entitled tenant — "Nearest Data Center", which routes through whichever data centre is closest to the device, and a set of regional shared IP pools. Read them with the `..._ztna_shared_gateways` data source; they cannot be modified, deleted, or made a member of a group.
+- A **dedicated gateway** is your own egress point, and a paid add-on. Setting the `ipsec` block builds a tunnel to your own VPN concentrator; omitting it provisions a pair of private egress IP addresses, reported back in `dedicated_egress_ip_addresses`.
+- A **grouped gateway** is a failover and routing group over two or more dedicated gateways of the *same* form — all IPsec or all internet. Shared gateways are refused as members.
+
+```hcl
+resource "jamfplatform_security_cloud_ztna_gateway" "frankfurt" {
+  name          = "Frankfurt DC"
+  egress_region = "Europe - Germany"
+  tenant_ids    = [var.security_cloud_tenant_id]
+
+  contact = {
+    name  = "Network Operations"
+    email = "netops@example.com"
+  }
+
+  # Omitted here, so this is a dedicated internet gateway. Adding or removing the
+  # block replaces the gateway — see "Immutable forms" below.
+  # ipsec = { ... }
+}
+```
+
+`tenant_ids` is mandatory and every tenant named in it must belong to the same organization as the provider's credentials. Because no API lists an environment's tenants, an environment-scoped configuration has no way to fill it in from data — supply the tenant ID as an input, or configure the provider with `tenant_id`.
+
+### Short names and fixed addresses
+
+Two tenant-wide settings sit alongside the zones, both under **Custom DNS** in the portal, and both are single-instance resources:
+
+```hcl
+# Completes an incomplete host name for apps that only accept short names: a user
+# asking for "wiki" is directed to "wiki.example.corp". Setting this is also what
+# lets an access policy's hostnames be written as short names.
+resource "jamfplatform_security_cloud_dns_search_domain" "corp" {
+  domain_name = "example.corp"
+}
+
+# Fixed answers for internal host names. This resource owns the tenant's ENTIRE
+# set: a mapping added elsewhere and absent here is removed on the next apply.
+resource "jamfplatform_security_cloud_dns_hostname_mappings" "internal" {
+  mappings = [
+    {
+      hostname       = "build.example.corp"
+      ipv4_addresses = ["10.10.5.20"]
+
+      # Traffic vectoring. Both are required on every mapping — note that the
+      # admin UI's add dialog pre-selects Connect to ZTNA, so a mapping added
+      # there and one written here do not start from the same value.
+      connect_to_ztna       = true
+      connect_to_secure_dns = false
+    },
+    {
+      hostname              = "artifacts.example.corp"
+      ipv4_addresses        = ["10.10.5.21"]
+      connect_to_ztna       = true
+      connect_to_secure_dns = false
+    },
+  ]
+}
+```
+
+Between 1 and 500 mappings, each host name once, and at least one of `ipv4_addresses` or `ipv6_addresses` per entry. An empty `mappings` collection is not accepted: to remove them all, destroy the resource.
+
+## Traffic matching is tenant-unique
+
+A host name or address range belongs to **one** application across the whole tenant. Declaring one that another application already claims is rejected at apply, which makes a rename-by-replacement land badly: Terraform creates the new application before destroying the old one, and the create is refused because the old one still holds the names. Split such a change into two applies, or use `terraform state` to move the resource rather than replacing it.
+
+Within one tenant Jamf resolves overlaps by specificity — the most granularly defined host name wins, so `images.app.example.com` matches an application declaring it ahead of one declaring `*.example.com`, and a custom application's host name takes precedence over the same name inside a predefined definition. That is what makes the pattern Jamf recommends work: start with one wildcard application to get traffic flowing, then carve specific applications out of it without touching the wildcard. See the [Network Engineer's Guide to Jamf Connect ZTNA](https://trusted.jamf.com/docs/network-engineers-guide-to-private-access).
+
+Two further limits on `direct_ips_and_subnets`, both Jamf's: it needs the Jamf Trust app on the device, and direct-IP traffic does not appear in the access reports. Prefer host names where the application supports them.
+
+## Delete ordering
+
+Jamf Security Cloud enforces references on delete in three different ways, and knowing which is which saves a confusing destroy:
+
+| Destroying | What happens |
+|---|---|
+| A **gateway** a DNS zone, grouped gateway or app still references | Refused. Drop the reference in an earlier apply. |
+| A **grouped gateway's member** while it is still in the group | Refused. |
+| A **device group** an app assignment or UEM mapping still names | **Succeeds silently**, and quietly drops the group from every assignment that named it — which can leave an application assigned to nobody. |
+
+The third is the dangerous one, because nothing fails. Check what references a device group before removing it. Note also that the built-in **Default Group** cannot be managed here at all: Jamf gives it no identifier and reserves the name. It shows up in the `..._device_groups` data source with `built_in = true` and a null `id`.
+
+## Tenant-wide singletons
+
+Three resources are one-per-tenant, and each behaves slightly differently when you destroy it:
+
+- `dns_search_domain` — destroying it clears the search domain for the tenant.
+- `dns_hostname_mappings` — owns the **whole set**; destroying it removes every mapping, and any mapping added outside Terraform is removed on the next apply.
+- `uem_connect` — creating a second is refused, so **import** where one already exists rather than declaring a new one.
+
+Declare each of them once. A second instance of any of them in one configuration will fight itself on every apply.
+
+## Immutable forms
+
+Three constructs pick a shape at create time that Jamf will not convert afterwards, so Terraform replaces the object instead:
+
+- A **gateway** is IPsec or internet, decided by whether the `ipsec` block is present.
+- A **ZTNA app** is predefined or custom, decided by whether `predefined_app_id` is set.
+- A **UEM Connect** integration's vendor, address and authentication method are fixed; changing any of them replaces the integration, which briefly interrupts syncing.
+
+## UEM Connect
+
+UEM Connect syncs device inventory and group membership from Jamf Pro into Jamf Security Cloud, and signals device risk back. It is what makes the managed-device security requirement above mean anything, and what lets you keep deciding group membership in Jamf Pro.
+
+```hcl
+resource "jamfplatform_security_cloud_uem_connect" "jamf_pro" {
+  uem_vendor = "JAMF_PRO"
+  enabled    = true
+
+  # Prefer platform_tenant: Jamf Security Cloud creates and manages its own
+  # credentials on the named Jamf Pro tenant, so no secret is configured here.
+  # The alternative, oauth, takes the client ID and secret of an API integration
+  # you created on the Jamf Pro instance yourself, plus uem_server_url.
+  platform_tenant = {
+    tenant_id = var.jamf_pro_tenant_id
+  }
+
+  group_membership_mapping = {
+    enabled = true
+
+    # Order matters. Jamf evaluates the list in order and a device joins the
+    # group of the first entry it matches, so put the most specific first. A
+    # device matching nothing joins the default group.
+    mappings = [
+      {
+        # A Jamf Pro group is written as computer_ or mobile_ followed by the
+        # group's number. This composes out of a jamfplatform_device_group:
+        #   "${jamfplatform_device_group.x.device_type}_${jamfplatform_device_group.x.jamf_pro_id}"
+        uem_group_id            = "computer_12"
+        security_cloud_group_id = jamfplatform_security_cloud_device_group.engineering.id
+      },
+    ]
+  }
+}
+
+# Starts a sync immediately instead of waiting for the scheduled one. Jamf runs it
+# in the background, so this returns as soon as the run has started and reports
+# nothing about what it did — read latest_sync from the data source afterwards.
+action "jamfplatform_security_cloud_uem_connect_synchronize" "now" {
+  config {
+    uem_connect_id = jamfplatform_security_cloud_uem_connect.jamf_pro.id
+  }
+}
+```
+
+Jamf Security Cloud does not check that either side of a mapping exists, so a wrong group number is accepted and simply never matches. Declaring `group_membership_mapping` at all replaces what it does not mention — an omitted or empty `mappings` clears every mapping.
+
+Importing an existing integration has one wrinkle worth knowing in advance: `user_data_field_mapping` and `group_membership_mapping` are captured from the tenant even though your configuration may not declare them, so run `terraform plan` straight after the import and write in what the plan shows you rather than letting the next apply clear them.
+
+## Getting the configuration onto devices
+
+Nothing above reaches a device on its own. Devices enrol with Jamf Security Cloud through an **activation profile** distributed alongside the Jamf Trust app, and the provider covers exactly one step of that: the portal's **Deploy to Jamf Pro** button, which creates the activation profile's configuration profile in Jamf Pro and scopes it.
+
+```hcl
+action "jamfplatform_security_cloud_activation_profile_deploy" "macos" {
+  config {
+    activation_profile_code = var.activation_profile_code
+    os                      = "macos"
+    jamf_pro_group_ids      = ["1", "2"]
+  }
+}
+```
+
+Three things about it. The **activation profile code** is issued by Jamf Security Cloud during activation profile setup and cannot be created or looked up from Terraform — it is the last path segment of the activation profile's deployment page — so it is an input. There is **one deployment per operating system** (`macos`, `ios_byod`, `ios_supervised`, `ios_unsupervised`), so cover more than one by invoking the action once for each, and name computer groups for `macos` and mobile device groups otherwise. And **scope only ever accumulates** — `jamf_pro_group_ids` adds groups and never removes one, and omitting it on a *first* deployment scopes the configuration profile to nothing while still reporting success. Narrow or clear a scope in Jamf Pro.
+
+## Requirements
+
+Jamf Security Cloud is reached under **either** scope: set `environment_id` (preferred) or `tenant_id` on the provider. Unlike the Platform Services constructs there is no version gate — Jamf Security Cloud is continuously deployed and a tenant can hold it without holding Jamf Pro.
+
+Two things about authorisation are specific to this namespace:
+
+- **Entitlement is not authentication.** A valid API integration can still be refused with `403 NOT_ENTITLED` when the tenant does not hold the product behind the construct — dedicated gateways, for instance, are a paid add-on. The provider translates that into a named diagnostic rather than surfacing the raw error.
+- **Permissions are per construct**, granted in Jamf Account's permission picker. Each resource, data source and action page carries its own table naming the category, the row and the boxes to tick; the capabilities across this namespace are `ztna`, `device-groups`, `content-categories`, `custom-hostname-mappings`, `search-domains` and `uem-connect`.
+
+## Further reading
+
+| Topic | Page |
+|---|---|
+| The portal, end to end, in Jamf's words | [Jamf Security Cloud Portal Setup Guide](https://learn.jamf.com/r/en-US/jamf-security-cloud-setup-guide/RADAR_Portal) |
+| What an access policy is made of | [Access Policy](https://learn.jamf.com/r/en-US/jamf-connect-documentation-current/Access_Policies) |
+| Predefined and custom applications | [Adding a New Predefined Application](https://learn.jamf.com/r/en-US/jamf-connect-documentation-current/Adding_a_New_SaaS_Application), [Adding a New Custom Application](https://learn.jamf.com/r/en-US/jamf-connect-documentation-current/Adding_a_New_Enterprise_Application) |
+| Gateway types, and what a shared gateway is | [Shared Internet Gateways](https://learn.jamf.com/r/en-US/jamf-connect-documentation-current/Internet_Cloud_Gateways), [Grouped Gateways](https://learn.jamf.com/r/en-US/jamf-connect-documentation-current/Grouped_Gateways) |
+| Grouping gateways, and the routing strategies | [Creating a Group of Gateways](https://learn.jamf.com/r/en-US/jamf-connect-documentation-current/Creating_a_Grouped_Gateway) |
+| Custom DNS zones | [DNS Zones](https://learn.jamf.com/r/en-US/jamf-security-cloud-setup-guide/Custom_DNS_Zones), [Configuring Custom DNS Zones](https://learn.jamf.com/r/en-US/jamf-security-cloud-setup-guide/Configuring_Custom_DNS_Zones), [Troubleshooting Custom DNS Zones](https://learn.jamf.com/r/en-US/jamf-security-cloud-setup-guide/Troubleshooting_Custom_DNS_Zones) |
+| UEM Connect, and its settings | [UEM Connect](https://learn.jamf.com/r/en-US/jamf-security-cloud-setup-guide/UEM_Connect_Overview), [UEM Connect Settings Reference](https://learn.jamf.com/r/en-US/jamf-security-cloud-setup-guide/UEM_Connect_Settings), [UEM Connect Integration by Vendor](https://learn.jamf.com/r/en-US/jamf-security-cloud-setup-guide/UEM_Vendor_Integration) |
+| Activation profiles | [Activation Profiles](https://learn.jamf.com/r/en-US/jamf-security-cloud-setup-guide/Activation_Profiles), [Creating an Activation Profile](https://learn.jamf.com/r/en-US/jamf-security-cloud-setup-guide/Creating_Activation_Profiles) |
+| The policies this provider does not manage yet | [Policies](https://learn.jamf.com/r/en-US/jamf-security-cloud-setup-guide/Policies) |
+| How the routing fabric actually works | [Network Engineer's Guide to Jamf Connect ZTNA](https://trusted.jamf.com/docs/network-engineers-guide-to-private-access) |

--- a/templates/guides/security-cloud.md
+++ b/templates/guides/security-cloud.md
@@ -287,6 +287,10 @@ Three constructs pick a shape at create time that Jamf will not convert afterwar
 UEM Connect syncs device inventory and group membership from Jamf Pro into Jamf Security Cloud, and signals device risk back. It is what makes the managed-device security requirement above mean anything, and what lets you keep deciding group membership in Jamf Pro.
 
 ```hcl
+# The Jamf Pro tenant identifier is the one value here you cannot read off the
+# UEM Connect screen, so read it rather than copying it between consoles.
+data "jamfplatform_pro_tenant_id" "jamf_pro" {}
+
 resource "jamfplatform_security_cloud_uem_connect" "jamf_pro" {
   uem_vendor = "JAMF_PRO"
   enabled    = true
@@ -296,7 +300,7 @@ resource "jamfplatform_security_cloud_uem_connect" "jamf_pro" {
   # The alternative, oauth, takes the client ID and secret of an API integration
   # you created on the Jamf Pro instance yourself, plus uem_server_url.
   platform_tenant = {
-    tenant_id = var.jamf_pro_tenant_id
+    tenant_id = data.jamfplatform_pro_tenant_id.jamf_pro.tenant_id
   }
 
   group_membership_mapping = {
@@ -326,6 +330,8 @@ action "jamfplatform_security_cloud_uem_connect_synchronize" "now" {
   }
 }
 ```
+
+`jamfplatform_pro_tenant_id` reaches the Jamf Pro namespace, so it works under a platform environment — where it resolves the Jamf Pro tenant in that environment — and under tenant scope pointed at the Jamf Pro tenant. It does **not** work under tenant scope pointed at the Security Cloud tenant, because Jamf Pro does not answer under that scope; supply the identifier as an input there. Note this is a different identifier from a gateway's `tenant_ids` above, which names Security Cloud tenants and has no data source to read it from.
 
 Jamf Security Cloud does not check that either side of a mapping exists, so a wrong group number is accepted and simply never matches. The group configuration is replaced wholesale on every apply, so there is no way to leave it unmanaged: declaring `group_membership_mapping` replaces what it does not mention — an omitted or empty `mappings` clears every mapping — and **omitting the block entirely resets the whole group configuration to its defaults**. Manage it, or expect it cleared.
 

--- a/templates/guides/security-cloud.md
+++ b/templates/guides/security-cloud.md
@@ -145,7 +145,7 @@ resource "jamfplatform_security_cloud_dns_zone" "internal" {
 Queries matching the zone's domains go to one of its name servers by pseudo-random load balancing. Four rules here are Jamf's, not the provider's, and each one is a plan that applies and then fails to work:
 
 - A **domain belongs to exactly one zone**, tenant-wide, and a name server IP address may appear only once per zone.
-- The name server has to be reachable **through the gateway you name**, and **its address must be publicly routable when that gateway is shared**. Jamf Security Cloud refuses a reserved address — private, loopback and similar — behind the shared "Nearest Data Center" egress. A name server on an internal address needs a gateway of your own that reaches your network, which is what the dedicated gateways below are for.
+- The name server has to be reachable **through the gateway you name**, and **its address must be publicly routable**. Jamf Security Cloud refuses a reserved address — private, loopback and similar — with `Name server IP address not allowed`. Jamf's own documentation attaches that restriction to the shared "Nearest Data Center" egress, but a dedicated *internet* gateway refuses a private address just the same, so do not plan on one lifting the rule. A name server on an internal address needs a gateway that actually reaches your network, which means the IPsec form below.
 - Reverse lookups work by adding the `.in-addr.arpa` and `.ipv6.arpa` domains to the zone.
 - **Changes to your own infrastructure need the zone changed too** — a new or renumbered name server, or an application on a domain the zone does not match.
 
@@ -177,6 +177,8 @@ resource "jamfplatform_security_cloud_ztna_gateway" "frankfurt" {
 ```
 
 `tenant_ids` is mandatory and every tenant named in it must belong to the same organization as the provider's credentials. Because no API lists an environment's tenants, an environment-scoped configuration has no way to fill it in from data — supply the tenant ID as an input, or configure the provider with `tenant_id`.
+
+A gateway reports `PENDING` the moment it is created and carries no `dedicated_egress_ip_addresses` until Jamf has finished provisioning it, so an apply completing is not the same as a gateway being usable. Changing `egress_region` later re-provisions it: connectivity drops, the status returns to `PENDING`, and the egress addresses stay stale until it settles.
 
 ### Short names and fixed addresses
 
@@ -230,9 +232,11 @@ Jamf Security Cloud enforces references on delete in three different ways, and k
 
 | Destroying | What happens |
 |---|---|
-| A **gateway** a DNS zone, grouped gateway or app still references | Refused. Drop the reference in an earlier apply. |
+| A **gateway** a DNS zone, grouped gateway or app still references | Refused, naming what holds it. |
 | A **grouped gateway's member** while it is still in the group | Refused. |
 | A **device group** an app assignment or UEM mapping still names | **Succeeds silently**, and quietly drops the group from every assignment that named it — which can leave an application assigned to nobody. |
+
+The first has a Terraform-specific trap on top of the API's refusal. Dropping the reference *and* the gateway in a single apply does not work either, because Terraform sequences the destroy before the update that would have released the gateway — so the destroy still hits a live reference. Release it in one apply, destroy the gateway in the next.
 
 The third is the dangerous one, because nothing fails. Check what references a device group before removing it. Note also that the built-in **Default Group** cannot be managed here at all: Jamf gives it no identifier and reserves the name. It shows up in the `..._device_groups` data source with `built_in = true` and a null `id`.
 


### PR DESCRIPTION
## Why

Jamf Security Cloud shipped construct by construct and never got an orienting document. A reader arriving at eight resources, sixteen data sources and two actions had no map from them to the portal pages they manage, and no pointer to Jamf's own documentation — which for this product is split across two guides, the [Security Cloud Portal Setup Guide](https://learn.jamf.com/r/en-US/jamf-security-cloud-setup-guide/RADAR_Portal) and the [Zero Trust Network Access](https://learn.jamf.com/r/en-US/jamf-connect-documentation-current/Private_Access) section of the Jamf Connect Documentation. Both are now cited, and the guide is explicitly the Terraform half.

Companion to #352, which did the same for AI Governance.

## What's in it

- **A construct-to-portal table** — every resource, data source and action against the page it manages, plus what is deliberately *not* covered (activation profiles themselves, Jamf Protect's content-filtering policies, device enrolment).
- **An end-to-end walk** publishing one enterprise app over ZTNA: device group → access-policy app → routing → the Security tab, with the Jamf Protect licence requirement on those security cards and the UEM Connect dependency behind "managed device".
- **Predefined vs custom apps**, and the line that decides which you need: a predefined app requires every host name to be publicly resolvable, so split-brain DNS has to be a custom app.
- **Private apps and custom DNS** — zones, the gateway kinds (shared / dedicated / grouped), search domain, hostname mappings.
- **The things only learned by getting them wrong**: traffic matching is unique tenant-wide, so a rename-by-replacement collides with itself; the three different ways a referenced delete behaves, one of which *succeeds silently* and strands an app assigned to nobody; the tenant-wide singletons; the three immutable forms; group-mapping evaluation order.
- **Further reading** table of the fourteen Jamf pages worth having open.

## Verification

Every HCL block was run against a live EU tenant, not written from the schema:

| | Result |
|---|---|
| `terraform validate` — all 7 blocks including the gateway | ✅ |
| `terraform apply` — 6 blocks (7 resources) | ✅ 7 added |
| `terraform plan` after apply | ✅ No changes (idempotent) |
| `terraform destroy` | ✅ 7 destroyed |
| Tenant compared to its pre-run state | ✅ identical; no residue |

That caught **six errors this guide would otherwise have shipped**:

1. `authoritative_name_servers`, not `name_servers`
2. a hostname mapping takes `ipv4_addresses` (a set), not `ipv4_address`
3. …and requires both `connect_to_ztna` and `connect_to_secure_dns`
4. `uem_connect` requires `uem_vendor`, and nests `mappings` under `group_membership_mapping`
5. a Jamf Pro group is written `computer_12`, not `12`
6. the deploy action's argument is `os = "macos"`, not `operating_system = "macOS"`

It also confirmed a wire fact worth stating in the guide: a name server on a **private address is refused outright behind the shared "Nearest Data Center" gateway** (`Name server IP address not allowed`), so an internal name server needs a dedicated gateway of your own.

**Not applied:** the dedicated-gateway block. It validates, but a dedicated gateway is a paid add-on that provisions real egress infrastructure, and I was not willing to bill someone's tenant to prove a code sample. Flagging it rather than implying otherwise.

## Also in here

The content-categories and predefined-apps data sources both told the reader that the construct consuming their output "is not yet managed by this provider". `jamfplatform_security_cloud_ztna_app` now ships, so they name it instead. The test pinning that disclaimer said in its own comment to delete it when the app resource landed — it now asserts the opposite, so the description cannot drift back.

## Checks

`make fmt` clean · `go test ./internal/...` green · `make generate` run, `docs/guides/security-cloud.md` verified byte-identical to its template below the frontmatter. The `make lint` / `make test` failures on this branch are pre-existing and confined to gitignored `local-testing/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
