### PR TITLE
fix(security_cloud): unmanaged_sync_threshold is read-only, unbreaking every uem_connect apply

### DIFF
--- a/docs/data-sources/security_cloud_uem_connect.md
+++ b/docs/data-sources/security_cloud_uem_connect.md
@@ -77,7 +77,7 @@ output "uem_connect_id" {
 - `uem_auto_delete_behavior` (String) **"Configure UEM auto-delete behavior"** in the Jamf Security Cloud admin UI.
 - `uem_server_url` (String) **"UEM server URL"** in the Jamf Security Cloud admin UI.
 - `uem_vendor` (String) **"UEM vendor"** in the Jamf Security Cloud admin UI.
-- `unmanaged_sync_threshold` (Number) How many consecutive syncs a device may be missing from Jamf Pro before Jamf Security Cloud treats it as unmanaged.
+- `unmanaged_sync_threshold` (Number) Days since a device last checked in before Jamf Security Cloud treats it as unmanaged. Reported as `0` for a Jamf Pro connection, which does not use this setting.
 - `user_data_field_mapping` (Attributes) **"User data field mapping"** in the Jamf Security Cloud admin UI. (see [below for nested schema](#nestedatt--user_data_field_mapping))
 
 <a id="nestedatt--timeouts"></a>

--- a/docs/guides/platform-api-ga.md
+++ b/docs/guides/platform-api-ga.md
@@ -335,6 +335,28 @@ top-level `activation_conditions` and `legacy_payloads`, are superseded by named
 October 2026**. Migrating ahead of that date is recommended; `terraform plan` reports every
 attribute requiring migration.
 
+### Now read-only: `unmanaged_sync_threshold` on `jamfplatform_security_cloud_uem_connect`
+
+**Action needed if the attribute is set: remove it from your configuration.** Like
+`personal_device_enrollment_type` below, this is a Jamf-side behaviour change rather than a
+provider decision — but unlike that one it could not simply be retained, because it was breaking
+every apply.
+
+Jamf Security Cloud does not apply an unmanaged threshold to a Jamf Pro connection; it takes
+device status from Jamf Pro directly. Wire-probed 2026-09-01: every value sent for a `JAMF_PRO`
+connector is accepted and then discarded, and the connector always reports `0`. Because the
+provider defaulted the attribute to `3` and sent it on every write, Terraform saw a value it had
+planned come back different and failed the apply:
+
+```
+Error: Provider produced inconsistent result after apply
+.unmanaged_sync_threshold: was cty.NumberIntVal(3), but now cty.NumberIntVal(0)
+```
+
+The attribute is now `Computed` and always reads `0`. Leaving it in a configuration is an error
+(`Invalid Configuration for Read-Only Attribute`), so delete the line; no state edit is needed.
+Nothing about how your devices are treated changes — the setting never took effect.
+
 ### Retained: `personal_device_enrollment_type`
 
 **No action needed.** On `jamfplatform_pro_user_initiated_enrollment_settings`. This is a Jamf

--- a/docs/resources/security_cloud_uem_connect.md
+++ b/docs/resources/security_cloud_uem_connect.md
@@ -82,10 +82,9 @@ resource "jamfplatform_security_cloud_uem_connect" "jamf_pro" {
 
   sync_refresh_interval_minutes = 720
 
-  # Devices Jamf Pro no longer manages are removed after three consecutive syncs
-  # without them. Use keep_deleted_or_retired to retain them instead.
+  # Devices Jamf Pro no longer reports as managed are removed. Use
+  # keep_deleted_or_retired to retain them instead.
   uem_auto_delete_behavior = "remove_deleted_or_unmanaged"
-  unmanaged_sync_threshold = 3
 
   # Send each device's risk level back to Jamf Pro, so Jamf Pro can act on it.
   device_risk_uem_signaling_enabled = true
@@ -196,14 +195,14 @@ resource "jamfplatform_device_group" "field_staff" {
 
 - `keep_deleted_or_retired` — keep deleted or retired devices in Jamf Security Cloud.
 - `remove_deleted_or_retired` — remove deleted or retired devices from Jamf Security Cloud.
-- `remove_deleted_or_unmanaged` — also remove devices Jamf Pro no longer manages, after `unmanaged_sync_threshold` consecutive syncs without them.
+- `remove_deleted_or_unmanaged` — also remove devices Jamf Pro reports as no longer managed.
 - `uem_server_url` (String) **"UEM server URL"** in the Jamf Security Cloud admin UI — the full address of the Jamf Pro instance, including `https://`. Required with `oauth`. Must not be set with `platform_tenant`, which resolves the address from the tenant itself.
-- `unmanaged_sync_threshold` (Number) How many consecutive syncs a device may be missing from Jamf Pro before Jamf Security Cloud treats it as unmanaged. `0` removes it on the first sync it is missing from. Only has an effect when `uem_auto_delete_behavior` is `remove_deleted_or_unmanaged`.
 - `user_data_field_mapping` (Attributes) **"User data field mapping"** in the Jamf Security Cloud admin UI — which Jamf Pro attribute each Jamf Security Cloud device field is populated from. Omit the whole block for the defaults, which is what the admin UI's "Use default data field mapping" checkbox selects. (see [below for nested schema](#nestedatt--user_data_field_mapping))
 
 ### Read-Only
 
 - `id` (String) Integration ID assigned by Jamf Security Cloud.
+- `unmanaged_sync_threshold` (Number) Days since a device last checked in before Jamf Security Cloud treats it as unmanaged. Read-only, and reported as `0`: Jamf Security Cloud does not apply this setting to a Jamf Pro connection, taking device status from Jamf Pro directly instead, so there is nothing for this provider to set. Wire-probed 2026-09-01 — every value sent for a `JAMF_PRO` connector is accepted and then discarded.
 
 <a id="nestedatt--group_membership_mapping"></a>
 ### Nested Schema for `group_membership_mapping`

--- a/examples/resources/jamfplatform_security_cloud_uem_connect/resource.tf
+++ b/examples/resources/jamfplatform_security_cloud_uem_connect/resource.tf
@@ -39,10 +39,9 @@ resource "jamfplatform_security_cloud_uem_connect" "jamf_pro" {
 
   sync_refresh_interval_minutes = 720
 
-  # Devices Jamf Pro no longer manages are removed after three consecutive syncs
-  # without them. Use keep_deleted_or_retired to retain them instead.
+  # Devices Jamf Pro no longer reports as managed are removed. Use
+  # keep_deleted_or_retired to retain them instead.
   uem_auto_delete_behavior = "remove_deleted_or_unmanaged"
-  unmanaged_sync_threshold = 3
 
   # Send each device's risk level back to Jamf Pro, so Jamf Pro can act on it.
   device_risk_uem_signaling_enabled = true

--- a/internal/resources/security_cloud/uem_connect/crud_partial_state_test.go
+++ b/internal/resources/security_cloud/uem_connect/crud_partial_state_test.go
@@ -79,7 +79,7 @@ func platformTenantPlan(ctx context.Context, connectorSchema resourceschema.Sche
 	values["scheduled_sync_enabled"] = tftypes.NewValue(tftypes.Bool, true)
 	values["sync_refresh_interval_minutes"] = tftypes.NewValue(tftypes.Number, defaultSyncRefreshIntervalMinutes)
 	values["uem_auto_delete_behavior"] = tftypes.NewValue(tftypes.String, defaultUEMAutoDeleteBehaviour)
-	values["unmanaged_sync_threshold"] = tftypes.NewValue(tftypes.Number, defaultUnmanagedSyncThreshold)
+	values["unmanaged_sync_threshold"] = tftypes.NewValue(tftypes.Number, 0)
 	values["device_risk_uem_signaling_enabled"] = tftypes.NewValue(tftypes.Bool, false)
 	values["disable_sync_on_auth_error"] = tftypes.NewValue(tftypes.Bool, true)
 	values["concurrent_device_sync_enabled"] = tftypes.NewValue(tftypes.Bool, true)

--- a/internal/resources/security_cloud/uem_connect/data_source.go
+++ b/internal/resources/security_cloud/uem_connect/data_source.go
@@ -89,8 +89,8 @@ func (d *UEMConnectDataSource) Schema(ctx context.Context, _ datasource.SchemaRe
 				Computed:            true,
 			},
 			"unmanaged_sync_threshold": schema.Int64Attribute{
-				MarkdownDescription: "How many consecutive syncs a device may be missing from Jamf Pro before Jamf " +
-					"Security Cloud treats it as unmanaged.",
+				MarkdownDescription: "Days since a device last checked in before Jamf Security Cloud treats it as " +
+					"unmanaged. Reported as `0` for a Jamf Pro connection, which does not use this setting.",
 				Computed: true,
 			},
 			"device_risk_uem_signaling_enabled": schema.BoolAttribute{

--- a/internal/resources/security_cloud/uem_connect/input_builders.go
+++ b/internal/resources/security_cloud/uem_connect/input_builders.go
@@ -105,22 +105,20 @@ func buildSyncSettingsInput(plan UEMConnectResourceModel) (*securitycloud.SyncSe
 
 	scheduled := plan.ScheduledSyncEnabled.ValueBool()
 	interval := plan.SyncRefreshIntervalMinutes.ValueInt64()
-	threshold := int(plan.UnmanagedSyncThreshold.ValueInt64())
 	riskTagging := plan.DeviceRiskUEMSignalingEnabled.ValueBool()
 	disableOnAuthError := plan.DisableSyncOnAuthError.ValueBool()
 	concurrent := plan.ConcurrentDeviceSyncEnabled.ValueBool()
 
 	input := &securitycloud.SyncSettings{
-		Vendor:                   plan.UEMVendor.ValueString(),
-		AutoDeviceDeletion:       behaviour,
-		Scheduled:                &scheduled,
-		RefreshRateMinutes:       &interval,
-		DeviceUnmanagedThreshold: &threshold,
-		DeviceRiskTagging:        &riskTagging,
-		DisableSyncOnAuthError:   &disableOnAuthError,
-		ConcurrentSyncEnabled:    &concurrent,
-		DeviceFieldMappings:      buildDeviceFieldMappings(plan.UserDataFieldMapping),
-		GroupSettings:            buildGroupSettings(plan.GroupMembershipMapping),
+		Vendor:                 plan.UEMVendor.ValueString(),
+		AutoDeviceDeletion:     behaviour,
+		Scheduled:              &scheduled,
+		RefreshRateMinutes:     &interval,
+		DeviceRiskTagging:      &riskTagging,
+		DisableSyncOnAuthError: &disableOnAuthError,
+		ConcurrentSyncEnabled:  &concurrent,
+		DeviceFieldMappings:    buildDeviceFieldMappings(plan.UserDataFieldMapping),
+		GroupSettings:          buildGroupSettings(plan.GroupMembershipMapping),
 	}
 
 	return input, diags

--- a/internal/resources/security_cloud/uem_connect/input_builders_test.go
+++ b/internal/resources/security_cloud/uem_connect/input_builders_test.go
@@ -20,7 +20,6 @@ func planWithDefaults() UEMConnectResourceModel {
 		ScheduledSyncEnabled:          types.BoolValue(true),
 		SyncRefreshIntervalMinutes:    types.Int64Value(defaultSyncRefreshIntervalMinutes),
 		UEMAutoDeleteBehaviour:        types.StringValue(defaultUEMAutoDeleteBehaviour),
-		UnmanagedSyncThreshold:        types.Int64Value(defaultUnmanagedSyncThreshold),
 		DeviceRiskUEMSignalingEnabled: types.BoolValue(false),
 		DisableSyncOnAuthError:        types.BoolValue(true),
 		ConcurrentDeviceSyncEnabled:   types.BoolValue(true),
@@ -202,11 +201,13 @@ func TestBuildCreateInput_NoAuthBlockErrors(t *testing.T) {
 // TestBuildSyncSettings_SendsEveryField is the load-bearing test for this file. The
 // settings write is a full replacement, so any field the builder omits is reset to
 // Jamf's default — silently reverting configuration the user did not touch. Every
-// scalar must therefore be present on every write.
+// scalar must therefore be present on every write, with one deliberate exception:
+// deviceUnmanagedThreshold, which Jamf Security Cloud discards for a JAMF_PRO
+// connector, so there is no configuration to revert and sending it only invited a
+// plan/apply mismatch.
 func TestBuildSyncSettings_SendsEveryField(t *testing.T) {
 	plan := planWithDefaults()
-	plan.SyncRefreshIntervalMinutes = types.Int64Value(360)
-	plan.UnmanagedSyncThreshold = types.Int64Value(7)
+	plan.SyncRefreshIntervalMinutes = types.Int64Value(720)
 	plan.DeviceRiskUEMSignalingEnabled = types.BoolValue(true)
 	plan.DisableSyncOnAuthError = types.BoolValue(false)
 	plan.ConcurrentDeviceSyncEnabled = types.BoolValue(false)
@@ -223,11 +224,13 @@ func TestBuildSyncSettings_SendsEveryField(t *testing.T) {
 	if input.Scheduled == nil || *input.Scheduled {
 		t.Error("scheduled was omitted or wrong")
 	}
-	if input.RefreshRateMinutes == nil || *input.RefreshRateMinutes != 360 {
+	if input.RefreshRateMinutes == nil || *input.RefreshRateMinutes != 720 {
 		t.Error("refreshRateMinutes was omitted or wrong")
 	}
-	if input.DeviceUnmanagedThreshold == nil || *input.DeviceUnmanagedThreshold != 7 {
-		t.Error("deviceUnmanagedThreshold was omitted or wrong")
+	if input.DeviceUnmanagedThreshold != nil {
+		t.Error("deviceUnmanagedThreshold was sent; it is the one field this builder must omit, " +
+			"because Jamf Security Cloud discards it for a JAMF_PRO connector and echoing it back " +
+			"as state breaks every apply")
 	}
 	if input.DeviceRiskTagging == nil || !*input.DeviceRiskTagging {
 		t.Error("deviceRiskTagging was omitted or wrong")

--- a/internal/resources/security_cloud/uem_connect/resource.go
+++ b/internal/resources/security_cloud/uem_connect/resource.go
@@ -108,23 +108,18 @@ import (
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/providerdata"
 )
 
-// Bounds and defaults Jamf Security Cloud applies. Wire-probed against production
-// EU on 2026-08-28.
+// Bounds and defaults Jamf Security Cloud applies. Wire-probed against a real
+// Jamf Security Cloud tenant on 2026-09-01, superseding a 2026-08-28 probe whose
+// findings the service has since changed under: the sync interval then accepted
+// any value of 1 or more with no ceiling, and the unmanaged threshold then stored
+// what it was sent.
 //
-// The sync interval floor is enforced by the server ("must be greater than or
-// equal to 1"); there is no ceiling, and 100000 was accepted. The unmanaged
-// threshold has no server validation at all — -1 was stored — so the floor here
-// is the provider's, not Jamf's: a negative count of syncs cannot mean anything,
-// and storing one would silently disable the grace period.
+// The interval floor stays declared here because it is the schema's own; the
+// service's accepted set is narrower and is validated separately.
 const (
 	minSyncRefreshIntervalMinutes     = 1
 	defaultSyncRefreshIntervalMinutes = 1440
-	minUnmanagedSyncThreshold         = 0
-	// Jamf Security Cloud applies 3 on create but resets an omitted value to 0.
-	// The resource always sends the value, so the create default is the one that
-	// matters and the one declared here.
-	defaultUnmanagedSyncThreshold = 3
-	defaultUEMAutoDeleteBehaviour = "remove_deleted_or_retired"
+	defaultUEMAutoDeleteBehaviour     = "remove_deleted_or_retired"
 )
 
 // jamfProGroupIDPattern is the form Jamf Security Cloud requires of a Jamf Pro
@@ -346,8 +341,7 @@ func (r *UEMConnectResource) Schema(ctx context.Context, _ resource.SchemaReques
 					"UI — what happens in Jamf Security Cloud to devices that leave Jamf Pro.\n\n" +
 					"- `keep_deleted_or_retired` — keep deleted or retired devices in Jamf Security Cloud.\n" +
 					"- `remove_deleted_or_retired` — remove deleted or retired devices from Jamf Security Cloud.\n" +
-					"- `remove_deleted_or_unmanaged` — also remove devices Jamf Pro no longer manages, after " +
-					"`unmanaged_sync_threshold` consecutive syncs without them.",
+					"- `remove_deleted_or_unmanaged` — also remove devices Jamf Pro reports as no longer managed.",
 				Optional: true,
 				Computed: true,
 				Default:  stringdefault.StaticString(defaultUEMAutoDeleteBehaviour),
@@ -356,15 +350,12 @@ func (r *UEMConnectResource) Schema(ctx context.Context, _ resource.SchemaReques
 				},
 			},
 			"unmanaged_sync_threshold": schema.Int64Attribute{
-				MarkdownDescription: "How many consecutive syncs a device may be missing from Jamf Pro before Jamf " +
-					"Security Cloud treats it as unmanaged. `0` removes it on the first sync it is missing from. " +
-					"Only has an effect when `uem_auto_delete_behavior` is `remove_deleted_or_unmanaged`.",
-				Optional: true,
+				MarkdownDescription: "Days since a device last checked in before Jamf Security Cloud treats it as " +
+					"unmanaged. Read-only, and reported as `0`: Jamf Security Cloud does not apply this setting to a " +
+					"Jamf Pro connection, taking device status from Jamf Pro directly instead, so there is nothing " +
+					"for this provider to set. Wire-probed 2026-09-01 — every value sent for a `JAMF_PRO` connector " +
+					"is accepted and then discarded.",
 				Computed: true,
-				Default:  int64default.StaticInt64(defaultUnmanagedSyncThreshold),
-				Validators: []validator.Int64{
-					int64validator.AtLeast(minUnmanagedSyncThreshold),
-				},
 			},
 			"device_risk_uem_signaling_enabled": schema.BoolAttribute{
 				MarkdownDescription: "**\"Enable device risk UEM signaling\"** in the Jamf Security Cloud admin UI " +

--- a/internal/resources/security_cloud/uem_connect/resource_acceptance_test.go
+++ b/internal/resources/security_cloud/uem_connect/resource_acceptance_test.go
@@ -226,7 +226,7 @@ func TestAccResource_SecurityCloudUEMConnect_PlatformTenant(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "scheduled_sync_enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "sync_refresh_interval_minutes", "1440"),
 					resource.TestCheckResourceAttr(resourceName, "uem_auto_delete_behavior", "remove_deleted_or_retired"),
-					resource.TestCheckResourceAttr(resourceName, "unmanaged_sync_threshold", "3"),
+					resource.TestCheckResourceAttr(resourceName, "unmanaged_sync_threshold", "0"),
 					resource.TestCheckResourceAttr(resourceName, "device_risk_uem_signaling_enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "disable_sync_on_auth_error", "true"),
 					resource.TestCheckResourceAttr(resourceName, "concurrent_device_sync_enabled", "true"),
@@ -285,9 +285,8 @@ func TestAccResource_SecurityCloudUEMConnect_PlatformTenant(t *testing.T) {
 
 						enabled                        = false
 						scheduled_sync_enabled         = false
-						sync_refresh_interval_minutes          = 360
+						sync_refresh_interval_minutes          = 720
 						uem_auto_delete_behavior           = "remove_deleted_or_unmanaged"
-						unmanaged_sync_threshold       = 7
 						device_risk_uem_signaling_enabled  = true
 						disable_sync_on_auth_error     = false
 						concurrent_device_sync_enabled = false
@@ -316,9 +315,9 @@ func TestAccResource_SecurityCloudUEMConnect_PlatformTenant(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "scheduled_sync_enabled", "false"),
-					resource.TestCheckResourceAttr(resourceName, "sync_refresh_interval_minutes", "360"),
+					resource.TestCheckResourceAttr(resourceName, "sync_refresh_interval_minutes", "720"),
 					resource.TestCheckResourceAttr(resourceName, "uem_auto_delete_behavior", "remove_deleted_or_unmanaged"),
-					resource.TestCheckResourceAttr(resourceName, "unmanaged_sync_threshold", "7"),
+					resource.TestCheckResourceAttr(resourceName, "unmanaged_sync_threshold", "0"),
 					resource.TestCheckResourceAttr(resourceName, "device_risk_uem_signaling_enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "disable_sync_on_auth_error", "false"),
 					resource.TestCheckResourceAttr(resourceName, "concurrent_device_sync_enabled", "false"),
@@ -701,10 +700,10 @@ func TestAccResource_SecurityCloudUEMConnect_Validation(t *testing.T) {
 						platform_tenant = {
 							tenant_id = "00000000-0000-0000-0000-000000000000"
 						}
-						unmanaged_sync_threshold = -1
+						unmanaged_sync_threshold = 3
 					}
 				`,
-				ExpectError: regexp.MustCompile(`must be at least 0`),
+				ExpectError: regexp.MustCompile(`Invalid Configuration for Read-Only Attribute`),
 			},
 			{
 				Config: `

--- a/templates/guides/platform-api-ga.md
+++ b/templates/guides/platform-api-ga.md
@@ -335,6 +335,28 @@ top-level `activation_conditions` and `legacy_payloads`, are superseded by named
 October 2026**. Migrating ahead of that date is recommended; `terraform plan` reports every
 attribute requiring migration.
 
+### Now read-only: `unmanaged_sync_threshold` on `jamfplatform_security_cloud_uem_connect`
+
+**Action needed if the attribute is set: remove it from your configuration.** Like
+`personal_device_enrollment_type` below, this is a Jamf-side behaviour change rather than a
+provider decision — but unlike that one it could not simply be retained, because it was breaking
+every apply.
+
+Jamf Security Cloud does not apply an unmanaged threshold to a Jamf Pro connection; it takes
+device status from Jamf Pro directly. Wire-probed 2026-09-01: every value sent for a `JAMF_PRO`
+connector is accepted and then discarded, and the connector always reports `0`. Because the
+provider defaulted the attribute to `3` and sent it on every write, Terraform saw a value it had
+planned come back different and failed the apply:
+
+```
+Error: Provider produced inconsistent result after apply
+.unmanaged_sync_threshold: was cty.NumberIntVal(3), but now cty.NumberIntVal(0)
+```
+
+The attribute is now `Computed` and always reads `0`. Leaving it in a configuration is an error
+(`Invalid Configuration for Read-Only Attribute`), so delete the line; no state edit is needed.
+Nothing about how your devices are treated changes — the setting never took effect.
+
 ### Retained: `personal_device_enrollment_type`
 
 **No action needed.** On `jamfplatform_pro_user_initiated_enrollment_settings`. This is a Jamf


### PR DESCRIPTION
`jamfplatform_security_cloud_uem_connect` **cannot currently be created at all** unless the operator explicitly sets `unmanaged_sync_threshold = 0`. The schema defaults it to `3`, the service reports `0`, and Terraform fails the apply:

```
Error: Provider produced inconsistent result after apply
.unmanaged_sync_threshold: was cty.NumberIntVal(3), but now cty.NumberIntVal(0)
```

4 of the 7 acceptance tests in the package fail on exactly this. Found while running the suite for #357; **this is not a regression from that PR** — the code path is untouched by it and this branch is based on `feat/platform-api-ga` so it can merge independently.

## What the wire says

Probed 2026-09-01 against a real Security Cloud tenant with an M2M `JAMF_PRO` connector (self-provisioned, `connected: true`, synced immediately):

| PUT `deviceUnmanagedThreshold` | Response | Read back |
|---|---|---|
| 3, 7, 14, 1, 0 | **204** every time | **0** every time |

A freshly created connector also starts at `0`, not the `3` the previous probe recorded. This matches the SDK's godoc — *"Not applicable for JAMF_PRO — any value sent for that vendor is silently ignored (device status is taken exclusively from the UEM)"* — and means **the setting has never taken effect** for any connection this resource can create.

## Why `Computed`, not `Optional`

`uem_vendor` is restricted to `JAMF_PRO`, so the field is inert for every connection this resource supports. Keeping it settable would mean keeping a value that cannot be honoured and that fails the apply for any non-zero input. Making it read-only is the only option that doesn't lie.

This is a breaking schema change for anyone with the attribute in config — but their config already cannot apply unless the value is `0`, so the real blast radius is that one case. The GA guide records it under *Attribute removals and deprecations*, since a config setting it now errors with `Invalid Configuration for Read-Only Attribute` and needs a one-line edit. No state edit required.

`buildSyncSettingsInput` now omits the field. That builder's load-bearing test asserts *every* scalar is present — the settings write is a full replacement, so an omitted field is silently reset — so the omission is recorded there as a deliberate exception carrying its reason, rather than quietly dropped.

## Two stale claims corrected in passing

The recorded bounds comment (`resource.go`, from a 2026-08-28 probe) said the service enforced only `>= 1` on the sync interval, had **no ceiling**, and **accepted 100000**, and that the threshold had no validation at all. The service has changed under all of that:

| PUT `refreshRateMinutes` | Response |
|---|---|
| 60, 1440 | 204 |
| **360, 59, 1, 100000, 0** | **422** `Invalid refreshRateMinutes: 360. Allowed values: 60, 120, 240, 480, 720, 1440` |

So `360` in the acceptance fixture and the builder test is no longer a value the service takes. **Tightening that validator to the enum is deliberately left to a follow-up** — it wants its own review, and neither numeric enum has a generated `*Values()` helper to source from (a `OneOf` would be six restated literals, the third instance of that SDK generator gap). The fixtures move to `720` here only so the suite reflects reality.

Descriptions throughout carried the pre-redefinition semantics: the field counts **days since last check-in**, not consecutive syncs, and `0` means the **platform default**, not "remove on the first sync it is missing from". Corrected on the resource, the data source, the `uem_auto_delete_behavior` enum text that cross-referenced it, and the example.

## Acceptance

**5 pass, 2 skip, 0 fail** against a real Security Cloud tenant — all four previously failing tests now pass, and the tenant is left clean (`totalCount 0`).

```
--- PASS: TestAccResource_SecurityCloudUEMConnect_PlatformTenant
--- SKIP: TestAccResource_SecurityCloudUEMConnect_OAuth
--- SKIP: TestAccResource_SecurityCloudUEMConnect_ReplaceOnConnectionChange
--- PASS: TestAccResource_SecurityCloudUEMConnect_Validation
--- PASS: TestAccResource_SecurityCloudUEMConnect_DriftRecovery
--- PASS: TestAccDataSource_SecurityCloudUEMConnect_ReadsCreatedIntegration
--- PASS: TestAccListResource_SecurityCloudUEMConnect_FindsTheIntegration
```

Both skips need `JAMFPLATFORM_ACC_UEM_CONNECT_{SERVER_URL,CLIENT_ID,CLIENT_SECRET}` — an API client **on the Jamf Pro instance**, not Platform API gateway credentials. Security Cloud runs a real connection test on create, so placeholders can't stand in.

`Validation` step 10 also gave a useful correction: the framework's own error is `Invalid Configuration for Read-Only Attribute`, not Terraform core's `Can't configure a value for …`. The guide quotes the real one.

Gates: `go build ./...`, `go vet` (plain, `-tags acceptance`, `-tags acctargets`), `go test ./...` 0 failures, `gofmt`, `golangci-lint` 0 issues, `make generate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)