### PR TITLE
docs(platform_api_ga): pin rc.5, and note the gateway wait

### DIFF
--- a/docs/guides/platform-api-ga.md
+++ b/docs/guides/platform-api-ga.md
@@ -40,7 +40,7 @@ terraform {
   required_providers {
     jamfplatform = {
       source  = "Jamf-Concepts/jamfplatform"
-      version = "0.29.0-rc.4"
+      version = "0.29.0-rc.5"
     }
   }
 }
@@ -343,8 +343,8 @@ reports `USERENROLLMENT`. The attribute is read-only and is retained.
 
 ## Additions since v0.28.1
 
-**No action needed.** The following arrived during the GA cycle, across `v0.29.0-rc.1`,
-`v0.29.0-rc.2` and this pre-release. All of it is additive.
+**No action needed.** The following arrived during the GA cycle, across the `v0.29.0` release
+candidates. All of it is additive relative to `v0.28.1`.
 
 ### Jamf Security Cloud
 
@@ -366,6 +366,15 @@ Two delete behaviours affect destroy ordering. A ZTNA gateway that is still refe
 deleted, and the provider names the referrer in the diagnostic rather than surfacing an
 unqualified `409`. A Security Cloud device group referenced by a ZTNA app deletes successfully and
 empties the app's assignment. The behaviour differs per construct.
+
+New in this pre-release, and the one change here anyone already on `v0.29.0-rc.4` will notice: a
+ZTNA gateway apply now waits for the gateway to report a settled status instead of returning as
+soon as Jamf accepts the write. Creating or re-provisioning a dedicated internet gateway therefore
+takes about five minutes rather than seconds, which is what makes its
+`dedicated_egress_ip_addresses` usable from the same apply — previously the first apply recorded an
+empty list, and a region change recorded the *previous* region's addresses. Raise `create` or
+`update` in the resource's `timeouts` block if a region provisions more slowly than the default ten
+minutes allows. Further detail: [Jamf Security Cloud](security-cloud).
 
 ### Jamf AI Governance
 

--- a/templates/guides/platform-api-ga.md
+++ b/templates/guides/platform-api-ga.md
@@ -40,7 +40,7 @@ terraform {
   required_providers {
     jamfplatform = {
       source  = "Jamf-Concepts/jamfplatform"
-      version = "0.29.0-rc.4"
+      version = "0.29.0-rc.5"
     }
   }
 }
@@ -343,8 +343,8 @@ reports `USERENROLLMENT`. The attribute is read-only and is retained.
 
 ## Additions since v0.28.1
 
-**No action needed.** The following arrived during the GA cycle, across `v0.29.0-rc.1`,
-`v0.29.0-rc.2` and this pre-release. All of it is additive.
+**No action needed.** The following arrived during the GA cycle, across the `v0.29.0` release
+candidates. All of it is additive relative to `v0.28.1`.
 
 ### Jamf Security Cloud
 
@@ -366,6 +366,15 @@ Two delete behaviours affect destroy ordering. A ZTNA gateway that is still refe
 deleted, and the provider names the referrer in the diagnostic rather than surfacing an
 unqualified `409`. A Security Cloud device group referenced by a ZTNA app deletes successfully and
 empties the app's assignment. The behaviour differs per construct.
+
+New in this pre-release, and the one change here anyone already on `v0.29.0-rc.4` will notice: a
+ZTNA gateway apply now waits for the gateway to report a settled status instead of returning as
+soon as Jamf accepts the write. Creating or re-provisioning a dedicated internet gateway therefore
+takes about five minutes rather than seconds, which is what makes its
+`dedicated_egress_ip_addresses` usable from the same apply — previously the first apply recorded an
+empty list, and a region change recorded the *previous* region's addresses. Raise `create` or
+`update` in the resource's `timeouts` block if a region provisions more slowly than the default ten
+minutes allows. Further detail: [Jamf Security Cloud](security-cloud).
 
 ### Jamf AI Governance
 


### PR DESCRIPTION
## Why

The next pre-release needs the guide's install constraint moved, and rc.5 carries one behavioural change worth naming rather than leaving people to discover.

## What's in it

**The install constraint moves to `0.29.0-rc.5`.** Every other version reference stays: the base-URL cutover happened at rc.4, so "versions prior to `v0.29.0-rc.4` are bound to the beta host" and the `base_url` table are still correct.

**The additions section stops enumerating release candidates.** It claimed to cover "`v0.29.0-rc.1`, `v0.29.0-rc.2` and this pre-release" — already two candidates behind. It now says "across the `v0.29.0` release candidates", so it no longer needs an edit per rc.

**The ZTNA gateway wait is called out.** From #355, a gateway apply waits for a settled status rather than returning as soon as Jamf accepts the write, so creating or re-provisioning a dedicated internet gateway takes about five minutes instead of seconds. Anyone already on rc.4 will notice that, so it says so explicitly, with the reason (it is what makes `dedicated_egress_ip_addresses` usable from the same apply — previously a first apply recorded an empty list and a region change recorded the *previous* region's addresses) and with the `timeouts` block as the lever.

**The Security Cloud section gains a pointer to its own guide**, which the AI Governance section already had.

## One thing to confirm before tagging

`Built against Jamf Pro 11.31.0 and Classic API 11.28.0` is left untouched. Nothing in the repo pins those numbers, so I could not verify they still hold after the SDK ingests since rc.4. Worth a look.

## Checks

`make generate` run; `docs/guides/platform-api-ga.md` verified byte-identical to its template below the frontmatter. No wrapped table row, no link broken across `]`/`(`, no code span split across lines, no non-table line over 200 characters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
