### PR TITLE
feat(pro): migrate patch_software_title to the Jamf Pro v3 configurations API

### DIFF
--- a/docs/data-sources/pro_patch_software_title.md
+++ b/docs/data-sources/pro_patch_software_title.md
@@ -65,7 +65,7 @@ output "patch_software_title_version_packages" {
 - `email_notification` (Boolean) Whether an email notification is sent for new versions.
 - `name_id` (String) Patch catalog key that defines the title.
 - `site_id` (String) Jamf Pro site ID.
-- `source_id` (Number) Patch source ID this title is sourced from.
+- `source_id` (Number) Patch source ID this title is sourced from. Jamf Pro reports the source by name here, so the provider matches that name against the tenant's internal and external patch sources: the value is null, with a warning, when the name matches none of them, matches both an internal and an external source, or those sources cannot be read.
 - `version_packages` (Map of String) Every version→package assignment on the title (software_version → package ID).
 - `web_notification` (Boolean) Whether a Jamf Pro notification is raised for new versions.
 

--- a/docs/data-sources/pro_patch_software_title.md
+++ b/docs/data-sources/pro_patch_software_title.md
@@ -8,6 +8,8 @@ description: |-
   Grant the API integration the following permissions in Jamf Account — see Getting started with the Platform API https://developer.jamf.com/platform-api/reference/getting-started-with-platform-api. Category and Permission name the section and row of the permission picker; Actions are the boxes to tick within that row.
   | Category | Permission | Actions | API capability |
   |---|---|---|---|
+  | App lifecycle management | External patch sources | Read | `patch-external-source` |
+  | App lifecycle management | Internal patch sources | Read | `patch-internal-source` |
   | App lifecycle management | Patch titles | Read | `patch-management-software-titles` |
 ---
 
@@ -21,6 +23,8 @@ Grant the API integration the following permissions in Jamf Account — see [Get
 
 | Category | Permission | Actions | API capability |
 |---|---|---|---|
+| App lifecycle management | External patch sources | Read | `patch-external-source` |
+| App lifecycle management | Internal patch sources | Read | `patch-internal-source` |
 | App lifecycle management | Patch titles | Read | `patch-management-software-titles` |
 
 ## Example Usage
@@ -58,11 +62,9 @@ output "patch_software_title_version_packages" {
 
 - `available_versions` (List of String) All software_version strings the patch source publishes for this title.
 - `category_id` (String) Jamf Pro category ID.
-- `category_name` (String) Category display name.
 - `email_notification` (Boolean) Whether an email notification is sent for new versions.
 - `name_id` (String) Patch catalog key that defines the title.
 - `site_id` (String) Jamf Pro site ID.
-- `site_name` (String) Site display name.
 - `source_id` (Number) Patch source ID this title is sourced from.
 - `version_packages` (Map of String) Every version→package assignment on the title (software_version → package ID).
 - `web_notification` (Boolean) Whether a Jamf Pro notification is raised for new versions.

--- a/docs/guides/platform-api-ga.md
+++ b/docs/guides/platform-api-ga.md
@@ -326,6 +326,24 @@ upgrade, so the benchmark continues to target the same device group; the removal
 configuration edit only, never a re-scope. The attribute has also been removed from the
 corresponding data source.
 
+### Removed: `category_name` and `site_name` on `jamfplatform_pro_patch_software_title`
+
+**Action needed only if either attribute is referenced: read the name from the object that owns
+it.** Both were read-only display names, and the Jamf Pro endpoints this resource now uses report
+category and site by ID alone:
+
+```hcl
+# category_name = jamfplatform_pro_patch_software_title.example.category_name
+category_name = jamfplatform_pro_category.example.name
+```
+
+State migrates automatically — the provider strips both attributes during the state upgrade, so
+no `terraform state` surgery is needed. They have also been removed from the corresponding data
+source. Nothing else about the resource changes: patch software titles are now read, updated and
+deleted through Jamf Pro's `/patch-software-title-configurations` endpoints rather than the
+deprecated ProClassic `/patchsoftwaretitles` ones, and every other attribute behaves as before,
+`version_packages` included — an assignment made outside Terraform still survives an apply.
+
 ### Deprecated, not yet removed: the flat blueprint component attributes
 
 **No action needed yet.** The flat top-level component attributes on

--- a/docs/guides/platform-api-ga.md
+++ b/docs/guides/platform-api-ga.md
@@ -71,17 +71,21 @@ during the public beta; the second only at GA.
    them cannot produce a plan of any kind. See [Removed constructs](#removed-constructs).
 2. **Set `base_url` to the GA gateway in the same change as the provider upgrade.** The host and
    the provider version are paired. See [Base URL](#base-url).
-3. Take a state backup, as for any breaking provider upgrade.
+3. **Extend the integration's permissions where a workspace uses
+   `jamfplatform_pro_patch_software_title`.** Its data source, list resource and `terraform import`
+   now read the tenant's patch source catalogues, so two read permissions must be added. See
+   [Attribute removals and deprecations](#attribute-removals-and-deprecations).
+4. Take a state backup, as for any breaking provider upgrade.
 
-Existing beta credentials and `tenant_id` continue to work through this upgrade. Nothing else is
-required to adopt the release before GA.
+Existing beta credentials and `tenant_id` continue to work through this upgrade, and nothing else
+is required to adopt the release before GA.
 
 **At GA:**
 
-4. **Register a replacement API integration and update the provider credentials.** Record the
+5. **Register a replacement API integration and update the provider credentials.** Record the
    permissions held by each beta integration beforehand, so the equivalents can be selected. See
    [API integration credentials](#api-integration-credentials).
-5. **Replace `tenant_id` with `environment_id`.** Register the replacement as
+6. **Replace `tenant_id` with `environment_id`.** Register the replacement as
    environment-scoped unless single-product access is deliberately what you want: tenant scope is
    the legacy option, costs one integration per tenant per product, and cannot hold the blueprint
    or compliance-benchmark permissions at all. See [Scope](#scope).
@@ -328,21 +332,59 @@ corresponding data source.
 
 ### Removed: `category_name` and `site_name` on `jamfplatform_pro_patch_software_title`
 
-**Action needed only if either attribute is referenced: read the name from the object that owns
-it.** Both were read-only display names, and the Jamf Pro endpoints this resource now uses report
-category and site by ID alone:
+**Action needed if either attribute is referenced: read the name from the object that owns it.**
+Both were read-only display names, and the Jamf Pro endpoints this resource now uses report
+category and site by ID alone. Where the category is managed by Terraform, read the name from that
+resource. Where it is not — the usual case, since these attributes were read-only and the
+assignment is commonly made in the Jamf Pro UI — look it up by the ID the title reports:
 
 ```hcl
-# category_name = jamfplatform_pro_patch_software_title.example.category_name
-category_name = jamfplatform_pro_category.example.name
+# the category is managed by Terraform
+output "category_name" {
+  # value = jamfplatform_pro_patch_software_title.example.category_name
+  value = jamfplatform_pro_category.example.name
+}
+
+# the category is not managed by Terraform
+data "jamfplatform_pro_category" "title" {
+  id = jamfplatform_pro_patch_software_title.example.category_id
+}
+
+output "category_name" {
+  value = data.jamfplatform_pro_category.title.name
+}
 ```
+
+`jamfplatform_pro_site` covers `site_name` the same way, selected by either `id` or `name`.
 
 State migrates automatically — the provider strips both attributes during the state upgrade, so
 no `terraform state` surgery is needed. They have also been removed from the corresponding data
-source. Nothing else about the resource changes: patch software titles are now read, updated and
-deleted through Jamf Pro's `/patch-software-title-configurations` endpoints rather than the
-deprecated ProClassic `/patchsoftwaretitles` ones, and every other attribute behaves as before,
-`version_packages` included — an assignment made outside Terraform still survives an apply.
+source.
+
+**Grant two further permissions.** The data source, the list resource and `terraform import`
+resolve a title's `source_id` from the tenant's patch source catalogues, because the endpoints
+this resource now uses name its patch source without numbering it. An integration reaching this
+resource through any of those three paths therefore needs **App lifecycle management → External
+patch sources → Read** and **App lifecycle management → Internal patch sources → Read** alongside
+**Patch titles**. Without them the read fails with `403 BAD_PERMISSIONS`, reported as `Unable to
+determine the patch software title's source_id`. Planning and applying a title already in state
+is unaffected, as `source_id` is carried forward rather than resolved again. The **Required Jamf
+permissions** table on each of the three documentation pages lists the full set.
+
+**`category_id` and `site_id` no longer accept `"0"`.** Use `-1`, the default, for "No category
+assigned" and "NONE"; a configuration setting either attribute to `"0"` is now rejected at plan
+time. This is the reverse of the retired endpoint's convention, under which `0` cleared the
+assignment and `-1` was a silent no-op. A title whose state still holds `"0"` needs no state edit,
+as the next refresh reads it back as `-1`; only a configuration setting the value explicitly has to
+change.
+
+Otherwise the resource behaves as before: patch software titles are now read, updated and deleted
+through Jamf Pro's `/patch-software-title-configurations` endpoints rather than the deprecated
+ProClassic `/patchsoftwaretitles` ones, and every attribute that remains keeps its meaning.
+`version_packages` still manages only the versions it names, but it now delivers that by reading
+the title's current assignments and rewriting the whole set rather than by the endpoint merging
+each version in turn. An assignment created in the Jamf Pro UI between that read and the write can
+therefore be lost, so avoid editing a title's **Definition** tab while an apply is in flight.
 
 ### Deprecated, not yet removed: the flat blueprint component attributes
 

--- a/docs/list-resources/pro_patch_software_title.md
+++ b/docs/list-resources/pro_patch_software_title.md
@@ -8,6 +8,8 @@ description: |-
   Grant the API integration the following permissions in Jamf Account — see Getting started with the Platform API https://developer.jamf.com/platform-api/reference/getting-started-with-platform-api. Category and Permission name the section and row of the permission picker; Actions are the boxes to tick within that row.
   | Category | Permission | Actions | API capability |
   |---|---|---|---|
+  | App lifecycle management | External patch sources | Read | `patch-external-source` |
+  | App lifecycle management | Internal patch sources | Read | `patch-internal-source` |
   | App lifecycle management | Patch titles | Read | `patch-management-software-titles` |
 ---
 
@@ -21,6 +23,8 @@ Grant the API integration the following permissions in Jamf Account — see [Get
 
 | Category | Permission | Actions | API capability |
 |---|---|---|---|
+| App lifecycle management | External patch sources | Read | `patch-external-source` |
+| App lifecycle management | Internal patch sources | Read | `patch-internal-source` |
 | App lifecycle management | Patch titles | Read | `patch-management-software-titles` |
 
 ## Example Usage

--- a/docs/list-resources/pro_patch_software_title.md
+++ b/docs/list-resources/pro_patch_software_title.md
@@ -30,20 +30,22 @@ Grant the API integration the following permissions in Jamf Account — see [Get
 ## Example Usage
 
 ```terraform
-# List every Jamf Pro patch software title.
+# List every Jamf Pro patch software title. NOTE: with include_resource the
+# returned objects leave available_versions and extension_attributes null —
+# each would cost one extra Jamf Pro call per title; read a single title with
+# the data source when you need them.
 list "jamfplatform_pro_patch_software_title" "all" {
   provider = jamfplatform
 }
 
-# List patch software titles whose name_id (catalog key) contains the substring
-# "285" (case-insensitive). NOTE: the classic list response surfaces no display
-# name through the SDK, so the filter matches name_id, not the display name.
-list "jamfplatform_pro_patch_software_title" "by_name_id" {
+# List patch software titles whose display name contains the substring "Adobe"
+# (case-insensitive).
+list "jamfplatform_pro_patch_software_title" "by_name" {
   provider = jamfplatform
 
   config {
     filter = {
-      name_substring = "285"
+      name_substring = "Adobe"
     }
   }
 }

--- a/docs/resources/pro_patch_software_title.md
+++ b/docs/resources/pro_patch_software_title.md
@@ -4,11 +4,12 @@ page_title: "jamfplatform_pro_patch_software_title Resource - terraform-provider
 subcategory: ""
 description: |-
   Manages a Jamf Pro patch software title, found in the UI under Computers → Patch management. A configured title spans the tabs of that interface: the Software Title Settings tab (name, category_id, site_id, notifications), the Definition tab (per-version package assignments), and the Extension Attribute tab (extension_attributes / accept_extension_attributes). A title is defined by its name_id (catalog key) and source_id (patch source); the server populates the full catalog of available_versions. Assign packages to specific versions via version_packages (the Definition tab's per-version Package column) so patch policies can target them.
-  **Deprecation notice:** this resource is backed by the Jamf ProClassic `/patchsoftwaretitles` endpoints, which the Jamf API spec flags as deprecated in favour of `/patch-software-title-configurations`. The classic endpoints remain the only functional create surface: the configurations `POST` requires a `softwareTitleId`, which is the classic title id, and the only call that mints one also creates the configuration — so there is nothing for the provider to migrate create onto. Behaviour may change if Jamf removes the classic endpoints.
   Required Jamf permissions
   Grant the API integration the following permissions in Jamf Account — see Getting started with the Platform API https://developer.jamf.com/platform-api/reference/getting-started-with-platform-api. Category and Permission name the section and row of the permission picker; Actions are the boxes to tick within that row.
   | Category | Permission | Actions | API capability |
   |---|---|---|---|
+  | App lifecycle management | External patch sources | Read | `patch-external-source` |
+  | App lifecycle management | Internal patch sources | Read | `patch-internal-source` |
   | App lifecycle management | Patch titles | Create, Read, Update, Delete | `patch-management-software-titles` |
 ---
 
@@ -16,7 +17,7 @@ description: |-
 
 Manages a Jamf Pro patch software title, found in the UI under **Computers → Patch management**. A configured title spans the tabs of that interface: the **Software Title Settings** tab (`name`, `category_id`, `site_id`, notifications), the **Definition** tab (per-version package assignments), and the **Extension Attribute** tab (`extension_attributes` / `accept_extension_attributes`). A title is defined by its `name_id` (catalog key) and `source_id` (patch source); the server populates the full catalog of `available_versions`. Assign packages to specific versions via `version_packages` (the **Definition** tab's per-version **Package** column) so patch policies can target them.
 
-> **Deprecation notice:** this resource is backed by the Jamf ProClassic `/patchsoftwaretitles` endpoints, which the Jamf API spec flags as deprecated in favour of `/patch-software-title-configurations`. The classic endpoints remain the only functional create surface: the configurations `POST` requires a `softwareTitleId`, which is the classic title id, and the only call that mints one also creates the configuration — so there is nothing for the provider to migrate create onto. Behaviour may change if Jamf removes the classic endpoints.
+
 
 **Required Jamf permissions**
 
@@ -24,6 +25,8 @@ Grant the API integration the following permissions in Jamf Account — see [Get
 
 | Category | Permission | Actions | API capability |
 |---|---|---|---|
+| App lifecycle management | External patch sources | Read | `patch-external-source` |
+| App lifecycle management | Internal patch sources | Read | `patch-internal-source` |
 | App lifecycle management | Patch titles | Create, Read, Update, Delete | `patch-management-software-titles` |
 
 ## Example Usage
@@ -114,10 +117,8 @@ output "adobe_air_extension_attributes" {
 ### Read-Only
 
 - `available_versions` (List of String) All `software_version` strings the patch source publishes for this title, newest first. Returned by Jamf Pro; use these as keys for `version_packages`.
-- `category_name` (String) Category display name. Returned by Jamf Pro; not user-settable.
 - `extension_attributes` (Attributes List) Extension attributes Jamf has attached to this title, with their acceptance status. Read-only — use `accept_extension_attributes` to accept pending ones. Empty for titles with no extension attribute. (see [below for nested schema](#nestedatt--extension_attributes))
 - `id` (String) Patch software title ID assigned by Jamf Pro.
-- `site_name` (String) Site display name. Returned by Jamf Pro; not user-settable.
 
 <a id="nestedatt--timeouts"></a>
 ### Nested Schema for `timeouts`

--- a/docs/resources/pro_patch_software_title.md
+++ b/docs/resources/pro_patch_software_title.md
@@ -17,8 +17,6 @@ description: |-
 
 Manages a Jamf Pro patch software title, found in the UI under **Computers → Patch management**. A configured title spans the tabs of that interface: the **Software Title Settings** tab (`name`, `category_id`, `site_id`, notifications), the **Definition** tab (per-version package assignments), and the **Extension Attribute** tab (`extension_attributes` / `accept_extension_attributes`). A title is defined by its `name_id` (catalog key) and `source_id` (patch source); the server populates the full catalog of `available_versions`. Assign packages to specific versions via `version_packages` (the **Definition** tab's per-version **Package** column) so patch policies can target them.
 
-
-
 **Required Jamf permissions**
 
 Grant the API integration the following permissions in Jamf Account — see [Getting started with the Platform API](https://developer.jamf.com/platform-api/reference/getting-started-with-platform-api). `Category` and `Permission` name the section and row of the permission picker; `Actions` are the boxes to tick within that row.
@@ -107,11 +105,11 @@ output "adobe_air_extension_attributes" {
 ### Optional
 
 - `accept_extension_attributes` (Boolean) Accept the extension attribute(s) Jamf attaches to this title (UI "Extension Attribute" tab, **Accept**). For some titles Jamf supplies a script that runs on managed computers to collect the installed version; inventory is not gathered until it is accepted. Set to `true` to accept any pending extension attributes on the next apply. **Accepting is one-way** — it cannot be reverted, so setting this back to `false` (or removing it) does not un-accept; it simply stops accepting new ones. Leave unset for titles that have no extension attribute.
-- `category_id` (String) Jamf Pro category ID (UI "Category"). Use `-1` (default) for "No category assigned".
+- `category_id` (String) Jamf Pro category ID (UI "Category"). Set `-1` for "No category assigned" — the value a title starts out with. Only a positive ID or `-1` is accepted; `0` and other non-positive values are rejected when you plan. Removing this attribute from your configuration leaves the current category in place, so clear an assigned category by setting `-1` explicitly.
 - `email_notification` (Boolean) Whether an email notification is sent for new versions (UI "Email"). Server-defaulted when omitted.
-- `site_id` (String) Jamf Pro site ID. Use `-1` (default) for "NONE".
+- `site_id` (String) Jamf Pro site ID (UI "Site"). Set `-1` for "None" — the value a title starts out with. Only a positive ID or `-1` is accepted; `0` and other non-positive values are rejected when you plan. Removing this attribute from your configuration leaves the current site in place, so clear an assigned site by setting `-1` explicitly.
 - `timeouts` (Attributes) (see [below for nested schema](#nestedatt--timeouts))
-- `version_packages` (Map of String) Managed map of version→package assignments. Keys are `software_version` strings drawn from `available_versions`; values are Jamf Pro package ID strings. A patch policy can only target a version that has a package assigned here. Only the keys you declare are managed: other server-side assignments are left untouched, and removing a key clears that version's package on the next apply.
+- `version_packages` (Map of String) Managed map of version→package assignments. Keys are `software_version` strings drawn from `available_versions`; values are Jamf Pro package ID strings. A patch policy can only target a version that has a package assigned here. Only the keys you declare are managed: other assignments on the title are left alone, and removing a key clears that version's package on the next apply. Omit the attribute entirely to manage no assignments — an empty map is not accepted.
 - `web_notification` (Boolean) Whether a Jamf Pro notification is raised for new versions (UI "Jamf Pro Notification"). Server-defaulted when omitted.
 
 ### Read-Only

--- a/examples/list-resources/jamfplatform_pro_patch_software_title/list-resource.tfquery.hcl
+++ b/examples/list-resources/jamfplatform_pro_patch_software_title/list-resource.tfquery.hcl
@@ -1,17 +1,19 @@
-# List every Jamf Pro patch software title.
+# List every Jamf Pro patch software title. NOTE: with include_resource the
+# returned objects leave available_versions and extension_attributes null —
+# each would cost one extra Jamf Pro call per title; read a single title with
+# the data source when you need them.
 list "jamfplatform_pro_patch_software_title" "all" {
   provider = jamfplatform
 }
 
-# List patch software titles whose name_id (catalog key) contains the substring
-# "285" (case-insensitive). NOTE: the classic list response surfaces no display
-# name through the SDK, so the filter matches name_id, not the display name.
-list "jamfplatform_pro_patch_software_title" "by_name_id" {
+# List patch software titles whose display name contains the substring "Adobe"
+# (case-insensitive).
+list "jamfplatform_pro_patch_software_title" "by_name" {
   provider = jamfplatform
 
   config {
     filter = {
-      name_substring = "285"
+      name_substring = "Adobe"
     }
   }
 }

--- a/internal/providerdata/providerdata.go
+++ b/internal/providerdata/providerdata.go
@@ -9,6 +9,7 @@ package providerdata
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 
@@ -102,6 +103,9 @@ type Data struct {
 
 	aiSchemaMu    sync.Mutex
 	aiSchemaCache *aischemas.Cache
+
+	patchSourceMu    sync.Mutex
+	patchSourceCache *PatchSourceCache
 }
 
 // AISchemaCache returns the shared AI Governance product catalogue and vendor schema cache, building
@@ -122,6 +126,110 @@ func (d *Data) AISchemaCache() *aischemas.Cache {
 		d.aiSchemaCache = aischemas.NewCache(d.Client)
 	}
 	return d.aiSchemaCache
+}
+
+// PatchSourceCatalogues is a snapshot of the tenant's two Jamf Pro patch source
+// catalogues, internal and external, as one value.
+//
+// It carries the catalogue entries as read rather than a name → id index, because the
+// question its consumer asks is not a plain lookup: a patch software title names its
+// source but never numbers it, a name present in both catalogues cannot be resolved at
+// all, and the refusal has to name the candidate ids. Keeping the snapshot as-read leaves
+// that decision in one pure function over these two slices (in the patch software title
+// package, which owns the law and the calls that fill this), so the cache only ever
+// answers "what does this tenant have", never "which id is it".
+type PatchSourceCatalogues struct {
+	Internal []proclassic.IDName
+	External []proclassic.IDName
+}
+
+// PatchSourceCache holds one PatchSourceCatalogues snapshot per configured provider
+// instance, read on first use.
+//
+// Both catalogues are tenant-global and identical for every patch software title in a
+// configuration, and every title read outside the managed-resource steady state needs
+// them, so without this a configuration with N patch software title data sources pays 2N
+// identical catalogue requests on every plan and again on every apply.
+//
+// A failed read is not cached: the next caller retries it. A transient blip or a
+// momentary privilege problem on the first title must not blank every later title's
+// source_id for the rest of the run — the same rule this package applies to the Jamf Pro
+// version fetch and aischemas to its vendor schemas.
+//
+// The read itself is injected rather than written here. The two SDK calls it makes belong
+// to the patch software title package: that package declares the privileges they require,
+// and its tests derive that declaration from the call sites in its own files.
+type PatchSourceCache struct {
+	client *proclassic.Client
+	read   func(context.Context, *proclassic.Client) (PatchSourceCatalogues, error)
+
+	mu         sync.Mutex
+	loaded     bool
+	catalogues PatchSourceCatalogues
+}
+
+// Catalogues returns the snapshot, reading it at most once per configured provider
+// instance.
+//
+// The lock is held across the read, so concurrent callers collapse into one round-trip
+// instead of racing to fill the same snapshot. There is exactly one snapshot to fill —
+// unlike the AI Governance schema cache, where a lock held across a fetch would make
+// callers wanting different schemas wait on each other.
+//
+// Nil-receiver-safe: resolving a patch source name is best-effort everywhere except
+// import, so a construct that never received a cache must report an unresolved id rather
+// than panic mid-plan.
+func (c *PatchSourceCache) Catalogues(ctx context.Context) (PatchSourceCatalogues, error) {
+	if c == nil {
+		return PatchSourceCatalogues{}, errors.New("the provider is not configured, so the patch source catalogues cannot be read")
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.loaded {
+		return c.catalogues, nil
+	}
+	catalogues, err := c.read(ctx, c.client)
+	if err != nil {
+		return PatchSourceCatalogues{}, err
+	}
+	c.catalogues = catalogues
+	c.loaded = true
+	return c.catalogues, nil
+}
+
+// ConfigurePatchSources returns the patch source cache shared by every construct
+// configured from this provider instance, building it on first use with read.
+//
+// It mirrors ConfigureImpact: no diagnostics, and nil when providerData is not a *Data —
+// including the nil ProviderData the framework passes during early lifecycle. A caller
+// that receives nil still resolves nothing and reports it, because a null source_id
+// outside import is advisory.
+//
+// The first caller's read function is the cache's read function; later callers reuse the
+// cache they find. Every caller passes the same package-level function, so which one
+// registered it cannot matter.
+func ConfigurePatchSources(providerData any, read func(context.Context, *proclassic.Client) (PatchSourceCatalogues, error)) *PatchSourceCache {
+	pd, ok := providerData.(*Data)
+	if !ok {
+		return nil
+	}
+	return pd.patchSources(read)
+}
+
+// patchSources lazily builds the provider-instance patch source cache over a classic
+// client of this Data's own, so no caller has to hand one in.
+func (d *Data) patchSources(read func(context.Context, *proclassic.Client) (PatchSourceCatalogues, error)) *PatchSourceCache {
+	if d == nil {
+		return nil
+	}
+	d.patchSourceMu.Lock()
+	defer d.patchSourceMu.Unlock()
+
+	if d.patchSourceCache == nil {
+		d.patchSourceCache = &PatchSourceCache{client: proclassic.New(d.Client), read: read}
+	}
+	return d.patchSourceCache
 }
 
 // EnableImpactAlerts turns on plan-time impact alerts for this provider

--- a/internal/providerdata/providerdata_test.go
+++ b/internal/providerdata/providerdata_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform"
+	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/proclassic"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 )
 
@@ -366,5 +367,137 @@ func TestEnrollmentWriteLock_StableIdentity(t *testing.T) {
 	// Distinct Data values must not share a lock.
 	if other := New(newFakeClient()).EnrollmentWriteLock(); other == a {
 		t.Error("distinct Data values unexpectedly share one enrollment write lock")
+	}
+}
+
+// The patch source cache is the second provider-instance cache in this file (the
+// Jamf Pro version being the first) and follows the same two rules: a success is
+// read once and shared, an error is not cached. Both catalogue reads are
+// injected, so none of these tests needs a client or a mock server.
+
+// TestPatchSourceCache_ReadsOnce verifies the snapshot is read once per cache
+// and shared. Without it a configuration with N patch software title data
+// sources pays 2N identical catalogue requests on every plan and again on every
+// apply.
+func TestPatchSourceCache_ReadsOnce(t *testing.T) {
+	name := "Jamf"
+	id := 1
+	calls := 0
+	cache := &PatchSourceCache{
+		read: func(_ context.Context, _ *proclassic.Client) (PatchSourceCatalogues, error) {
+			calls++
+			return PatchSourceCatalogues{Internal: []proclassic.IDName{{ID: &id, Name: &name}}}, nil
+		},
+	}
+
+	for i := range 3 {
+		got, err := cache.Catalogues(context.Background())
+		if err != nil {
+			t.Fatalf("call %d: unexpected error %v", i, err)
+		}
+		if len(got.Internal) != 1 || got.Internal[0].Name == nil || *got.Internal[0].Name != "Jamf" {
+			t.Fatalf("call %d: expected the cached snapshot, got %+v", i, got)
+		}
+	}
+	if calls != 1 {
+		t.Errorf("expected exactly 1 catalogue read for a cached success, got %d", calls)
+	}
+}
+
+// TestPatchSourceCache_ErrorIsNotCached verifies a failed read is retried by the
+// next caller. A transient blip or a momentary privilege problem on the first
+// title must not blank every later title's source_id for the rest of the run.
+func TestPatchSourceCache_ErrorIsNotCached(t *testing.T) {
+	name := "Jamf"
+	id := 1
+	calls := 0
+	cache := &PatchSourceCache{
+		read: func(_ context.Context, _ *proclassic.Client) (PatchSourceCatalogues, error) {
+			calls++
+			if calls == 1 {
+				return PatchSourceCatalogues{}, errors.New("transient 503")
+			}
+			return PatchSourceCatalogues{External: []proclassic.IDName{{ID: &id, Name: &name}}}, nil
+		},
+	}
+
+	if _, err := cache.Catalogues(context.Background()); err == nil {
+		t.Fatal("expected the first read's error to surface")
+	}
+
+	got, err := cache.Catalogues(context.Background())
+	if err != nil {
+		t.Fatalf("expected the second read to retry and succeed, got %v", err)
+	}
+	if len(got.External) != 1 {
+		t.Errorf("expected the retried snapshot, got %+v", got)
+	}
+	if calls != 2 {
+		t.Errorf("expected the failed read to be retried (2 reads), got %d", calls)
+	}
+}
+
+// TestPatchSourceCache_NilReceiver verifies a construct that never received a
+// cache reports an unresolved id rather than panicking mid-plan. Resolving a
+// patch source name is best-effort everywhere except import.
+func TestPatchSourceCache_NilReceiver(t *testing.T) {
+	got, err := (*PatchSourceCache)(nil).Catalogues(context.Background())
+	if err == nil {
+		t.Fatal("expected an error from a nil cache")
+	}
+	if len(got.Internal) != 0 || len(got.External) != 0 {
+		t.Errorf("expected an empty snapshot from a nil cache, got %+v", got)
+	}
+	if !strings.Contains(err.Error(), "not configured") {
+		t.Errorf("expected the error to say the provider is not configured, got %q", err)
+	}
+}
+
+// TestConfigurePatchSources_NilProviderData verifies the nil ProviderData the
+// framework passes during early lifecycle yields a nil cache rather than a
+// diagnostic — the same contract ConfigureImpact keeps.
+func TestConfigurePatchSources_NilProviderData(t *testing.T) {
+	noRead := func(context.Context, *proclassic.Client) (PatchSourceCatalogues, error) {
+		t.Fatal("the read must not be invoked while configuring")
+		return PatchSourceCatalogues{}, nil
+	}
+	if got := ConfigurePatchSources(nil, noRead); got != nil {
+		t.Errorf("expected a nil cache for nil providerData, got %v", got)
+	}
+	if got := ConfigurePatchSources("not a Data value", noRead); got != nil {
+		t.Errorf("expected a nil cache for a wrong providerData type, got %v", got)
+	}
+}
+
+// TestConfigurePatchSources_StableIdentity verifies every construct configured
+// from one provider instance shares one cache — the whole point of hanging it
+// off Data — and that distinct Data values do not share one. The read is also
+// asserted to receive a client, since Data builds the classic client itself
+// rather than taking one from the caller.
+func TestConfigurePatchSources_StableIdentity(t *testing.T) {
+	var gotClient *proclassic.Client
+	read := func(_ context.Context, c *proclassic.Client) (PatchSourceCatalogues, error) {
+		gotClient = c
+		return PatchSourceCatalogues{}, nil
+	}
+
+	pd := New(newFakeClient())
+	a := ConfigurePatchSources(pd, read)
+	b := ConfigurePatchSources(pd, read)
+	if a == nil {
+		t.Fatal("expected a cache for a *Data providerData")
+	}
+	if a != b {
+		t.Errorf("expected one shared cache per provider instance, got %p and %p", a, b)
+	}
+	if other := ConfigurePatchSources(New(newFakeClient()), read); other == a {
+		t.Error("distinct Data values unexpectedly share one patch source cache")
+	}
+
+	if _, err := a.Catalogues(context.Background()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotClient == nil {
+		t.Error("the cache must hand its own classic client to the read")
 	}
 }

--- a/internal/resources/pro/patch_software_title/crud.go
+++ b/internal/resources/pro/patch_software_title/crud.go
@@ -22,7 +22,14 @@
 // flagged deprecated in the Jamf API spec (the SDK func carries `// Deprecated:`
 // pointing at /v2/patch-software-title-configurations), so the one remaining
 // call is annotated rather than removed. Revisit only if Jamf gives the
-// configurations surface an id-minting create.
+// configurations surface an id-minting create, and note that its suppression
+// names #311 rather than a successor, because there is none.
+//
+// This move completes the patch-software-title-configurations half of #311
+// (deprecation(pro): computers-inventory v3→v4,
+// patch-software-title-configurations v2→v3 — migrate by 2027-01-14). The
+// computers-inventory half of that issue is still outstanding, so #311 stays
+// open.
 //
 // Everything else moved to v3, wire-probed 2026-09-02 on Jamf Pro 11.31.1 in
 // production EU. Four behaviours drive the code and are easy to get wrong:
@@ -49,6 +56,13 @@
 // absoluteOrderId:asc order is the newest-first order the classic <versions>
 // block used, so no re-sorting).
 //
+// That /definitions read is ADVISORY everywhere. available_versions is plain
+// Computed, informational, and never written by Terraform, while every caller
+// sits either after a write that has already landed (the id-minting create, the
+// merge-patch) or on an object that read cleanly — so a failed catalogue read
+// warns and keeps the value already recorded rather than failing the operation.
+// See readAvailableVersionsBestEffort.
+//
 // /pro/v3 answers 200 with no Deprecation header; /pro/v2 still answers 200
 // carrying `deprecation: date="Tue, 14 Jul 2026 00:00:00 GMT"`; /pro/v4 answers
 // 403 BAD_PERMISSIONS, which this repo reads as unrouted rather than
@@ -65,6 +79,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/helpers"
@@ -76,6 +91,13 @@ import (
 // the title), creating the v3 configuration in the same act.
 // category/site/notifications/version_packages are then applied through a
 // single v3 merge-patch, which answers with the stored configuration.
+//
+// The version catalogue read that follows is best-effort. The title is minted by
+// then, so a fatal catalogue failure would return before the only State.Set and
+// orphan it server-side — the next apply would re-POST the same
+// name_id + source_id. It therefore warns and leaves available_versions empty,
+// which the next Read fills in; the same line the accept side-call sits behind,
+// one screen lower.
 func (r *PatchSoftwareTitleResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var plan PatchSoftwareTitleResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
@@ -91,7 +113,7 @@ func (r *PatchSoftwareTitleResource) Create(ctx context.Context, req resource.Cr
 	createCtx, cancel := context.WithTimeout(ctx, createTimeout)
 	defer cancel()
 
-	created, err := r.client.CreatePatchSoftwareTitleByID(createCtx, "0", buildPatchSoftwareTitleCreateInput(plan)) //nolint:staticcheck // SA1019: classic /patchsoftwaretitles is the only id-minting create — see file header note
+	created, err := r.client.CreatePatchSoftwareTitleByID(createCtx, "0", buildPatchSoftwareTitleCreateInput(plan)) //nolint:staticcheck // SA1019: classic /patchsoftwaretitles is the only id-minting create, and the configurations surface has no successor to migrate to — see #311 and the file header note
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating Jamf Pro patch software title", err.Error())
 		return
@@ -126,11 +148,8 @@ func (r *PatchSoftwareTitleResource) Create(ctx context.Context, req resource.Cr
 		return
 	}
 
-	avail, availDiags := r.readAvailableVersions(createCtx, id.ValueString())
+	avail, availDiags := r.readAvailableVersionsBestEffort(createCtx, id.ValueString(), types.ListNull(types.StringType))
 	resp.Diagnostics.Append(availDiags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
 
 	resp.Diagnostics.Append(assignPatchSoftwareTitleResourceModel(createCtx, &plan, got, avail, keysOf(planPackages))...)
 	if resp.Diagnostics.HasError() {
@@ -173,6 +192,13 @@ func (r *PatchSoftwareTitleResource) Create(ctx context.Context, req resource.Cr
 // map comes back null and ImportStateVerify must ignore it (no prior keys to
 // reconstruct the managed subset from) — and source_id, which the v3 payload
 // does not carry, is resolved from the reported patch source name.
+//
+// The version catalogue read is best-effort here too: a title whose
+// configuration reads cleanly should not take a whole plan down because a
+// supplementary catalogue read failed, which is the line refreshExtensionAttributes
+// already draws. The prior state's available_versions is carried through on
+// failure, so a warning never rewrites the attribute to an empty list and
+// claims the title publishes no versions.
 func (r *PatchSoftwareTitleResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	var state PatchSoftwareTitleResourceModel
 	isImport := req.State.Raw.IsNull()
@@ -240,11 +266,8 @@ func (r *PatchSoftwareTitleResource) Read(ctx context.Context, req resource.Read
 		return
 	}
 
-	avail, availDiags := r.readAvailableVersions(readCtx, state.ID.ValueString())
+	avail, availDiags := r.readAvailableVersionsBestEffort(readCtx, state.ID.ValueString(), state.AvailableVersions)
 	resp.Diagnostics.Append(availDiags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
 
 	// source_id is carried forward by assignPatchSoftwareTitleResourceModel,
 	// which never touches it. Resolve it from the reported source name only when
@@ -264,7 +287,7 @@ func (r *PatchSoftwareTitleResource) Read(ctx context.Context, req resource.Read
 		if err != nil {
 			resp.Diagnostics.AddError(
 				"Unable to determine the patch software title's source_id",
-				fmt.Sprintf("Jamf Pro reports this title's patch source as %q, but the provider could not match that name to a patch source ID: %v", got.PatchSourceName, err),
+				unresolvedSourceIDDetail(got.DisplayName, got.PatchSourceName, err),
 			)
 			return
 		}
@@ -288,7 +311,18 @@ func (r *PatchSoftwareTitleResource) Read(ctx context.Context, req resource.Read
 // outside Terraform survive — the managed-subset contract version_packages
 // documents. That fold needs the live set, so it costs a read; when neither the
 // plan nor prior state declares any assignment there is nothing to manage and
-// the key is omitted instead, skipping the read.
+// the key is omitted instead, skipping the read. An assignment the provider
+// cannot read back (no version or no package id) cannot be folded in, and a full
+// replacement clears whatever it omits, so how many of those an apply is about
+// to clear is warned about rather than passed over in silence.
+//
+// The version catalogue read after the patch is best-effort, and falls back to
+// the PRIOR STATE's available_versions rather than the plan's: the attribute is
+// plain Computed with no plan modifier, so the planned value is Unknown here and
+// an apply must still write something known or Terraform reports an inconsistent
+// result. Erroring instead would discard a merge-patch that already succeeded,
+// leaving the pre-apply name, category, site, notifications and package
+// assignments in state.
 func (r *PatchSoftwareTitleResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	var plan, state PatchSoftwareTitleResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
@@ -323,7 +357,14 @@ func (r *PatchSoftwareTitleResource) Update(ctx context.Context, req resource.Up
 			resp.Diagnostics.AddError("Error reading Jamf Pro patch software title package assignments", err.Error())
 			return
 		}
-		desired = unionVersionPackages(assignedPackagesByVersion(live.Packages), planPackages, priorKeys)
+		liveAssigned, unreadable := assignedPackagesByVersionCounted(live.Packages)
+		if unreadable > 0 {
+			resp.Diagnostics.AddWarning(
+				"Patch software title package assignments could not be read in full",
+				fmt.Sprintf("Jamf Pro reported %d package assignment(s) for this title with no software version or no package ID, so the provider cannot carry them over. Because the v3 packages array is a full replacement, this apply clears those assignments.", unreadable),
+			)
+		}
+		desired = unionVersionPackages(liveAssigned, planPackages, priorKeys)
 	}
 
 	got, err := r.proClient.UpdatePatchSoftwareTitleConfigurationV3(updateCtx, plan.ID.ValueString(), buildPatchSoftwareTitleConfigurationPatch(plan, desired))
@@ -332,11 +373,8 @@ func (r *PatchSoftwareTitleResource) Update(ctx context.Context, req resource.Up
 		return
 	}
 
-	avail, availDiags := r.readAvailableVersions(updateCtx, plan.ID.ValueString())
+	avail, availDiags := r.readAvailableVersionsBestEffort(updateCtx, plan.ID.ValueString(), state.AvailableVersions)
 	resp.Diagnostics.Append(availDiags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
 
 	resp.Diagnostics.Append(assignPatchSoftwareTitleResourceModel(updateCtx, &plan, got, avail, keysOf(planPackages))...)
 	if resp.Diagnostics.HasError() {
@@ -403,15 +441,28 @@ func (r *PatchSoftwareTitleResource) Delete(ctx context.Context, req resource.De
 	}
 }
 
-// readAvailableVersions reads the title's version catalogue from the
-// /definitions sub-resource, which is where v3 keeps it — the configuration
-// body carries only the versions that have a package assigned.
-func (r *PatchSoftwareTitleResource) readAvailableVersions(ctx context.Context, id string) ([]string, diag.Diagnostics) {
+// readAvailableVersionsBestEffort reads the title's version catalogue from the
+// /definitions sub-resource, which is where v3 keeps it — the configuration body
+// carries only the versions that have a package assigned.
+//
+// There is deliberately no fatal variant: no caller may abort on this read.
+// available_versions is plain Computed and informational, and each caller either
+// has a write behind it that already landed or an object that read cleanly. A
+// failure therefore warns, names the endpoint, and yields the fallback value the
+// caller passes — prior state on Read and Update (the only known value there,
+// the planned one being Unknown), and a null list on Create, where the title is
+// new and the next Read fills the catalogue in.
+func (r *PatchSoftwareTitleResource) readAvailableVersionsBestEffort(ctx context.Context, id string, fallback types.List) ([]string, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	defs, err := r.proClient.ListPatchSoftwareTitleDefinitionsV3(ctx, id, nil, "")
 	if err != nil {
-		diags.AddError("Error reading Jamf Pro patch software title versions", err.Error())
-		return nil, diags
+		diags.AddWarning(
+			"Unable to read patch software title versions",
+			fmt.Sprintf("Jamf Pro did not return this title's version catalogue from GET /pro/v3/patch-software-title-configurations/%s/definitions, so available_versions keeps the value already recorded for it (empty for a title created by this apply). The title itself is unaffected and the next refresh repopulates it: %v", id, err),
+		)
+		prior, priorDiags := stringsFromList(ctx, fallback)
+		diags.Append(priorDiags...)
+		return prior, diags
 	}
 	return definitionVersions(defs), diags
 }

--- a/internal/resources/pro/patch_software_title/crud.go
+++ b/internal/resources/pro/patch_software_title/crud.go
@@ -2,46 +2,60 @@
 // SPDX-License-Identifier: MPL-2.0
 
 // SDK endpoints used:
-//   proclassic.CreatePatchSoftwareTitleByID                (POST id="0" mints the title)
-//   proclassic.GetPatchSoftwareTitleByID
-//   proclassic.UpdatePatchSoftwareTitleByID                (PUT, returns 201 empty body → GET after)
-//   proclassic.DeletePatchSoftwareTitleByID
-//   proclassic.ListPatchSoftwareTitles                     (list resource)
-//   pro.ListPatchSoftwareTitleExtensionAttributesV3        (read EAs; v3 config id == classic title id)
-//   pro.UpdatePatchSoftwareTitleConfigurationV3            (accept EAs; merge-patch, accept is one-way)
+//   proclassic.CreatePatchSoftwareTitleByID                (POST id="0" mints the title — the only classic call left)
+//   proclassic.ListPatchInternalSources                    (source_id resolution: name → id, import/data source only)
+//   proclassic.ListPatchExternalSources                    (source_id resolution: name → id, import/data source only)
+//   pro.GetPatchSoftwareTitleConfigurationV3               (read; v3 configuration id == classic title id)
+//   pro.UpdatePatchSoftwareTitleConfigurationV3            (merge-patch; returns the full object, so no GET after)
+//   pro.DeletePatchSoftwareTitleConfigurationV3            (204; removes the classic title with it)
+//   pro.ListPatchSoftwareTitleConfigurationsV3             (data source name lookup, list resource)
+//   pro.ListPatchSoftwareTitleDefinitionsV3                (available_versions — not on the configuration body)
+//   pro.ListPatchSoftwareTitleExtensionAttributesV3        (read EAs)
 //
-// DEPRECATION (classic CRUD): the /patchsoftwaretitles classic endpoints are
-// flagged deprecated in the Jamf API spec (the SDK funcs carry `// Deprecated:`
-// pointing at /v2/patch-software-title-configurations). They remain the only
-// functional create surface, and not merely for want of a shipped successor —
+// CREATE IS THE ONLY CLASSIC CALL, and not for want of a shipped successor —
 // the configurations POST cannot be one by construction. Wire-probed 2026-09-01
 // on Jamf Pro 11.31.1: its required softwareTitleId is the classic title id
 // itself, the catalogue's name_id is refused (400 SOFTWARE_TITLE_ID_NOT_FOUND on
 // field softwareTitleId), and the only way to mint an id — classic POST to
 // id="0" — creates the v3 configuration in the same act, so a follow-up v3 POST
-// with that id answers 400 ALREADY_EXISTS_FOR_SITE. GET
-// /proclassic/patchsoftwaretitles still answers 200. Revisit only if Jamf gives
-// the configurations surface an id-minting create, or removes the classic
-// endpoints.
+// with that id answers 400 ALREADY_EXISTS_FOR_SITE. The classic endpoints are
+// flagged deprecated in the Jamf API spec (the SDK func carries `// Deprecated:`
+// pointing at /v2/patch-software-title-configurations), so the one remaining
+// call is annotated rather than removed. Revisit only if Jamf gives the
+// configurations surface an id-minting create.
 //
-// EXTENSION-ATTRIBUTE SIDE-CHANNEL (v3): the v2 configurations client was
-// withdrawn from the SDK at this bump and the two calls in
-// extension_attributes.go moved to v3, closing the
-// patch-software-title-configurations half of #311. v3 is the top version rather
-// than an intermediate step — wire-probed 2026-09-01 on Jamf Pro 11.31.1,
-// /pro/v3/patch-software-title-configurations answers 200 with no Deprecation
-// header, /pro/v2 still answers 200 carrying `deprecation: date="Tue, 14 Jul 2026
-// 00:00:00 GMT"` (so the SDK withdrawal was spec-only), and /pro/v4 answers 403
-// BAD_PERMISSIONS, which this repo reads as unrouted rather than unprivileged.
+// Everything else moved to v3, wire-probed 2026-09-02 on Jamf Pro 11.31.1 in
+// production EU. Four behaviours drive the code and are easy to get wrong:
 //
-// Note the two deprecations point in opposite directions: the classic endpoints
-// are deprecated in favour of the configurations endpoints, whose v2 is itself
-// deprecated. Read and update could move to v3 today; create cannot, per the
-// probe above, so the surfaces cannot be retired as one.
+//   - The merge-patch needs Content-Type application/merge-patch+json; plain
+//     application/json is refused 415. The SDK sets it.
+//   - PATCH answers 200 carrying the full configuration, unlike the classic PUT
+//     (201, empty body), so Update no longer reads back what it just wrote.
+//   - `packages` is a FULL REPLACEMENT. A supplied array is the complete set of
+//     assignments — anything absent from it is cleared, and `[]` clears the lot —
+//     while omitting the key leaves the server's set untouched. The classic
+//     endpoint merged per version instead, which is what let version_packages
+//     promise that assignments made outside Terraform survive an apply. Update
+//     therefore reads the live set and folds the plan over it (unionVersionPackages)
+//     rather than sending the plan alone.
+//   - categoryId / siteId accept a positive id or the literal "-1" and reject
+//     everything else, "0" included. This retires the classic endpoint's
+//     opposite convention (0 cleared a category, -1 was a silent no-op) along
+//     with the translation either way.
 //
-// Status: extension-attribute side-channel current on v3. Classic CRUD deprecated
-// by Jamf with no published removal date, retained deliberately because the
-// configurations surface has no id-minting create. Last reviewed 2026-09-01.
+// Two things v3 does not carry: source_id (it names the patch source but never
+// numbers it — see resolveSourceID) and the version catalogue behind
+// available_versions (a separate /definitions read, whose default
+// absoluteOrderId:asc order is the newest-first order the classic <versions>
+// block used, so no re-sorting).
+//
+// /pro/v3 answers 200 with no Deprecation header; /pro/v2 still answers 200
+// carrying `deprecation: date="Tue, 14 Jul 2026 00:00:00 GMT"`; /pro/v4 answers
+// 403 BAD_PERMISSIONS, which this repo reads as unrouted rather than
+// unprivileged. v3 is therefore the top version, not an intermediate step.
+//
+// Status: current on v3 but for the id-minting create, which has no successor.
+// Last reviewed 2026-09-02.
 
 package patch_software_title
 
@@ -49,6 +63,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
@@ -58,8 +73,9 @@ import (
 // Create mints a new patch software title then applies metadata + package
 // assignments. The classic POST to id="0" allocates the real ID and seeds the
 // full versions catalog from the patch definition (name_id + source_id define
-// the title). category/site/notifications/version_packages are then applied via
-// a single follow-up PUT, after which we GET to refresh state.
+// the title), creating the v3 configuration in the same act.
+// category/site/notifications/version_packages are then applied through a
+// single v3 merge-patch, which answers with the stored configuration.
 func (r *PatchSoftwareTitleResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var plan PatchSoftwareTitleResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
@@ -75,7 +91,7 @@ func (r *PatchSoftwareTitleResource) Create(ctx context.Context, req resource.Cr
 	createCtx, cancel := context.WithTimeout(ctx, createTimeout)
 	defer cancel()
 
-	created, err := r.client.CreatePatchSoftwareTitleByID(createCtx, "0", buildPatchSoftwareTitleCreateInput(plan)) //nolint:staticcheck // SA1019: classic /patchsoftwaretitles intentionally used; v2 create unusable — see file header note
+	created, err := r.client.CreatePatchSoftwareTitleByID(createCtx, "0", buildPatchSoftwareTitleCreateInput(plan)) //nolint:staticcheck // SA1019: classic /patchsoftwaretitles is the only id-minting create — see file header note
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating Jamf Pro patch software title", err.Error())
 		return
@@ -90,30 +106,33 @@ func (r *PatchSoftwareTitleResource) Create(ctx context.Context, req resource.Cr
 	id := helpers.StringValueFromIntPtr(created.ID)
 	plan.ID = id
 
-	// Apply metadata + package assignments. priorKeys is empty on Create, so the
-	// builder only emits assigns (no clears).
-	putBody, putDiags := buildPatchSoftwareTitleUpdateInput(createCtx, plan, nil)
-	resp.Diagnostics.Append(putDiags...)
+	planPackages, pkgDiags := versionPackageMap(createCtx, plan.VersionPackages)
+	resp.Diagnostics.Append(pkgDiags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	if err := r.client.UpdatePatchSoftwareTitleByID(createCtx, id.ValueString(), putBody); err != nil { //nolint:staticcheck // SA1019: classic /patchsoftwaretitles intentionally used; v2 create unusable — see file header note
+
+	// A title minted moments ago has no assignments, so the desired set is
+	// already the complete set — no live read to fold over. Nothing configured
+	// means nothing to send, so the key is omitted entirely.
+	var desired map[string]string
+	if len(planPackages) > 0 {
+		desired = planPackages
+	}
+
+	got, err := r.proClient.UpdatePatchSoftwareTitleConfigurationV3(createCtx, id.ValueString(), buildPatchSoftwareTitleConfigurationPatch(plan, desired))
+	if err != nil {
 		resp.Diagnostics.AddError("Error applying Jamf Pro patch software title settings", err.Error())
 		return
 	}
 
-	got, err := r.client.GetPatchSoftwareTitleByID(createCtx, id.ValueString()) //nolint:staticcheck // SA1019: classic /patchsoftwaretitles intentionally used; v2 create unusable — see file header note
-	if err != nil {
-		resp.Diagnostics.AddError("Error reading created Jamf Pro patch software title", err.Error())
-		return
-	}
-
-	declaredKeys, keyDiags := versionPackageKeys(createCtx, plan.VersionPackages)
-	resp.Diagnostics.Append(keyDiags...)
+	avail, availDiags := r.readAvailableVersions(createCtx, id.ValueString())
+	resp.Diagnostics.Append(availDiags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	resp.Diagnostics.Append(assignPatchSoftwareTitleResourceModel(createCtx, &plan, got, declaredKeys)...)
+
+	resp.Diagnostics.Append(assignPatchSoftwareTitleResourceModel(createCtx, &plan, got, avail, keysOf(planPackages))...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -126,7 +145,7 @@ func (r *PatchSoftwareTitleResource) Create(ctx context.Context, req resource.Cr
 		return
 	}
 
-	// Persist state before attempting the accept side-call: the classic title is
+	// Persist state before attempting the accept side-call: the title is
 	// already minted, so a fatal accept failure must still leave it in state
 	// (else it orphans server-side). A later apply then retries via Update.
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
@@ -152,7 +171,8 @@ func (r *PatchSoftwareTitleResource) Create(ctx context.Context, req resource.Cr
 // Read refreshes state. version_packages is rebuilt from only the keys recorded
 // in prior state (the managed subset). On import there is no prior state, so the
 // map comes back null and ImportStateVerify must ignore it (no prior keys to
-// reconstruct the managed subset from).
+// reconstruct the managed subset from) — and source_id, which the v3 payload
+// does not carry, is resolved from the reported patch source name.
 func (r *PatchSoftwareTitleResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	var state PatchSoftwareTitleResourceModel
 	isImport := req.State.Raw.IsNull()
@@ -205,7 +225,7 @@ func (r *PatchSoftwareTitleResource) Read(ctx context.Context, req resource.Read
 		return
 	}
 
-	got, err := r.client.GetPatchSoftwareTitleByID(readCtx, state.ID.ValueString()) //nolint:staticcheck // SA1019: classic /patchsoftwaretitles intentionally used; v2 create unusable — see file header note
+	got, err := r.proClient.GetPatchSoftwareTitleConfigurationV3(readCtx, state.ID.ValueString())
 	if err != nil {
 		if helpers.IsNotFoundError(err) {
 			tflog.Info(ctx, "Jamf Pro patch software title not found, removing from state", map[string]any{"id": state.ID.ValueString()})
@@ -220,9 +240,35 @@ func (r *PatchSoftwareTitleResource) Read(ctx context.Context, req resource.Read
 		return
 	}
 
-	resp.Diagnostics.Append(assignPatchSoftwareTitleResourceModel(readCtx, &state, got, declaredKeys)...)
+	avail, availDiags := r.readAvailableVersions(readCtx, state.ID.ValueString())
+	resp.Diagnostics.Append(availDiags...)
 	if resp.Diagnostics.HasError() {
 		return
+	}
+
+	// source_id is carried forward by assignPatchSoftwareTitleResourceModel,
+	// which never touches it. Resolve it from the reported source name only when
+	// state has no number to carry — an import. It backs a Required,
+	// RequiresReplace attribute, so a wrong or absent value would show up as a
+	// plan that destroys the freshly imported title; a failure here is fatal
+	// rather than a warning for that reason.
+	needsSource := state.SourceID.IsNull() || state.SourceID.IsUnknown()
+
+	resp.Diagnostics.Append(assignPatchSoftwareTitleResourceModel(readCtx, &state, got, avail, declaredKeys)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if needsSource {
+		sourceID, err := resolveSourceID(readCtx, r.client, got.PatchSourceName)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Unable to determine the patch software title's source_id",
+				fmt.Sprintf("Jamf Pro reports this title's patch source as %q, but the provider could not match that name to a patch source ID: %v", got.PatchSourceName, err),
+			)
+			return
+		}
+		state.SourceID = sourceID
 	}
 
 	resp.Diagnostics.Append(r.refreshExtensionAttributes(readCtx, state.ID.ValueString(), &state)...)
@@ -234,10 +280,15 @@ func (r *PatchSoftwareTitleResource) Read(ctx context.Context, req resource.Read
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
-// Update applies metadata + package changes. The PUT carries one assign entry
-// per plan key and one empty-package clear entry per key dropped from prior
-// state (verified: empty <package></package> clears, omitted package retains).
-// UpdatePatchSoftwareTitleByID returns 201 with an empty body, so we GET after.
+// Update applies metadata + package changes through a single v3 merge-patch,
+// which answers with the stored configuration.
+//
+// Because the v3 `packages` array is a full replacement, the desired
+// assignments are folded over the server's live set so that assignments made
+// outside Terraform survive — the managed-subset contract version_packages
+// documents. That fold needs the live set, so it costs a read; when neither the
+// plan nor prior state declares any assignment there is nothing to manage and
+// the key is omitted instead, skipping the read.
 func (r *PatchSoftwareTitleResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	var plan, state PatchSoftwareTitleResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
@@ -259,29 +310,35 @@ func (r *PatchSoftwareTitleResource) Update(ctx context.Context, req resource.Up
 	if resp.Diagnostics.HasError() {
 		return
 	}
-
-	putBody, putDiags := buildPatchSoftwareTitleUpdateInput(updateCtx, plan, priorKeys)
-	resp.Diagnostics.Append(putDiags...)
+	planPackages, pkgDiags := versionPackageMap(updateCtx, plan.VersionPackages)
+	resp.Diagnostics.Append(pkgDiags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	if err := r.client.UpdatePatchSoftwareTitleByID(updateCtx, plan.ID.ValueString(), putBody); err != nil { //nolint:staticcheck // SA1019: classic /patchsoftwaretitles intentionally used; v2 create unusable — see file header note
+
+	var desired map[string]string
+	if len(planPackages) > 0 || len(priorKeys) > 0 {
+		live, err := r.proClient.GetPatchSoftwareTitleConfigurationV3(updateCtx, plan.ID.ValueString())
+		if err != nil {
+			resp.Diagnostics.AddError("Error reading Jamf Pro patch software title package assignments", err.Error())
+			return
+		}
+		desired = unionVersionPackages(assignedPackagesByVersion(live.Packages), planPackages, priorKeys)
+	}
+
+	got, err := r.proClient.UpdatePatchSoftwareTitleConfigurationV3(updateCtx, plan.ID.ValueString(), buildPatchSoftwareTitleConfigurationPatch(plan, desired))
+	if err != nil {
 		resp.Diagnostics.AddError("Error updating Jamf Pro patch software title", err.Error())
 		return
 	}
 
-	got, err := r.client.GetPatchSoftwareTitleByID(updateCtx, plan.ID.ValueString()) //nolint:staticcheck // SA1019: classic /patchsoftwaretitles intentionally used; v2 create unusable — see file header note
-	if err != nil {
-		resp.Diagnostics.AddError("Error reading updated Jamf Pro patch software title", err.Error())
-		return
-	}
-
-	declaredKeys, keyDiags := versionPackageKeys(updateCtx, plan.VersionPackages)
-	resp.Diagnostics.Append(keyDiags...)
+	avail, availDiags := r.readAvailableVersions(updateCtx, plan.ID.ValueString())
+	resp.Diagnostics.Append(availDiags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	resp.Diagnostics.Append(assignPatchSoftwareTitleResourceModel(updateCtx, &plan, got, declaredKeys)...)
+
+	resp.Diagnostics.Append(assignPatchSoftwareTitleResourceModel(updateCtx, &plan, got, avail, keysOf(planPackages))...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -293,8 +350,8 @@ func (r *PatchSoftwareTitleResource) Update(ctx context.Context, req resource.Up
 		return
 	}
 
-	// Persist the classic changes before the accept side-call so a fatal accept
-	// failure does not lose them; a later apply retries the accept.
+	// Persist the configuration changes before the accept side-call so a fatal
+	// accept failure does not lose them; a later apply retries the accept.
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -313,7 +370,10 @@ func (r *PatchSoftwareTitleResource) Update(ctx context.Context, req resource.Up
 	}
 }
 
-// Delete removes a Jamf Pro patch software title.
+// Delete removes a Jamf Pro patch software title. Deleting the v3 configuration
+// removes the classic title with it — wire-probed 2026-09-02: the DELETE answers
+// 204 and the classic GET then answers 404, so no classic-side object is left
+// behind.
 func (r *PatchSoftwareTitleResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
 	var state PatchSoftwareTitleResourceModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
@@ -334,11 +394,37 @@ func (r *PatchSoftwareTitleResource) Delete(ctx context.Context, req resource.De
 		return
 	}
 
-	if err := r.client.DeletePatchSoftwareTitleByID(deleteCtx, state.ID.ValueString()); err != nil { //nolint:staticcheck // SA1019: classic /patchsoftwaretitles intentionally used; v2 create unusable — see file header note
+	if err := r.proClient.DeletePatchSoftwareTitleConfigurationV3(deleteCtx, state.ID.ValueString()); err != nil {
 		if helpers.IsNotFoundError(err) {
 			tflog.Info(ctx, "Jamf Pro patch software title already removed", map[string]any{"id": state.ID.ValueString()})
 			return
 		}
 		resp.Diagnostics.AddError("Error deleting Jamf Pro patch software title", fmt.Sprintf("API error: %v", err))
 	}
+}
+
+// readAvailableVersions reads the title's version catalogue from the
+// /definitions sub-resource, which is where v3 keeps it — the configuration
+// body carries only the versions that have a package assigned.
+func (r *PatchSoftwareTitleResource) readAvailableVersions(ctx context.Context, id string) ([]string, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	defs, err := r.proClient.ListPatchSoftwareTitleDefinitionsV3(ctx, id, nil, "")
+	if err != nil {
+		diags.AddError("Error reading Jamf Pro patch software title versions", err.Error())
+		return nil, diags
+	}
+	return definitionVersions(defs), diags
+}
+
+// keysOf returns a map's keys, or nil for an empty map so callers reading it as
+// a declared-key set see "nothing declared".
+func keysOf(m map[string]string) []string {
+	if len(m) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
 }

--- a/internal/resources/pro/patch_software_title/data_source.go
+++ b/internal/resources/pro/patch_software_title/data_source.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform"
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/pro"
-	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/proclassic"
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/datasource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/datasourcevalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -31,6 +30,13 @@ import (
 // caller supplies at Create, so collisions across titles are possible —
 // multiple exact matches surface as *jamfplatform.AmbiguousMatchError rather
 // than silently returning the first hit.
+//
+// An entry carrying no id is not a match. Nothing downstream can read a title by
+// an empty id, so counting one would only move the failure to the version read
+// and have that blame the versions rather than the malformed entry. There is no
+// guard on an empty list: the configurations list returns a plain slice, in
+// which nil and empty are indistinguishable, and a tenant with no patch titles
+// at all is legitimate.
 func lookupByName(ctx context.Context, c *pro.Client, name string) (*pro.PatchSoftwareTitleConfiguration, error) {
 	list, err := c.ListPatchSoftwareTitleConfigurationsV3(ctx)
 	if err != nil {
@@ -39,7 +45,7 @@ func lookupByName(ctx context.Context, c *pro.Client, name string) (*pro.PatchSo
 	var matched *pro.PatchSoftwareTitleConfiguration
 	var matches []string
 	for i := range list {
-		if list[i].DisplayName != name {
+		if list[i].DisplayName != name || list[i].ID == "" {
 			continue
 		}
 		matched = &list[i]
@@ -60,11 +66,16 @@ func lookupByName(ctx context.Context, c *pro.Client, name string) (*pro.PatchSo
 // one of the two must be supplied. The full server view is surfaced,
 // including every assigned version→package pair.
 //
-// The classic client is here only to resolve source_id: the v3 configuration
-// names a title's patch source but never numbers it, and a data source has no
-// prior state to carry the number in (see resolveSourceID).
+// source_id is resolved, not read: the v3 configuration names a title's patch
+// source but never numbers it, and a data source has no prior state to carry the
+// number in. The resolution is best-effort — source_id comes back null with a
+// warning when the name matches no patch source, matches one in both
+// catalogues, or the catalogues cannot be read — because the attribute is
+// Computed and informational here, unlike the managed resource where it defines
+// the title. It goes through the provider-instance catalogue cache so a
+// configuration of many titles reads the catalogues once, not twice per title.
 type PatchSoftwareTitleDataSource struct {
-	client    *proclassic.Client
+	sources   *providerdata.PatchSourceCache
 	proClient *pro.Client
 }
 
@@ -106,7 +117,7 @@ func (d *PatchSoftwareTitleDataSource) Schema(ctx context.Context, req datasourc
 				Computed:            true,
 			},
 			"source_id": schema.Int64Attribute{
-				MarkdownDescription: "Patch source ID this title is sourced from.",
+				MarkdownDescription: "Patch source ID this title is sourced from. Jamf Pro reports the source by name here, so the provider matches that name against the tenant's internal and external patch sources: the value is null, with a warning, when the name matches none of them, matches both an internal and an external source, or those sources cannot be read.",
 				Computed:            true,
 			},
 			"category_id": schema.StringAttribute{
@@ -150,28 +161,21 @@ func (d *PatchSoftwareTitleDataSource) ConfigValidators(ctx context.Context) []d
 	}
 }
 
-// Configure wires both Jamf clients into the data source: the Pro client for the
-// v3 configuration reads, and the ProClassic client for patch-source name
-// resolution.
+// Configure wires the Pro client used for the v3 configuration reads, plus the
+// shared patch source catalogue cache source_id resolves through.
 func (d *PatchSoftwareTitleDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
-	client, diags := providerdata.ConfigureProClassic(ctx, req.ProviderData, minJamfProVersion, "jamfplatform_pro_patch_software_title")
-	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-	d.client = client
-
 	proClient, proDiags := providerdata.ConfigurePro(ctx, req.ProviderData, minJamfProVersion, "jamfplatform_pro_patch_software_title")
 	resp.Diagnostics.Append(proDiags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 	d.proClient = proClient
+	d.sources = providerdata.ConfigurePatchSources(req.ProviderData, fetchPatchSourceCatalogues)
 }
 
 // Read fetches a patch software title by ID and populates Terraform state.
 func (d *PatchSoftwareTitleDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
-	if d.client == nil || d.proClient == nil {
+	if d.proClient == nil {
 		resp.Diagnostics.AddError(
 			"Provider not configured",
 			"The provider client was not configured. Please ensure the provider block is set up correctly.",
@@ -223,13 +227,16 @@ func (d *PatchSoftwareTitleDataSource) Read(ctx context.Context, req datasource.
 		return
 	}
 
-	sourceID, err := resolveSourceID(readCtx, d.client, got.PatchSourceName)
-	if err != nil {
-		resp.Diagnostics.AddError(
+	sourceID := types.Int64Null()
+	catalogues, sourceErr := d.sources.Catalogues(readCtx)
+	if sourceErr == nil {
+		sourceID, sourceErr = sourceIDFromCatalogues(catalogues, got.PatchSourceName)
+	}
+	if sourceErr != nil {
+		resp.Diagnostics.AddWarning(
 			"Unable to determine the patch software title's source_id",
-			fmt.Sprintf("Jamf Pro reports this title's patch source as %q, but the provider could not match that name to a patch source ID: %v", got.PatchSourceName, err),
+			unresolvedSourceIDWarningDetail(got.DisplayName, got.PatchSourceName, sourceErr),
 		)
-		return
 	}
 
 	resp.Diagnostics.Append(assignPatchSoftwareTitleDataSourceModel(readCtx, &data, got, definitionVersions(defs), sourceID)...)

--- a/internal/resources/pro/patch_software_title/data_source.go
+++ b/internal/resources/pro/patch_software_title/data_source.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform"
+	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/pro"
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/proclassic"
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/datasource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/datasourcevalidator"
@@ -23,34 +24,32 @@ import (
 )
 
 // lookupByName resolves a patch software title by exact display name via
-// ListPatchSoftwareTitles + client-side name match, then
-// GetPatchSoftwareTitleByID. Classic /patchsoftwaretitles has no name-based
-// lookup endpoint (only list and get-by-id). `name` is a freeform Required
-// field the caller supplies at Create, so collisions across titles are
-// possible — multiple exact matches surface as *jamfplatform.AmbiguousMatchError
-// rather than silently returning the first hit.
-func lookupByName(ctx context.Context, c *proclassic.Client, name string) (*proclassic.PatchSoftwareTitle, error) {
-	list, err := c.ListPatchSoftwareTitles(ctx) //nolint:staticcheck // SA1019: classic /patchsoftwaretitles intentionally used; v2 create unusable — see crud.go header note
+// ListPatchSoftwareTitleConfigurationsV3 + client-side name match. The
+// configurations list has no name-based lookup endpoint, but it returns whole
+// configuration objects rather than stubs, so the match itself is the answer
+// and no follow-up get is needed. `name` is a freeform Required field the
+// caller supplies at Create, so collisions across titles are possible —
+// multiple exact matches surface as *jamfplatform.AmbiguousMatchError rather
+// than silently returning the first hit.
+func lookupByName(ctx context.Context, c *pro.Client, name string) (*pro.PatchSoftwareTitleConfiguration, error) {
+	list, err := c.ListPatchSoftwareTitleConfigurationsV3(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("list patch software titles while resolving %q: %w", name, err)
 	}
-	if list == nil {
-		return nil, fmt.Errorf("no patch software title named %q (empty list response)", name)
-	}
+	var matched *pro.PatchSoftwareTitleConfiguration
 	var matches []string
-	for _, item := range list.PatchSoftwareTitles {
-		if item.Name == nil || *item.Name != name {
+	for i := range list {
+		if list[i].DisplayName != name {
 			continue
 		}
-		if id := helpers.StringValueFromIntPtr(item.ID).ValueString(); id != "" {
-			matches = append(matches, id)
-		}
+		matched = &list[i]
+		matches = append(matches, list[i].ID)
 	}
 	switch len(matches) {
 	case 0:
 		return nil, fmt.Errorf("no patch software title named %q", name)
 	case 1:
-		return c.GetPatchSoftwareTitleByID(ctx, matches[0]) //nolint:staticcheck // SA1019: classic /patchsoftwaretitles intentionally used; v2 create unusable — see crud.go header note
+		return matched, nil
 	default:
 		return nil, &jamfplatform.AmbiguousMatchError{Name: name, Matches: matches}
 	}
@@ -60,8 +59,13 @@ func lookupByName(ctx context.Context, c *proclassic.Client, name string) (*proc
 // patch software titles. Lookup is by ID or by exact display name — exactly
 // one of the two must be supplied. The full server view is surfaced,
 // including every assigned version→package pair.
+//
+// The classic client is here only to resolve source_id: the v3 configuration
+// names a title's patch source but never numbers it, and a data source has no
+// prior state to carry the number in (see resolveSourceID).
 type PatchSoftwareTitleDataSource struct {
-	client *proclassic.Client
+	client    *proclassic.Client
+	proClient *pro.Client
 }
 
 var (
@@ -109,16 +113,8 @@ func (d *PatchSoftwareTitleDataSource) Schema(ctx context.Context, req datasourc
 				MarkdownDescription: "Jamf Pro category ID.",
 				Computed:            true,
 			},
-			"category_name": schema.StringAttribute{
-				MarkdownDescription: "Category display name.",
-				Computed:            true,
-			},
 			"site_id": schema.StringAttribute{
 				MarkdownDescription: "Jamf Pro site ID.",
-				Computed:            true,
-			},
-			"site_name": schema.StringAttribute{
-				MarkdownDescription: "Site display name.",
 				Computed:            true,
 			},
 			"web_notification": schema.BoolAttribute{
@@ -154,8 +150,9 @@ func (d *PatchSoftwareTitleDataSource) ConfigValidators(ctx context.Context) []d
 	}
 }
 
-// Configure wires the Jamf ProClassic client into the data source via the shared
-// providerdata.ConfigureProClassic helper.
+// Configure wires both Jamf clients into the data source: the Pro client for the
+// v3 configuration reads, and the ProClassic client for patch-source name
+// resolution.
 func (d *PatchSoftwareTitleDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
 	client, diags := providerdata.ConfigureProClassic(ctx, req.ProviderData, minJamfProVersion, "jamfplatform_pro_patch_software_title")
 	resp.Diagnostics.Append(diags...)
@@ -163,11 +160,18 @@ func (d *PatchSoftwareTitleDataSource) Configure(ctx context.Context, req dataso
 		return
 	}
 	d.client = client
+
+	proClient, proDiags := providerdata.ConfigurePro(ctx, req.ProviderData, minJamfProVersion, "jamfplatform_pro_patch_software_title")
+	resp.Diagnostics.Append(proDiags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	d.proClient = proClient
 }
 
 // Read fetches a patch software title by ID and populates Terraform state.
 func (d *PatchSoftwareTitleDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
-	if d.client == nil {
+	if d.client == nil || d.proClient == nil {
 		resp.Diagnostics.AddError(
 			"Provider not configured",
 			"The provider client was not configured. Please ensure the provider block is set up correctly.",
@@ -190,14 +194,14 @@ func (d *PatchSoftwareTitleDataSource) Read(ctx context.Context, req datasource.
 	defer cancel()
 
 	var (
-		got *proclassic.PatchSoftwareTitle
+		got *pro.PatchSoftwareTitleConfiguration
 		err error
 	)
 	switch {
 	case !data.ID.IsNull() && data.ID.ValueString() != "":
-		got, err = d.client.GetPatchSoftwareTitleByID(readCtx, data.ID.ValueString()) //nolint:staticcheck // SA1019: classic /patchsoftwaretitles intentionally used; v2 create unusable — see crud.go header note
+		got, err = d.proClient.GetPatchSoftwareTitleConfigurationV3(readCtx, data.ID.ValueString())
 	case !data.Name.IsNull() && data.Name.ValueString() != "":
-		got, err = lookupByName(readCtx, d.client, data.Name.ValueString())
+		got, err = lookupByName(readCtx, d.proClient, data.Name.ValueString())
 	default:
 		resp.Diagnostics.AddError("Missing patch software title selector", "Exactly one of id or name must be supplied.")
 		return
@@ -213,7 +217,22 @@ func (d *PatchSoftwareTitleDataSource) Read(ctx context.Context, req datasource.
 		resp.Diagnostics.AddError("Unable to find Jamf Pro patch software title", err.Error())
 		return
 	}
-	resp.Diagnostics.Append(assignPatchSoftwareTitleDataSourceModel(readCtx, &data, got)...)
+	defs, err := d.proClient.ListPatchSoftwareTitleDefinitionsV3(readCtx, got.ID, nil, "")
+	if err != nil {
+		resp.Diagnostics.AddError("Unable to read Jamf Pro patch software title versions", err.Error())
+		return
+	}
+
+	sourceID, err := resolveSourceID(readCtx, d.client, got.PatchSourceName)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to determine the patch software title's source_id",
+			fmt.Sprintf("Jamf Pro reports this title's patch source as %q, but the provider could not match that name to a patch source ID: %v", got.PatchSourceName, err),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(assignPatchSoftwareTitleDataSourceModel(readCtx, &data, got, definitionVersions(defs), sourceID)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/resources/pro/patch_software_title/data_source_test.go
+++ b/internal/resources/pro/patch_software_title/data_source_test.go
@@ -1,0 +1,178 @@
+// Copyright Jamf Software LLC 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package patch_software_title
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform"
+	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/pro"
+)
+
+// configurationsListPath is the single unpaginated v3 configurations list the
+// data source's name lookup reads. It returns whole configuration objects rather
+// than stubs, which is why a name match needs no follow-up get.
+const configurationsListPath = "/pro/v3/patch-software-title-configurations"
+
+// newListClient serves body verbatim from the configurations list endpoint and
+// returns a Pro client pointed at it, over the local stub server
+// patch_sources_test.go builds (see newStubClient for why it is local). status 0
+// means 200.
+func newListClient(t *testing.T, status int, body string) *pro.Client {
+	t.Helper()
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != configurationsListPath {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if status != 0 {
+			w.WriteHeader(status)
+			return
+		}
+		_, _ = w.Write([]byte(body))
+	})
+	return pro.New(newStubClient(t, handler))
+}
+
+// TestLookupByName_SingleMatch pins the happy path: the matched element is the
+// answer, carried back whole.
+func TestLookupByName_SingleMatch(t *testing.T) {
+	c := newListClient(t, 0, `[
+	  {"id":"147","displayName":"8x8 Work","softwareTitleNameId":"285","patchSourceName":"Jamf"},
+	  {"id":"148","displayName":"Firefox","softwareTitleNameId":"73","patchSourceName":"Jamf"}
+	]`)
+
+	got, err := lookupByName(context.Background(), c, "Firefox")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got == nil || got.ID != "148" || got.SoftwareTitleNameID != "73" {
+		t.Errorf("expected the Firefox configuration (id 148), got %+v", got)
+	}
+}
+
+// TestLookupByName_NoMatch pins that an absent name is reported and names the
+// name asked for, since the caller supplied it and nothing else identifies the
+// lookup that failed.
+func TestLookupByName_NoMatch(t *testing.T) {
+	c := newListClient(t, 0, `[{"id":"147","displayName":"8x8 Work"}]`)
+
+	got, err := lookupByName(context.Background(), c, "Firefox")
+	if err == nil {
+		t.Fatalf("expected an error, got %+v", got)
+	}
+	if !strings.Contains(err.Error(), `"Firefox"`) {
+		t.Errorf("error does not name the display name looked up: %v", err)
+	}
+	if got != nil {
+		t.Errorf("a failed lookup must return no configuration, got %+v", got)
+	}
+}
+
+// TestLookupByName_AmbiguousDisplayName is the mutation-critical case. name is a
+// freeform Required field the practitioner sets at Create, so two titles can
+// genuinely share a display name; the lookup must refuse and disclose both ids
+// rather than silently return whichever came back last, which would read a
+// different title than the configuration names.
+func TestLookupByName_AmbiguousDisplayName(t *testing.T) {
+	c := newListClient(t, 0, `[
+	  {"id":"147","displayName":"8x8 Work","softwareTitleNameId":"285"},
+	  {"id":"902","displayName":"8x8 Work","softwareTitleNameId":"285"}
+	]`)
+
+	got, err := lookupByName(context.Background(), c, "8x8 Work")
+	if err == nil {
+		t.Fatalf("expected an ambiguous-match error, got %+v", got)
+	}
+	if got != nil {
+		t.Errorf("an ambiguous lookup must return no configuration, got %+v", got)
+	}
+
+	ambiguous, ok := errors.AsType[*jamfplatform.AmbiguousMatchError](err)
+	if !ok {
+		t.Fatalf("expected *jamfplatform.AmbiguousMatchError so the data source can render its own diagnostic, got %T: %v", err, err)
+	}
+	if ambiguous.Name != "8x8 Work" {
+		t.Errorf("expected the error to carry the queried name, got %q", ambiguous.Name)
+	}
+	if len(ambiguous.Matches) != 2 || ambiguous.Matches[0] != "147" || ambiguous.Matches[1] != "902" {
+		t.Errorf("expected both colliding ids in wire order, got %v", ambiguous.Matches)
+	}
+	for _, want := range []string{"147", "902"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("rendered error does not name candidate id %s: %v", want, err)
+		}
+	}
+}
+
+// TestLookupByName_IDLessEntryIsNotAMatch pins the guard the v3 rewrite dropped
+// and the review restored: an entry whose id is empty is not a match. Nothing
+// downstream can read a title by an empty id, so counting one would move the
+// failure to the version read and have it blame the versions rather than the
+// malformed entry.
+func TestLookupByName_IDLessEntryIsNotAMatch(t *testing.T) {
+	c := newListClient(t, 0, `[{"id":"","displayName":"8x8 Work","softwareTitleNameId":"285"}]`)
+
+	got, err := lookupByName(context.Background(), c, "8x8 Work")
+	if err == nil {
+		t.Fatalf("expected an error, got %+v", got)
+	}
+	if _, ok := errors.AsType[*jamfplatform.AmbiguousMatchError](err); ok {
+		t.Errorf("an id-less entry is no match at all, not an ambiguity: %v", err)
+	}
+	if !strings.Contains(err.Error(), "no patch software title named") {
+		t.Errorf("expected the no-match error, got %v", err)
+	}
+}
+
+// TestLookupByName_IDLessEntryDoesNotMakeAMatchAmbiguous is the same guard from
+// the other side: an id-less entry sharing the name with one real match must
+// leave that match unique, not turn the lookup into a refusal.
+func TestLookupByName_IDLessEntryDoesNotMakeAMatchAmbiguous(t *testing.T) {
+	c := newListClient(t, 0, `[
+	  {"id":"","displayName":"8x8 Work"},
+	  {"id":"147","displayName":"8x8 Work","softwareTitleNameId":"285"}
+	]`)
+
+	got, err := lookupByName(context.Background(), c, "8x8 Work")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got == nil || got.ID != "147" {
+		t.Errorf("expected the one readable configuration (id 147), got %+v", got)
+	}
+}
+
+// TestLookupByName_ListFailureIsReported pins that a failed list says it was
+// resolving a name, so the diagnostic distinguishes "the lookup could not run"
+// from "the name matched nothing".
+func TestLookupByName_ListFailureIsReported(t *testing.T) {
+	c := newListClient(t, http.StatusForbidden, "")
+
+	_, err := lookupByName(context.Background(), c, "8x8 Work")
+	if err == nil {
+		t.Fatal("expected an error when the configurations list cannot be read")
+	}
+	for _, want := range []string{"list patch software titles", `"8x8 Work"`} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q does not contain %q", err, want)
+		}
+	}
+}
+
+// TestLookupByName_EmptyListIsANoMatch pins that a tenant with no patch titles
+// at all is a legitimate no-match rather than a special case: the configurations
+// list returns a plain slice, in which nil and empty are indistinguishable.
+func TestLookupByName_EmptyListIsANoMatch(t *testing.T) {
+	c := newListClient(t, 0, `[]`)
+
+	if _, err := lookupByName(context.Background(), c, "8x8 Work"); err == nil {
+		t.Fatal("expected a no-match error against an empty configurations list")
+	}
+}

--- a/internal/resources/pro/patch_software_title/input_builders.go
+++ b/internal/resources/pro/patch_software_title/input_builders.go
@@ -5,20 +5,21 @@ package patch_software_title
 
 import (
 	"context"
+	"maps"
 	"sort"
 	"strconv"
 
+	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/pro"
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/proclassic"
-	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/helpers"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-// buildPatchSoftwareTitleCreateInput builds the minimal POST payload that mints a
-// title. Per the verified wire semantics, name + name_id + source_id define the
-// title; the server then populates the full versions catalog from the patch
-// definition. category/site/notifications/version_packages are applied via a
-// follow-up PUT (see crud.go Create).
+// buildPatchSoftwareTitleCreateInput builds the minimal classic POST payload
+// that mints a title. Per the verified wire semantics, name + name_id +
+// source_id define the title; the server then populates the full versions
+// catalog from the patch definition. Everything else is applied by the
+// follow-up v3 merge-patch (see crud.go Create).
 func buildPatchSoftwareTitleCreateInput(plan PatchSoftwareTitleResourceModel) *proclassic.PatchSoftwareTitle {
 	out := &proclassic.PatchSoftwareTitle{}
 	if v := plan.Name.ValueString(); !plan.Name.IsNull() && !plan.Name.IsUnknown() {
@@ -36,144 +37,127 @@ func buildPatchSoftwareTitleCreateInput(plan PatchSoftwareTitleResourceModel) *p
 	return out
 }
 
-// buildPatchSoftwareTitleUpdateInput builds the full PUT payload carrying the
-// desired metadata (name, category, site, notifications) plus the per-version
-// package operations. priorKeys are the version_packages keys recorded in the
-// prior Terraform state (empty on Create); plan is the desired config.
+// buildPatchSoftwareTitleConfigurationPatch builds the v3 merge-patch body
+// carrying the desired metadata (display name, category, site, notifications).
 //
-// Per the verified wire semantics the server merges versions by software_version:
-//   - a version carrying <package><id>N</id></package> assigns package N
-//   - a version carrying an empty <package></package> CLEARS the assignment
-//   - a version omitted from the payload is left untouched
-//
-// We therefore emit one entry per plan key (assign) and one empty-package entry
-// per key that was in prior state but dropped from the plan (clear/unassign).
-func buildPatchSoftwareTitleUpdateInput(ctx context.Context, plan PatchSoftwareTitleResourceModel, priorKeys []string) (*proclassic.PatchSoftwareTitle, diag.Diagnostics) {
-	var diags diag.Diagnostics
-
-	out := &proclassic.PatchSoftwareTitle{}
-	if v := plan.Name.ValueString(); !plan.Name.IsNull() && !plan.Name.IsUnknown() {
-		name := v
-		out.Name = &name
+// packages carries the complete desired set of version→package assignments, or
+// nil to omit the key entirely. The distinction is load-bearing: the v3
+// `packages` array is a full replacement — a version absent from a supplied
+// array has its assignment cleared, and an empty array clears every assignment
+// — whereas omitting the key leaves the server's assignments untouched
+// (wire-probed 2026-09-02). Callers therefore pass nil unless they have the
+// live server set to build the replacement from; see unionVersionPackages.
+func buildPatchSoftwareTitleConfigurationPatch(plan PatchSoftwareTitleResourceModel, packages map[string]string) *pro.PatchSoftwareTitleConfigurationPatch {
+	out := &pro.PatchSoftwareTitleConfigurationPatch{}
+	if !plan.Name.IsNull() && !plan.Name.IsUnknown() {
+		name := plan.Name.ValueString()
+		out.DisplayName = &name
 	}
-	if id := helpers.StringIDPtr(plan.CategoryID); id != nil {
-		// This endpoint clears a category with wire id 0 — id -1 is a silent
-		// no-op here (it does clear <site>, but not <category>). Map the
-		// user-facing "-1 = No category assigned" sentinel (and any non-positive
-		// id) to the wire's 0 clear; pass real category ids through unchanged.
-		// categoryValues collapses the server's -1/0 no-category echoes back to
-		// "-1" on read so state matches config. Wire-probed 2026-06-01.
-		wireID := max(*id, 0)
-		out.Category = &proclassic.CategoryObject{ID: &wireID}
-	}
-	if id := helpers.StringIDPtr(plan.SiteID); id != nil {
-		out.Site = &proclassic.SiteObject{ID: id}
-	}
-	if n := buildNotifications(plan); n != nil {
-		out.Notifications = n
-	}
-
-	planPackages := map[string]string{}
-	if !plan.VersionPackages.IsNull() && !plan.VersionPackages.IsUnknown() {
-		diags.Append(plan.VersionPackages.ElementsAs(ctx, &planPackages, false)...)
-		if diags.HasError() {
-			return nil, diags
-		}
-	}
-
-	versions := buildVersionItems(planPackages, priorKeys)
-	if len(versions) > 0 {
-		out.Versions = &proclassic.PatchSoftwareTitleVersions{Version: &versions}
-	}
-
-	return out, diags
-}
-
-// buildNotifications returns a notifications block when either toggle is a known
-// value, or nil so the SDK omitempty drops it (server keeps / defaults). Each
-// configured bool is sent explicitly (false is meaningful).
-func buildNotifications(plan PatchSoftwareTitleResourceModel) *proclassic.PatchSoftwareTitleNotifications {
-	var web, email *bool
+	out.CategoryID = refIDPtr(plan.CategoryID)
+	out.SiteID = refIDPtr(plan.SiteID)
 	if !plan.WebNotification.IsNull() && !plan.WebNotification.IsUnknown() {
 		v := plan.WebNotification.ValueBool()
-		web = &v
+		out.UiNotifications = &v
 	}
 	if !plan.EmailNotification.IsNull() && !plan.EmailNotification.IsUnknown() {
 		v := plan.EmailNotification.ValueBool()
-		email = &v
+		out.EmailNotifications = &v
 	}
-	if web == nil && email == nil {
-		return nil
+	if packages != nil {
+		items := packageItems(packages)
+		out.Packages = &items
 	}
-	return &proclassic.PatchSoftwareTitleNotifications{
-		WebNotification:   web,
-		EmailNotification: email,
-	}
+	return out
 }
 
-// buildVersionItems produces the merge-by-software_version version entries:
-//   - one assign entry per plan key (software_version + package id)
-//   - one clear entry (empty package) per prior-state key absent from the plan
+// refIDPtr maps a configured category or site id onto the v3 wire value, or nil
+// so the merge-patch omits the field. The configurations endpoint accepts only
+// a positive id or the literal "-1", rejecting anything else outright ("id
+// field must be string of positive numeric value or -1"), so every non-positive
+// id — including the "0" a title last written through classic
+// /patchsoftwaretitles can still carry — is normalised to "-1".
+func refIDPtr(v types.String) *string {
+	if v.IsNull() || v.IsUnknown() {
+		return nil
+	}
+	raw := v.ValueString()
+	if raw == "" {
+		return nil
+	}
+	if n, err := strconv.Atoi(raw); err == nil && n <= 0 {
+		none := "-1"
+		return &none
+	}
+	return &raw
+}
+
+// unionVersionPackages folds the desired version_packages over the live server
+// assignments to produce the full replacement array the v3 `packages` field
+// requires, preserving the resource's managed-subset contract: only the keys
+// Terraform declares are managed, and an assignment made outside Terraform
+// survives an apply.
 //
-// A non-nil but empty *PatchSoftwareTitleVersionsVersionItemPackage marshals to
-// an empty <package></package> element, which the server treats as "clear this
-// version's package" (verified live). Omitting the package element entirely
-// would instead retain the existing assignment, so clears must emit the empty
-// element. Entries are sorted by software_version for deterministic payloads.
-func buildVersionItems(planPackages map[string]string, priorKeys []string) []proclassic.PatchSoftwareTitleVersionsVersionItem {
-	type op struct {
-		sv     string
-		pkgID  *int
-		assign bool
-	}
-	ops := map[string]op{}
-
-	for sv, pkgStr := range planPackages {
-		if n, err := strconv.Atoi(pkgStr); err == nil {
-			id := n
-			ops[sv] = op{sv: sv, pkgID: &id, assign: true}
+// live is the server's current assignment set, planPackages the desired
+// Terraform-managed subset, and priorKeys the keys recorded in prior state. A
+// key that was in prior state but has been dropped from the plan is an explicit
+// unassign, so it is removed from the union; every other live key is carried
+// across untouched.
+func unionVersionPackages(live, planPackages map[string]string, priorKeys []string) map[string]string {
+	union := make(map[string]string, len(live)+len(planPackages))
+	maps.Copy(union, live)
+	for _, k := range priorKeys {
+		if _, stillPlanned := planPackages[k]; !stillPlanned {
+			delete(union, k)
 		}
 	}
-	for _, sv := range priorKeys {
-		if _, stillPlanned := planPackages[sv]; stillPlanned {
-			continue
-		}
-		ops[sv] = op{sv: sv, assign: false}
-	}
+	maps.Copy(union, planPackages)
+	return union
+}
 
-	keys := make([]string, 0, len(ops))
-	for k := range ops {
-		keys = append(keys, k)
+// packageItems renders a version→package map as the v3 packages array, sorted
+// by version for a deterministic payload.
+func packageItems(packages map[string]string) []pro.PatchSoftwareTitlePackages {
+	versions := make([]string, 0, len(packages))
+	for v := range packages {
+		versions = append(versions, v)
 	}
-	sort.Strings(keys)
+	sort.Strings(versions)
 
-	items := make([]proclassic.PatchSoftwareTitleVersionsVersionItem, 0, len(keys))
-	for _, k := range keys {
-		o := ops[k]
-		sv := o.sv
-		item := proclassic.PatchSoftwareTitleVersionsVersionItem{SoftwareVersion: &sv}
-		if o.assign {
-			item.Package = &proclassic.PatchSoftwareTitleVersionsVersionItemPackage{ID: o.pkgID}
-		} else {
-			// Empty (but non-nil) package element clears the assignment.
-			item.Package = &proclassic.PatchSoftwareTitleVersionsVersionItemPackage{}
-		}
-		items = append(items, item)
+	items := make([]pro.PatchSoftwareTitlePackages, 0, len(versions))
+	for _, v := range versions {
+		version, pkgID := v, packages[v]
+		items = append(items, pro.PatchSoftwareTitlePackages{
+			Version:   &version,
+			PackageID: &pkgID,
+		})
 	}
 	return items
 }
 
-// versionPackageKeys returns the declared version_packages keys from a model's
-// map, used as the managed-subset key set for Read reconciliation and Update
-// clear-diffing. Returns nil for null/unknown maps.
-func versionPackageKeys(ctx context.Context, m types.Map) ([]string, diag.Diagnostics) {
+// versionPackageMap decodes a model's version_packages attribute into a plain
+// map. Returns an empty map for a null or unknown attribute.
+func versionPackageMap(ctx context.Context, m types.Map) (map[string]string, diag.Diagnostics) {
 	var diags diag.Diagnostics
+	out := map[string]string{}
 	if m.IsNull() || m.IsUnknown() {
+		return out, diags
+	}
+	diags.Append(m.ElementsAs(ctx, &out, false)...)
+	if diags.HasError() {
 		return nil, diags
 	}
-	elems := map[string]string{}
-	diags.Append(m.ElementsAs(ctx, &elems, false)...)
+	return out, diags
+}
+
+// versionPackageKeys returns the declared version_packages keys from a model's
+// map, used as the managed-subset key set for Read reconciliation and Update
+// unassign-diffing. Returns nil for null/unknown maps.
+func versionPackageKeys(ctx context.Context, m types.Map) ([]string, diag.Diagnostics) {
+	elems, diags := versionPackageMap(ctx, m)
 	if diags.HasError() {
+		return nil, diags
+	}
+	if len(elems) == 0 {
 		return nil, diags
 	}
 	keys := make([]string, 0, len(elems))

--- a/internal/resources/pro/patch_software_title/input_builders_test.go
+++ b/internal/resources/pro/patch_software_title/input_builders_test.go
@@ -5,9 +5,9 @@ package patch_software_title
 
 import (
 	"context"
+	"sort"
 	"testing"
 
-	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/helpers"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -20,12 +20,17 @@ func mustMap(t *testing.T, m map[string]string) types.Map {
 	return v
 }
 
+// TestBuildCreateInput_MintFieldsOnly pins the split between the two calls
+// Create makes. The classic POST exists only to mint an id, and sending
+// metadata or version assignments on it would write them through a deprecated
+// endpoint whose category/site clear conventions are the inverse of v3's — so
+// the mint payload must carry name + name_id + source_id and nothing else, even
+// when the plan has category and package assignments configured.
 func TestBuildCreateInput_MintFieldsOnly(t *testing.T) {
 	plan := PatchSoftwareTitleResourceModel{
-		Name:     types.StringValue("8x8 Work"),
-		NameID:   types.StringValue("285"),
-		SourceID: types.Int64Value(1),
-		// Metadata + packages must NOT be sent on the mint POST.
+		Name:            types.StringValue("8x8 Work"),
+		NameID:          types.StringValue("285"),
+		SourceID:        types.Int64Value(1),
 		CategoryID:      types.StringValue("5"),
 		VersionPackages: mustMap(t, map[string]string{"8.33.2.2": "79"}),
 	}
@@ -41,232 +46,337 @@ func TestBuildCreateInput_MintFieldsOnly(t *testing.T) {
 		t.Errorf("SourceID not set: %v", got.SourceID)
 	}
 	if got.Category != nil {
-		t.Errorf("Category must not be sent on mint POST")
-	}
-	if got.Versions != nil {
-		t.Errorf("Versions must not be sent on mint POST")
-	}
-	if got.ID != nil {
-		t.Errorf("ID must be nil on write payload")
-	}
-}
-
-func TestBuildUpdateInput_CategorySiteNotifications(t *testing.T) {
-	web, email := true, false
-	plan := PatchSoftwareTitleResourceModel{
-		Name:              types.StringValue("Title"),
-		CategoryID:        types.StringValue("5"),
-		SiteID:            types.StringValue("-1"),
-		WebNotification:   types.BoolValue(web),
-		EmailNotification: types.BoolValue(email),
-		VersionPackages:   types.MapNull(types.StringType),
-	}
-	got, diags := buildPatchSoftwareTitleUpdateInput(context.Background(), plan, nil)
-	if diags.HasError() {
-		t.Fatalf("diags: %v", diags)
-	}
-	if got.Category == nil || got.Category.ID == nil || *got.Category.ID != 5 {
-		t.Errorf("Category id not mapped: %+v", got.Category)
-	}
-	if got.Site == nil || got.Site.ID == nil || *got.Site.ID != -1 {
-		t.Errorf("Site id -1 not mapped: %+v", got.Site)
-	}
-	if got.Notifications == nil {
-		t.Fatalf("Notifications nil")
-	}
-	if got.Notifications.WebNotification == nil || *got.Notifications.WebNotification != true {
-		t.Errorf("web notification not true: %v", got.Notifications.WebNotification)
-	}
-	// false must be sent explicitly, not dropped.
-	if got.Notifications.EmailNotification == nil || *got.Notifications.EmailNotification != false {
-		t.Errorf("email notification false must be explicit, got %v", got.Notifications.EmailNotification)
-	}
-}
-
-// TestBuildUpdateInput_CategoryClearSentinel locks the wire-probed quirk: the
-// endpoint clears <category> with id 0, not -1 (id -1 is a silent no-op for
-// category, though it does clear <site>). The builder maps the user-facing
-// "-1" sentinel — and any non-positive id — to wire id 0. Site is unaffected
-// and sends its -1 verbatim.
-func TestBuildUpdateInput_CategoryClearSentinel(t *testing.T) {
-	for _, in := range []string{"-1", "0"} {
-		plan := PatchSoftwareTitleResourceModel{
-			Name:            types.StringValue("Title"),
-			CategoryID:      types.StringValue(in),
-			SiteID:          types.StringValue("-1"),
-			VersionPackages: types.MapNull(types.StringType),
-		}
-		got, diags := buildPatchSoftwareTitleUpdateInput(context.Background(), plan, nil)
-		if diags.HasError() {
-			t.Fatalf("diags: %v", diags)
-		}
-		if got.Category == nil || got.Category.ID == nil || *got.Category.ID != 0 {
-			t.Errorf("category_id %q must map to wire id 0, got %+v", in, got.Category)
-		}
-		// Site must still send -1 verbatim (its native clear sentinel).
-		if got.Site == nil || got.Site.ID == nil || *got.Site.ID != -1 {
-			t.Errorf("site_id -1 must send verbatim, got %+v", got.Site)
-		}
-	}
-}
-
-func TestBuildUpdateInput_NoMetadataMeansNilBlocks(t *testing.T) {
-	plan := PatchSoftwareTitleResourceModel{
-		CategoryID:        types.StringNull(),
-		SiteID:            types.StringNull(),
-		WebNotification:   types.BoolNull(),
-		EmailNotification: types.BoolNull(),
-		VersionPackages:   types.MapNull(types.StringType),
-	}
-	got, diags := buildPatchSoftwareTitleUpdateInput(context.Background(), plan, nil)
-	if diags.HasError() {
-		t.Fatalf("diags: %v", diags)
-	}
-	if got.Category != nil {
-		t.Errorf("Category must be nil when unset")
+		t.Errorf("Category must not be sent on the mint POST")
 	}
 	if got.Site != nil {
-		t.Errorf("Site must be nil when unset")
+		t.Errorf("Site must not be sent on the mint POST")
 	}
 	if got.Notifications != nil {
-		t.Errorf("Notifications must be nil when both unset")
+		t.Errorf("Notifications must not be sent on the mint POST")
 	}
 	if got.Versions != nil {
-		t.Errorf("Versions must be nil when no plan keys and no prior keys")
+		t.Errorf("Versions must not be sent on the mint POST")
+	}
+	if got.ID != nil {
+		t.Errorf("ID must be nil on a write payload")
 	}
 }
 
-func TestBuildUpdateInput_VersionPackages_AssignOnly(t *testing.T) {
+// TestBuildConfigurationPatch_MetadataAndNotifications pins that a configured
+// value reaches the merge-patch, and specifically that a false notification is
+// emitted rather than dropped. A merge-patch omitting the key leaves the
+// server's value in place, so treating false as "nothing to say" would make
+// disabling a notification impossible.
+func TestBuildConfigurationPatch_MetadataAndNotifications(t *testing.T) {
 	plan := PatchSoftwareTitleResourceModel{
-		VersionPackages: mustMap(t, map[string]string{"8.33.2.2": "79", "8.32.2.10": "81"}),
+		Name:              types.StringValue("8x8 Work"),
+		CategoryID:        types.StringValue("58"),
+		SiteID:            types.StringValue("-1"),
+		WebNotification:   types.BoolValue(true),
+		EmailNotification: types.BoolValue(false),
+		VersionPackages:   types.MapNull(types.StringType),
 	}
-	got, diags := buildPatchSoftwareTitleUpdateInput(context.Background(), plan, nil)
-	if diags.HasError() {
-		t.Fatalf("diags: %v", diags)
+	got := buildPatchSoftwareTitleConfigurationPatch(plan, nil)
+
+	if got.DisplayName == nil || *got.DisplayName != "8x8 Work" {
+		t.Errorf("displayName not mapped: %v", got.DisplayName)
 	}
-	if got.Versions == nil || got.Versions.Version == nil {
-		t.Fatalf("expected versions block")
+	if got.CategoryID == nil || *got.CategoryID != "58" {
+		t.Errorf("categoryId not mapped: %v", got.CategoryID)
 	}
-	items := *got.Versions.Version
-	if len(items) != 2 {
-		t.Fatalf("expected 2 version items, got %d", len(items))
+	if got.SiteID == nil || *got.SiteID != "-1" {
+		t.Errorf("siteId not mapped: %v", got.SiteID)
 	}
-	byVer := map[string]int{}
-	for _, it := range items {
-		if it.SoftwareVersion == nil {
-			t.Fatalf("nil software version")
-		}
-		if it.Package == nil || it.Package.ID == nil {
-			t.Errorf("assign entry %q must carry a package id", *it.SoftwareVersion)
-			continue
-		}
-		byVer[*it.SoftwareVersion] = *it.Package.ID
+	if got.UiNotifications == nil || !*got.UiNotifications {
+		t.Errorf("uiNotifications must be true, got %v", got.UiNotifications)
 	}
-	if byVer["8.33.2.2"] != 79 || byVer["8.32.2.10"] != 81 {
-		t.Errorf("assignments wrong: %+v", byVer)
+	if got.EmailNotifications == nil {
+		t.Fatalf("emailNotifications false must be emitted explicitly, not omitted")
 	}
-	// Deterministic sort by software_version.
-	if *items[0].SoftwareVersion != "8.32.2.10" || *items[1].SoftwareVersion != "8.33.2.2" {
-		t.Errorf("expected sorted versions, got %q then %q", *items[0].SoftwareVersion, *items[1].SoftwareVersion)
+	if *got.EmailNotifications {
+		t.Errorf("emailNotifications must be false, got true")
 	}
 }
 
-// TestBuildUpdateInput_VersionPackages_ClearDiff covers the unassign path: a key
-// present in prior state but dropped from the plan emits an empty (non-nil)
-// package element which the server treats as "clear". A retained key emits its
-// package id. A key never declared is not touched.
-func TestBuildUpdateInput_VersionPackages_ClearDiff(t *testing.T) {
+// TestBuildConfigurationPatch_UnsetMetadataOmitsFields pins the other half of
+// the merge-patch contract: an attribute the plan does not set must leave its
+// key out of the body entirely, so the server's stored value survives rather
+// than being overwritten with a zero value.
+func TestBuildConfigurationPatch_UnsetMetadataOmitsFields(t *testing.T) {
 	plan := PatchSoftwareTitleResourceModel{
-		VersionPackages: mustMap(t, map[string]string{"8.33.2.2": "79"}),
+		Name:              types.StringNull(),
+		CategoryID:        types.StringNull(),
+		SiteID:            types.StringUnknown(),
+		WebNotification:   types.BoolNull(),
+		EmailNotification: types.BoolUnknown(),
+		VersionPackages:   types.MapNull(types.StringType),
 	}
-	priorKeys := []string{"8.33.2.2", "8.32.2.10"} // 8.32.2.10 was removed
-	got, diags := buildPatchSoftwareTitleUpdateInput(context.Background(), plan, priorKeys)
-	if diags.HasError() {
-		t.Fatalf("diags: %v", diags)
+	got := buildPatchSoftwareTitleConfigurationPatch(plan, nil)
+
+	if got.DisplayName != nil {
+		t.Errorf("displayName must be omitted when unset, got %q", *got.DisplayName)
 	}
-	items := *got.Versions.Version
-	if len(items) != 2 {
-		t.Fatalf("expected 2 entries (1 assign + 1 clear), got %d", len(items))
+	if got.CategoryID != nil {
+		t.Errorf("categoryId must be omitted when null, got %q", *got.CategoryID)
 	}
-	var sawAssign, sawClear bool
-	for _, it := range items {
-		switch *it.SoftwareVersion {
-		case "8.33.2.2":
-			if it.Package == nil || it.Package.ID == nil || *it.Package.ID != 79 {
-				t.Errorf("retained version must keep package 79, got %+v", it.Package)
-			}
-			sawAssign = true
-		case "8.32.2.10":
-			// Clear: non-nil empty package element (ID nil).
-			if it.Package == nil {
-				t.Errorf("clear version must carry a non-nil empty package element")
-			} else if it.Package.ID != nil {
-				t.Errorf("clear version package must have nil ID, got %d", *it.Package.ID)
-			}
-			sawClear = true
-		default:
-			t.Errorf("unexpected version %q", *it.SoftwareVersion)
-		}
+	if got.SiteID != nil {
+		t.Errorf("siteId must be omitted when unknown, got %q", *got.SiteID)
 	}
-	if !sawAssign || !sawClear {
-		t.Errorf("expected both assign and clear entries (assign=%v clear=%v)", sawAssign, sawClear)
+	if got.UiNotifications != nil {
+		t.Errorf("uiNotifications must be omitted when null, got %v", *got.UiNotifications)
+	}
+	if got.EmailNotifications != nil {
+		t.Errorf("emailNotifications must be omitted when unknown, got %v", *got.EmailNotifications)
+	}
+	if got.SoftwareTitleID != nil {
+		t.Errorf("softwareTitleId must never be sent on the patch, got %q", *got.SoftwareTitleID)
+	}
+	if got.ExtensionAttributes != nil {
+		t.Errorf("extensionAttributes must never be sent on the patch")
 	}
 }
 
-func TestBuildVersionItems_EmptyWhenNothingToDo(t *testing.T) {
-	items := buildVersionItems(map[string]string{}, nil)
+// TestBuildConfigurationPatch_PackagesIsFullReplacement pins the wire law that
+// makes the packages argument three-valued rather than a plain map. v3 treats a
+// supplied `packages` array as the complete assignment set — anything absent
+// from it is cleared — while omitting the key leaves the server's set alone. So
+// nil must omit the key, an empty (non-nil) map must serialise as `[]` to clear
+// every assignment, and a populated map must carry the whole array. Collapsing
+// the empty map onto nil would make "unassign everything" unexpressible; the
+// reverse would silently wipe out-of-band assignments on every apply.
+func TestBuildConfigurationPatch_PackagesIsFullReplacement(t *testing.T) {
+	plan := PatchSoftwareTitleResourceModel{
+		Name:            types.StringValue("Title"),
+		VersionPackages: types.MapNull(types.StringType),
+	}
+
+	tests := []struct {
+		name     string
+		packages map[string]string
+		wantNil  bool
+		want     map[string]string
+	}{
+		{name: "nil omits the key", packages: nil, wantNil: true},
+		{name: "empty map clears every assignment", packages: map[string]string{}, want: map[string]string{}},
+		{
+			name:     "populated map replaces the whole set",
+			packages: map[string]string{"8.33.2.2": "1", "8.32.2.10": "2"},
+			want:     map[string]string{"8.33.2.2": "1", "8.32.2.10": "2"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := buildPatchSoftwareTitleConfigurationPatch(plan, tc.packages)
+			if tc.wantNil {
+				if got.Packages != nil {
+					t.Fatalf("packages must be omitted for a nil map, got %+v", *got.Packages)
+				}
+				return
+			}
+			if got.Packages == nil {
+				t.Fatalf("packages must be emitted for a non-nil map")
+			}
+			items := *got.Packages
+			if len(items) != len(tc.want) {
+				t.Fatalf("expected %d package items, got %d", len(tc.want), len(items))
+			}
+			for _, it := range items {
+				if it.Version == nil || it.PackageID == nil {
+					t.Fatalf("package item missing version or packageId: %+v", it)
+				}
+				if want, ok := tc.want[*it.Version]; !ok || want != *it.PackageID {
+					t.Errorf("unexpected assignment %q → %q", *it.Version, *it.PackageID)
+				}
+			}
+		})
+	}
+}
+
+// TestRefIDPtr_NormalisesNonPositiveToMinusOne pins the v3 category/site id
+// vocabulary: only a positive id or the literal "-1" is accepted, and anything
+// else is refused outright. A title last written through the classic endpoint
+// can still carry id "0" (that endpoint's own clear sentinel), so passing state
+// straight through would fail the very apply meant to migrate it.
+func TestRefIDPtr_NormalisesNonPositiveToMinusOne(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      types.String
+		wantNil bool
+		want    string
+	}{
+		{name: "null omits the key", in: types.StringNull(), wantNil: true},
+		{name: "unknown omits the key", in: types.StringUnknown(), wantNil: true},
+		{name: "empty omits the key", in: types.StringValue(""), wantNil: true},
+		{name: "minus one passes through", in: types.StringValue("-1"), want: "-1"},
+		{name: "classic zero normalises", in: types.StringValue("0"), want: "-1"},
+		{name: "other negative normalises", in: types.StringValue("-7"), want: "-1"},
+		{name: "positive passes through", in: types.StringValue("58"), want: "58"},
+		{name: "non-numeric passes through", in: types.StringValue("abc"), want: "abc"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := refIDPtr(tc.in)
+			if tc.wantNil {
+				if got != nil {
+					t.Fatalf("expected nil, got %q", *got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("expected %q, got nil", tc.want)
+			}
+			if *got != tc.want {
+				t.Errorf("expected %q, got %q", tc.want, *got)
+			}
+		})
+	}
+}
+
+// TestUnionVersionPackages_PreservesOutOfBandAssignments pins the promise
+// version_packages makes: only declared keys are managed. Because v3 `packages`
+// is a full replacement, sending the plan alone would silently unassign every
+// version a Jamf admin wired up outside Terraform, so the plan has to be folded
+// over the live set instead.
+func TestUnionVersionPackages_PreservesOutOfBandAssignments(t *testing.T) {
+	live := map[string]string{"1.0": "5", "9.9": "7"}
+	got := unionVersionPackages(live, map[string]string{"1.0": "6"}, nil)
+
+	if len(got) != 2 {
+		t.Fatalf("expected 2 assignments, got %d: %+v", len(got), got)
+	}
+	if got["9.9"] != "7" {
+		t.Errorf("out-of-band assignment 9.9 must survive as 7, got %q", got["9.9"])
+	}
+	if got["1.0"] != "6" {
+		t.Errorf("declared assignment 1.0 must take the plan value 6, got %q", got["1.0"])
+	}
+}
+
+// TestUnionVersionPackages_PriorKeyDroppedFromPlanIsUnassigned pins the one way
+// an assignment is allowed to disappear: a key that prior state managed and the
+// plan no longer declares is a deliberate unassign, so it must leave the union.
+// Without the prior-state diff there would be no difference between "the user
+// removed this key" and "the user never managed it", and a removed key would
+// stick forever.
+func TestUnionVersionPackages_PriorKeyDroppedFromPlanIsUnassigned(t *testing.T) {
+	live := map[string]string{"1.0": "5", "9.9": "7"}
+	got := unionVersionPackages(live, map[string]string{"1.0": "6"}, []string{"9.9"})
+
+	if _, ok := got["9.9"]; ok {
+		t.Errorf("9.9 was managed and has been dropped from the plan, so it must be unassigned, got %q", got["9.9"])
+	}
+	if got["1.0"] != "6" {
+		t.Errorf("declared assignment 1.0 must take the plan value 6, got %q", got["1.0"])
+	}
+}
+
+// TestUnionVersionPackages_RetainedPriorKeyIsNotDropped guards the ordering
+// inside the fold: the prior-key deletion pass runs before the plan is applied,
+// so a key present in both prior state and the plan must survive with the
+// plan's value rather than being deleted by its own prior-state entry.
+func TestUnionVersionPackages_RetainedPriorKeyIsNotDropped(t *testing.T) {
+	got := unionVersionPackages(map[string]string{"1.0": "5"}, map[string]string{"1.0": "6"}, []string{"1.0"})
+	if got["1.0"] != "6" {
+		t.Errorf("a retained key must keep the plan value 6, got %q", got["1.0"])
+	}
+}
+
+// TestPackageItems_SortedByVersion pins the deterministic payload order. Go map
+// iteration is randomised, so an unsorted array would make the merge-patch body
+// differ between otherwise identical applies — noise in request logs and in any
+// diff taken against a captured body.
+func TestPackageItems_SortedByVersion(t *testing.T) {
+	items := packageItems(map[string]string{"8.33.2.2": "1", "8.32.2.10": "2", "8.31.3.1": "3"})
+
+	wantVersions := []string{"8.31.3.1", "8.32.2.10", "8.33.2.2"}
+	wantPackages := []string{"3", "2", "1"}
+	if len(items) != len(wantVersions) {
+		t.Fatalf("expected %d items, got %d", len(wantVersions), len(items))
+	}
+	for i, it := range items {
+		if it.Version == nil || it.PackageID == nil {
+			t.Fatalf("item %d missing version or packageId: %+v", i, it)
+		}
+		if *it.Version != wantVersions[i] {
+			t.Errorf("item %d: expected version %q, got %q", i, wantVersions[i], *it.Version)
+		}
+		if *it.PackageID != wantPackages[i] {
+			t.Errorf("item %d (%q): expected package %q, got %q", i, *it.Version, wantPackages[i], *it.PackageID)
+		}
+	}
+}
+
+// TestPackageItems_EmptyMapYieldsNonNilEmptySlice pins the shape the clear path
+// depends on: an empty map must produce a non-nil empty slice, because the
+// caller takes its address and a nil slice would marshal as JSON null rather
+// than the `[]` that clears every assignment.
+func TestPackageItems_EmptyMapYieldsNonNilEmptySlice(t *testing.T) {
+	items := packageItems(map[string]string{})
+	if items == nil {
+		t.Fatalf("expected a non-nil empty slice so the body carries [] rather than null")
+	}
 	if len(items) != 0 {
 		t.Errorf("expected no items, got %d", len(items))
 	}
 }
 
+// TestVersionPackageMap pins that an unset attribute decodes to an empty map
+// rather than nil. Callers distinguish "nothing configured" by length, and the
+// nil-versus-empty distinction is reserved for the packages argument of the
+// merge-patch builder, where it means something else entirely.
+func TestVersionPackageMap(t *testing.T) {
+	tests := []struct {
+		name string
+		in   types.Map
+		want map[string]string
+	}{
+		{name: "null", in: types.MapNull(types.StringType), want: map[string]string{}},
+		{name: "unknown", in: types.MapUnknown(types.StringType), want: map[string]string{}},
+		{name: "populated", in: mustMap(t, map[string]string{"1.0": "5"}), want: map[string]string{"1.0": "5"}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, diags := versionPackageMap(context.Background(), tc.in)
+			if diags.HasError() {
+				t.Fatalf("diags: %v", diags)
+			}
+			if got == nil {
+				t.Fatalf("expected a non-nil map")
+			}
+			if len(got) != len(tc.want) {
+				t.Fatalf("expected %+v, got %+v", tc.want, got)
+			}
+			for k, v := range tc.want {
+				if got[k] != v {
+					t.Errorf("expected %q → %q, got %q", k, v, got[k])
+				}
+			}
+		})
+	}
+}
+
+// TestVersionPackageKeys pins the declared-key set used for Read reconciliation
+// and Update unassign-diffing. An unset map must yield no keys at all rather
+// than an empty non-nil slice, because "no keys declared" is what makes Read
+// leave version_packages null instead of writing an empty map into state.
 func TestVersionPackageKeys(t *testing.T) {
 	keys, diags := versionPackageKeys(context.Background(), mustMap(t, map[string]string{"a": "1", "b": "2"}))
 	if diags.HasError() {
 		t.Fatalf("diags: %v", diags)
 	}
-	if len(keys) != 2 {
-		t.Errorf("expected 2 keys, got %d", len(keys))
+	sort.Strings(keys)
+	if len(keys) != 2 || keys[0] != "a" || keys[1] != "b" {
+		t.Errorf("expected [a b], got %v", keys)
 	}
 
 	nullKeys, diags := versionPackageKeys(context.Background(), types.MapNull(types.StringType))
 	if diags.HasError() {
 		t.Fatalf("diags: %v", diags)
 	}
-	if len(nullKeys) != 0 {
-		t.Errorf("expected 0 keys for null map, got %d", len(nullKeys))
-	}
-}
-
-func TestOptionalIntFromStringID(t *testing.T) {
-	cases := []struct {
-		name    string
-		in      types.String
-		wantNil bool
-		want    int
-	}{
-		{name: "null", in: types.StringNull(), wantNil: true},
-		{name: "unknown", in: types.StringUnknown(), wantNil: true},
-		{name: "empty", in: types.StringValue(""), wantNil: true},
-		{name: "non-numeric", in: types.StringValue("abc"), wantNil: true},
-		{name: "minus one", in: types.StringValue("-1"), want: -1},
-		{name: "positive", in: types.StringValue("42"), want: 42},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			got := helpers.StringIDPtr(tc.in)
-			if tc.wantNil {
-				if got != nil {
-					t.Errorf("expected nil, got %d", *got)
-				}
-				return
-			}
-			if got == nil {
-				t.Fatalf("expected %d, got nil", tc.want)
-			}
-			if *got != tc.want {
-				t.Errorf("expected %d, got %d", tc.want, *got)
-			}
-		})
+	if nullKeys != nil {
+		t.Errorf("expected nil keys for a null map, got %v", nullKeys)
 	}
 }

--- a/internal/resources/pro/patch_software_title/list_resource.go
+++ b/internal/resources/pro/patch_software_title/list_resource.go
@@ -5,8 +5,10 @@ package patch_software_title
 
 import (
 	"context"
+	"fmt"
 	"time"
 
+	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/pro"
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/proclassic"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/list"
@@ -20,9 +22,10 @@ import (
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/providerdata"
 )
 
-// defaultListTimeout caps how long the list operation will wait on the classic
-// /patchsoftwaretitles endpoint. The list resource schema does not expose a
-// user-overridable timeout, so this is a fixed safety bound.
+// defaultListTimeout caps how long the list operation will wait on the v3
+// configurations list plus the two patch-source catalogue reads. The list
+// resource schema does not expose a user-overridable timeout, so this is a
+// fixed safety bound.
 const defaultListTimeout = 90 * time.Second
 
 var _ list.ListResource = &PatchSoftwareTitleListResource{}
@@ -34,12 +37,16 @@ func NewPatchSoftwareTitleListResource() list.ListResource {
 	return &PatchSoftwareTitleListResource{}
 }
 
-// PatchSoftwareTitleListResource implements Terraform query list support. Classic
-// /patchsoftwaretitles accepts no query parameters, so the optional `filter`
+// PatchSoftwareTitleListResource implements Terraform query list support. The v3
+// configurations list accepts no query parameters, so the optional `filter`
 // block is applied client-side via filters.ApplyClassicFilter after the full
 // list is fetched.
+//
+// The classic client is here only to resolve source_id: the v3 configuration
+// names a title's patch source but never numbers it (see resolveSourceID).
 type PatchSoftwareTitleListResource struct {
-	client *proclassic.Client
+	client    *proclassic.Client
+	proClient *pro.Client
 }
 
 // Metadata sets the list resource type name.
@@ -47,8 +54,9 @@ func (r *PatchSoftwareTitleListResource) Metadata(ctx context.Context, req resou
 	resp.TypeName = req.ProviderTypeName + "_pro_patch_software_title"
 }
 
-// Configure wires the Jamf ProClassic client into the list resource via the shared
-// providerdata.ConfigureProClassic helper.
+// Configure wires both Jamf clients into the list resource: the Pro client for
+// the v3 configurations list, and the ProClassic client for patch-source name
+// resolution.
 func (r *PatchSoftwareTitleListResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
 	client, diags := providerdata.ConfigureProClassic(ctx, req.ProviderData, minJamfProVersion, "jamfplatform_pro_patch_software_title")
 	resp.Diagnostics.Append(diags...)
@@ -56,6 +64,13 @@ func (r *PatchSoftwareTitleListResource) Configure(ctx context.Context, req reso
 		return
 	}
 	r.client = client
+
+	proClient, proDiags := providerdata.ConfigurePro(ctx, req.ProviderData, minJamfProVersion, "jamfplatform_pro_patch_software_title")
+	resp.Diagnostics.Append(proDiags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	r.proClient = proClient
 }
 
 // ListResourceConfigSchema describes the supported list filters.
@@ -72,14 +87,20 @@ func (r *PatchSoftwareTitleListResource) ListResourceConfigSchema(ctx context.Co
 // List executes the query and streams patch software title identities back to
 // Terraform.
 //
-// The classic /patchsoftwaretitles list endpoint returns only id+name+name_id+
-// source_id per item. When include_resource is requested we therefore hydrate
-// only those four attributes; the remaining attributes are set null rather than
-// issuing a per-item GET against this concurrency-sensitive classic endpoint. A
-// list preview does not require full hydration — consumers needing the full
-// object should use the singular data source or the managed resource.
+// The v3 configurations list returns whole configuration objects rather than
+// stubs, so include_resource hydrates everything that payload carries. Two
+// attributes stay null because filling them would cost a call per item:
+// available_versions, which lives on the /definitions sub-resource, and
+// extension_attributes, whose display names come from the /extension-attributes
+// sub-resource (the configuration body carries only ids and accept flags). A
+// list preview does not require full hydration — consumers needing those should
+// use the singular data source or the managed resource.
+//
+// source_id is not on the payload either, but it resolves from the patch source
+// name through two small tenant-wide catalogue reads, done once for the whole
+// list rather than per item.
 func (r *PatchSoftwareTitleListResource) List(ctx context.Context, req list.ListRequest, stream *list.ListResultsStream) {
-	if r.client == nil {
+	if r.client == nil || r.proClient == nil {
 		stream.Results = list.ListResultsStreamDiagnostics(diag.Diagnostics{
 			diag.NewErrorDiagnostic(
 				"Unconfigured Provider",
@@ -99,7 +120,7 @@ func (r *PatchSoftwareTitleListResource) List(ctx context.Context, req list.List
 	listCtx, cancel := context.WithTimeout(ctx, defaultListTimeout)
 	defer cancel()
 
-	resp, err := r.client.ListPatchSoftwareTitles(listCtx) //nolint:staticcheck // SA1019: classic /patchsoftwaretitles intentionally used; v2 create unusable — see crud.go header note
+	items, err := r.proClient.ListPatchSoftwareTitleConfigurationsV3(listCtx)
 	if err != nil {
 		stream.Results = list.ListResultsStreamDiagnostics(diag.Diagnostics{
 			diag.NewErrorDiagnostic("Unable to list Jamf Pro patch software titles", err.Error()),
@@ -107,9 +128,12 @@ func (r *PatchSoftwareTitleListResource) List(ctx context.Context, req list.List
 		return
 	}
 
-	items := []proclassic.PatchSoftwareTitlesItemPatchSoftwareTitle{}
-	if resp != nil {
-		items = resp.PatchSoftwareTitles
+	sourceIDs, err := patchSourceIDsByName(listCtx, r.client)
+	if err != nil {
+		stream.Results = list.ListResultsStreamDiagnostics(diag.Diagnostics{
+			diag.NewErrorDiagnostic("Unable to read Jamf Pro patch sources", err.Error()),
+		})
+		return
 	}
 
 	filter := filters.ClassicFilterModel{}
@@ -131,9 +155,9 @@ func (r *PatchSoftwareTitleListResource) List(ctx context.Context, req list.List
 		}
 
 		result := req.NewListResult(ctx)
-		result.DisplayName = helpers.DerefString(s.Name)
+		result.DisplayName = s.DisplayName
 
-		id := helpers.StringValueFromIntPtr(s.ID)
+		id := types.StringValue(s.ID)
 		result.Diagnostics.Append(helpers.SetIdentity(ctx, result.Identity, patchSoftwareTitleIdentityModel{ID: id})...)
 		if result.Diagnostics.HasError() {
 			stream.Results = list.ListResultsStreamDiagnostics(result.Diagnostics)
@@ -141,20 +165,24 @@ func (r *PatchSoftwareTitleListResource) List(ctx context.Context, req list.List
 		}
 
 		if req.IncludeResource {
-			// The list endpoint exposes only id+name+name_id+source_id; the
-			// remaining attributes are left null (see method doc).
+			assignments, assignDiags := types.MapValueFrom(ctx, types.StringType, assignedPackagesByVersion(s.Packages))
+			if assignDiags.HasError() {
+				stream.Results = list.ListResultsStreamDiagnostics(assignDiags)
+				return
+			}
+
+			// available_versions and extension_attributes stay null: both cost a
+			// call per item (see method doc).
 			state := PatchSoftwareTitleResourceModel{
 				ID:                        id,
-				Name:                      helpers.StringPointerValueOrNull(s.Name),
-				NameID:                    helpers.StringPointerValueOrNull(s.NameID),
-				SourceID:                  int64PointerValueOrNull(s.SourceID),
-				CategoryID:                types.StringNull(),
-				CategoryName:              types.StringNull(),
-				SiteID:                    types.StringNull(),
-				SiteName:                  types.StringNull(),
-				WebNotification:           types.BoolNull(),
-				EmailNotification:         types.BoolNull(),
-				VersionPackages:           types.MapNull(types.StringType),
+				Name:                      types.StringValue(s.DisplayName),
+				NameID:                    types.StringValue(s.SoftwareTitleNameID),
+				SourceID:                  sourceIDs[s.PatchSourceName],
+				CategoryID:                refIDValue(s.CategoryID),
+				SiteID:                    refIDValue(s.SiteID),
+				WebNotification:           types.BoolValue(s.UiNotifications),
+				EmailNotification:         types.BoolValue(s.EmailNotifications),
+				VersionPackages:           assignments,
 				AvailableVersions:         types.ListNull(types.StringType),
 				AcceptExtensionAttributes: types.BoolNull(),
 				// Typed null (not the zero-value types.List, which is an
@@ -194,14 +222,52 @@ func (r *PatchSoftwareTitleListResource) List(ctx context.Context, req list.List
 
 // patchSoftwareTitleDisplayName is the name accessor passed to
 // filters.ApplyClassicFilter, matching each title's display name.
-func patchSoftwareTitleDisplayName(s proclassic.PatchSoftwareTitlesItemPatchSoftwareTitle) string {
-	return helpers.DerefString(s.Name)
+func patchSoftwareTitleDisplayName(s pro.PatchSoftwareTitleConfiguration) string {
+	return s.DisplayName
 }
 
-// int64PointerValueOrNull maps an SDK *int onto a Terraform Int64, null for nil.
-func int64PointerValueOrNull(p *int) types.Int64 {
-	if p == nil {
-		return types.Int64Null()
+// patchSourceIDsByName builds a patch source name → id lookup from the two
+// classic source catalogues, so a list hydrates source_id for every title
+// without a per-item resolve. A name present in both catalogues is omitted
+// rather than guessed: the two id spaces are separate, and source_id backs a
+// RequiresReplace attribute, so a wrong number is worse than none.
+func patchSourceIDsByName(ctx context.Context, c *proclassic.Client) (map[string]types.Int64, error) {
+	out := map[string]types.Int64{}
+	if c == nil {
+		return out, nil
 	}
-	return types.Int64Value(int64(*p))
+
+	internal, err := c.ListPatchInternalSources(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("listing internal patch sources: %w", err)
+	}
+	external, err := c.ListPatchExternalSources(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("listing external patch sources: %w", err)
+	}
+
+	ambiguous := map[string]bool{}
+	add := func(sources []proclassic.IDName) {
+		for i := range sources {
+			if sources[i].Name == nil || sources[i].ID == nil {
+				continue
+			}
+			name := *sources[i].Name
+			if _, seen := out[name]; seen {
+				ambiguous[name] = true
+				continue
+			}
+			out[name] = types.Int64Value(int64(*sources[i].ID))
+		}
+	}
+	if internal != nil {
+		add(internal.PatchInternalSources)
+	}
+	if external != nil {
+		add(external.PatchExternalSources)
+	}
+	for name := range ambiguous {
+		delete(out, name)
+	}
+	return out, nil
 }

--- a/internal/resources/pro/patch_software_title/list_resource.go
+++ b/internal/resources/pro/patch_software_title/list_resource.go
@@ -5,11 +5,9 @@ package patch_software_title
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/pro"
-	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/proclassic"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/list"
 	listschema "github.com/hashicorp/terraform-plugin-framework/list/schema"
@@ -42,10 +40,12 @@ func NewPatchSoftwareTitleListResource() list.ListResource {
 // block is applied client-side via filters.ApplyClassicFilter after the full
 // list is fetched.
 //
-// The classic client is here only to resolve source_id: the v3 configuration
-// names a title's patch source but never numbers it (see resolveSourceID).
+// source_id is resolved, not read: the v3 configuration names a title's patch
+// source but never numbers it. The resolution goes through the shared
+// provider-instance catalogue cache, so a list pays the two catalogue reads once
+// however many titles it returns, and it is best-effort — see List.
 type PatchSoftwareTitleListResource struct {
-	client    *proclassic.Client
+	sources   *providerdata.PatchSourceCache
 	proClient *pro.Client
 }
 
@@ -54,23 +54,16 @@ func (r *PatchSoftwareTitleListResource) Metadata(ctx context.Context, req resou
 	resp.TypeName = req.ProviderTypeName + "_pro_patch_software_title"
 }
 
-// Configure wires both Jamf clients into the list resource: the Pro client for
-// the v3 configurations list, and the ProClassic client for patch-source name
-// resolution.
+// Configure wires the Pro client used for the v3 configurations list, plus the
+// shared patch source catalogue cache source_id resolves through.
 func (r *PatchSoftwareTitleListResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
-	client, diags := providerdata.ConfigureProClassic(ctx, req.ProviderData, minJamfProVersion, "jamfplatform_pro_patch_software_title")
-	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-	r.client = client
-
 	proClient, proDiags := providerdata.ConfigurePro(ctx, req.ProviderData, minJamfProVersion, "jamfplatform_pro_patch_software_title")
 	resp.Diagnostics.Append(proDiags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 	r.proClient = proClient
+	r.sources = providerdata.ConfigurePatchSources(req.ProviderData, fetchPatchSourceCatalogues)
 }
 
 // ListResourceConfigSchema describes the supported list filters.
@@ -96,11 +89,17 @@ func (r *PatchSoftwareTitleListResource) ListResourceConfigSchema(ctx context.Co
 // list preview does not require full hydration — consumers needing those should
 // use the singular data source or the managed resource.
 //
-// source_id is not on the payload either, but it resolves from the patch source
-// name through two small tenant-wide catalogue reads, done once for the whole
-// list rather than per item.
+// source_id is not on the payload either. The provider tries to resolve it from
+// the patch source name, out of two small tenant-wide catalogues read once for
+// the whole list, but the attempt can fail without the list failing: a name
+// present in both catalogues cannot be resolved at all, a source renamed or
+// removed since the title was created matches neither, and the catalogues need
+// privileges of their own. Every one of those leaves that title's source_id null
+// and attaches a warning naming the title — a preview reports what it could not
+// determine rather than dropping it, and rather than failing the whole listing
+// over an informational attribute.
 func (r *PatchSoftwareTitleListResource) List(ctx context.Context, req list.ListRequest, stream *list.ListResultsStream) {
-	if r.client == nil || r.proClient == nil {
+	if r.proClient == nil {
 		stream.Results = list.ListResultsStreamDiagnostics(diag.Diagnostics{
 			diag.NewErrorDiagnostic(
 				"Unconfigured Provider",
@@ -128,12 +127,12 @@ func (r *PatchSoftwareTitleListResource) List(ctx context.Context, req list.List
 		return
 	}
 
-	sourceIDs, err := patchSourceIDsByName(listCtx, r.client)
-	if err != nil {
-		stream.Results = list.ListResultsStreamDiagnostics(diag.Diagnostics{
-			diag.NewErrorDiagnostic("Unable to read Jamf Pro patch sources", err.Error()),
-		})
-		return
+	var (
+		catalogues   providerdata.PatchSourceCatalogues
+		catalogueErr error
+	)
+	if req.IncludeResource {
+		catalogues, catalogueErr = r.sources.Catalogues(listCtx)
 	}
 
 	filter := filters.ClassicFilterModel{}
@@ -148,6 +147,7 @@ func (r *PatchSoftwareTitleListResource) List(ctx context.Context, req list.List
 	}
 
 	results := make([]list.ListResult, 0, maxResults)
+	catalogueWarned := false
 
 	for _, s := range items {
 		if int64(len(results)) >= maxResults {
@@ -171,13 +171,31 @@ func (r *PatchSoftwareTitleListResource) List(ctx context.Context, req list.List
 				return
 			}
 
+			sourceID := types.Int64Null()
+			if catalogueErr != nil {
+				if !catalogueWarned {
+					catalogueWarned = true
+					result.Diagnostics.AddWarning(
+						"Unable to read this tenant's patch sources",
+						unreadableCataloguesWarningDetail(catalogueErr),
+					)
+				}
+			} else if resolved, resolveErr := sourceIDFromCatalogues(catalogues, s.PatchSourceName); resolveErr != nil {
+				result.Diagnostics.AddWarning(
+					"Unable to determine source_id for a patch software title",
+					unresolvedSourceIDWarningDetail(s.DisplayName, s.PatchSourceName, resolveErr),
+				)
+			} else {
+				sourceID = resolved
+			}
+
 			// available_versions and extension_attributes stay null: both cost a
 			// call per item (see method doc).
 			state := PatchSoftwareTitleResourceModel{
 				ID:                        id,
 				Name:                      types.StringValue(s.DisplayName),
 				NameID:                    types.StringValue(s.SoftwareTitleNameID),
-				SourceID:                  sourceIDs[s.PatchSourceName],
+				SourceID:                  sourceID,
 				CategoryID:                refIDValue(s.CategoryID),
 				SiteID:                    refIDValue(s.SiteID),
 				WebNotification:           types.BoolValue(s.UiNotifications),
@@ -224,50 +242,4 @@ func (r *PatchSoftwareTitleListResource) List(ctx context.Context, req list.List
 // filters.ApplyClassicFilter, matching each title's display name.
 func patchSoftwareTitleDisplayName(s pro.PatchSoftwareTitleConfiguration) string {
 	return s.DisplayName
-}
-
-// patchSourceIDsByName builds a patch source name → id lookup from the two
-// classic source catalogues, so a list hydrates source_id for every title
-// without a per-item resolve. A name present in both catalogues is omitted
-// rather than guessed: the two id spaces are separate, and source_id backs a
-// RequiresReplace attribute, so a wrong number is worse than none.
-func patchSourceIDsByName(ctx context.Context, c *proclassic.Client) (map[string]types.Int64, error) {
-	out := map[string]types.Int64{}
-	if c == nil {
-		return out, nil
-	}
-
-	internal, err := c.ListPatchInternalSources(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("listing internal patch sources: %w", err)
-	}
-	external, err := c.ListPatchExternalSources(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("listing external patch sources: %w", err)
-	}
-
-	ambiguous := map[string]bool{}
-	add := func(sources []proclassic.IDName) {
-		for i := range sources {
-			if sources[i].Name == nil || sources[i].ID == nil {
-				continue
-			}
-			name := *sources[i].Name
-			if _, seen := out[name]; seen {
-				ambiguous[name] = true
-				continue
-			}
-			out[name] = types.Int64Value(int64(*sources[i].ID))
-		}
-	}
-	if internal != nil {
-		add(internal.PatchInternalSources)
-	}
-	if external != nil {
-		add(external.PatchExternalSources)
-	}
-	for name := range ambiguous {
-		delete(out, name)
-	}
-	return out, nil
 }

--- a/internal/resources/pro/patch_software_title/model_types.go
+++ b/internal/resources/pro/patch_software_title/model_types.go
@@ -18,17 +18,16 @@ import (
 // VersionPackages is a managed-subset map keyed by software_version with
 // package_id string values. The user only declares the version→package
 // assignments they care about; the server holds the full catalog of versions
-// (20+) for the title and merges per software_version on write. Read therefore
-// reconciles only the keys the user declared (see state_builders.go).
+// (20+) for the title. Read reconciles only the keys the user declared, and
+// Update folds them over the server's live set, so an assignment made outside
+// Terraform survives an apply (see state_builders.go, input_builders.go).
 type PatchSoftwareTitleResourceModel struct {
 	ID                        types.String           `tfsdk:"id"`
 	Name                      types.String           `tfsdk:"name"`
 	NameID                    types.String           `tfsdk:"name_id"`
 	SourceID                  types.Int64            `tfsdk:"source_id"`
 	CategoryID                types.String           `tfsdk:"category_id"`
-	CategoryName              types.String           `tfsdk:"category_name"`
 	SiteID                    types.String           `tfsdk:"site_id"`
-	SiteName                  types.String           `tfsdk:"site_name"`
 	WebNotification           types.Bool             `tfsdk:"web_notification"`
 	EmailNotification         types.Bool             `tfsdk:"email_notification"`
 	VersionPackages           types.Map              `tfsdk:"version_packages"`
@@ -65,16 +64,15 @@ var patchSoftwareTitleEAAttrTypes = map[string]attr.Type{
 
 // PatchSoftwareTitleDataSourceModel represents the Terraform data source model.
 // Lookup is by ID or by exact display name — exactly one of the two must be
-// supplied. See data_source.go (lookupByName).
+// supplied. See data_source.go (lookupByName). SourceID is resolved from the
+// patch source name the v3 payload reports (see resolveSourceID).
 type PatchSoftwareTitleDataSourceModel struct {
 	ID                types.String             `tfsdk:"id"`
 	Name              types.String             `tfsdk:"name"`
 	NameID            types.String             `tfsdk:"name_id"`
 	SourceID          types.Int64              `tfsdk:"source_id"`
 	CategoryID        types.String             `tfsdk:"category_id"`
-	CategoryName      types.String             `tfsdk:"category_name"`
 	SiteID            types.String             `tfsdk:"site_id"`
-	SiteName          types.String             `tfsdk:"site_name"`
 	WebNotification   types.Bool               `tfsdk:"web_notification"`
 	EmailNotification types.Bool               `tfsdk:"email_notification"`
 	VersionPackages   types.Map                `tfsdk:"version_packages"`
@@ -89,8 +87,9 @@ type patchSoftwareTitleIdentityModel struct {
 }
 
 // PatchSoftwareTitleListResourceModel represents the config model for list
-// queries. Classic has no RSQL — the filter shape is the shared client-side
-// substring block, matching each title's display name.
+// queries. The v3 configurations list takes no query parameters, so the filter
+// shape is the shared client-side substring block, matching each title's
+// display name.
 type PatchSoftwareTitleListResourceModel struct {
 	Filter *filters.ClassicFilterModel `tfsdk:"filter"`
 }

--- a/internal/resources/pro/patch_software_title/model_types.go
+++ b/internal/resources/pro/patch_software_title/model_types.go
@@ -64,8 +64,14 @@ var patchSoftwareTitleEAAttrTypes = map[string]attr.Type{
 
 // PatchSoftwareTitleDataSourceModel represents the Terraform data source model.
 // Lookup is by ID or by exact display name — exactly one of the two must be
-// supplied. See data_source.go (lookupByName). SourceID is resolved from the
-// patch source name the v3 payload reports (see resolveSourceID).
+// supplied. See data_source.go (lookupByName).
+//
+// SourceID is not read but resolved, from the patch source name the payload
+// reports, and the resolution is best-effort: it is null with a warning whenever
+// the name cannot be matched to exactly one patch source, including when the
+// source catalogues cannot be read at all (see sourceIDFromCatalogues). The
+// managed resource is the one construct where an unresolved name is fatal, on
+// import, because there SourceID defines the title and forces replacement.
 type PatchSoftwareTitleDataSourceModel struct {
 	ID                types.String             `tfsdk:"id"`
 	Name              types.String             `tfsdk:"name"`

--- a/internal/resources/pro/patch_software_title/patch_sources.go
+++ b/internal/resources/pro/patch_software_title/patch_sources.go
@@ -1,0 +1,76 @@
+// Copyright Jamf Software LLC 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package patch_software_title
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/proclassic"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// resolveSourceID resolves a patch source's numeric id from the name the v3
+// configuration reports in patchSourceName.
+//
+// The configurations endpoint names a title's patch source but never numbers
+// it, while source_id is what defines a title on the classic create call and
+// therefore what the schema exposes. The number is only ever needed where
+// there is no prior state to carry it — an import, a data source read, or list
+// hydration — so this walks the two classic source catalogues (internal, then
+// external) rather than adding a lookup to the steady-state read path. Both
+// catalogues are small: a tenant has one internal source and a handful of
+// external ones at most.
+//
+// A name matching in both catalogues is an error rather than a silent
+// first-match, since the two id spaces are separate and guessing would put a
+// wrong number in state for a RequiresReplace attribute.
+func resolveSourceID(ctx context.Context, c *proclassic.Client, name string) (types.Int64, error) {
+	if c == nil || name == "" {
+		return types.Int64Null(), fmt.Errorf("cannot resolve a patch source without a name")
+	}
+
+	var matches []int
+
+	internal, err := c.ListPatchInternalSources(ctx)
+	if err != nil {
+		return types.Int64Null(), fmt.Errorf("listing internal patch sources while resolving %q: %w", name, err)
+	}
+	if internal != nil {
+		matches = append(matches, matchSourceIDs(internal.PatchInternalSources, name)...)
+	}
+
+	external, err := c.ListPatchExternalSources(ctx)
+	if err != nil {
+		return types.Int64Null(), fmt.Errorf("listing external patch sources while resolving %q: %w", name, err)
+	}
+	if external != nil {
+		matches = append(matches, matchSourceIDs(external.PatchExternalSources, name)...)
+	}
+
+	switch len(matches) {
+	case 0:
+		return types.Int64Null(), fmt.Errorf("no patch source named %q in this tenant's internal or external patch sources", name)
+	case 1:
+		return types.Int64Value(int64(matches[0])), nil
+	default:
+		return types.Int64Null(), fmt.Errorf("patch source name %q is not unique across this tenant's internal and external patch sources (ids %v); the provider cannot determine which source_id the title uses", name, matches)
+	}
+}
+
+// matchSourceIDs returns the ids of every catalogue entry whose name matches
+// exactly.
+func matchSourceIDs(sources []proclassic.IDName, name string) []int {
+	var out []int
+	for i := range sources {
+		if sources[i].Name == nil || *sources[i].Name != name {
+			continue
+		}
+		if sources[i].ID == nil {
+			continue
+		}
+		out = append(out, *sources[i].ID)
+	}
+	return out
+}

--- a/internal/resources/pro/patch_software_title/patch_sources.go
+++ b/internal/resources/pro/patch_software_title/patch_sources.go
@@ -5,49 +5,73 @@ package patch_software_title
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/proclassic"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/providerdata"
 )
 
-// resolveSourceID resolves a patch source's numeric id from the name the v3
-// configuration reports in patchSourceName.
+// fetchPatchSourceCatalogues reads the tenant's internal and external patch source
+// catalogues into one snapshot.
 //
-// The configurations endpoint names a title's patch source but never numbers
-// it, while source_id is what defines a title on the classic create call and
-// therefore what the schema exposes. The number is only ever needed where
-// there is no prior state to carry it — an import, a data source read, or list
-// hydration — so this walks the two classic source catalogues (internal, then
-// external) rather than adding a lookup to the steady-state read path. Both
-// catalogues are small: a tenant has one internal source and a handful of
-// external ones at most.
+// This is the only place the two reads happen. It backs the provider-instance cache
+// (providerdata.ConfigurePatchSources, used by the data source and by list hydration) and
+// the uncached resolveSourceID the resource's import path calls, so a change to how the
+// catalogues are gathered lands in both.
 //
-// A name matching in both catalogues is an error rather than a silent
-// first-match, since the two id spaces are separate and guessing would put a
-// wrong number in state for a RequiresReplace attribute.
-func resolveSourceID(ctx context.Context, c *proclassic.Client, name string) (types.Int64, error) {
-	if c == nil || name == "" {
-		return types.Int64Null(), fmt.Errorf("cannot resolve a patch source without a name")
+// Both catalogues are always read, even when the first already matched: a name present in
+// both is ambiguous, and only reading both can establish that. They are small — a tenant
+// has one internal source and a handful of external ones at most.
+func fetchPatchSourceCatalogues(ctx context.Context, c *proclassic.Client) (providerdata.PatchSourceCatalogues, error) {
+	var out providerdata.PatchSourceCatalogues
+	if c == nil {
+		return out, errors.New("the Jamf Pro client is not configured")
 	}
-
-	var matches []int
 
 	internal, err := c.ListPatchInternalSources(ctx)
 	if err != nil {
-		return types.Int64Null(), fmt.Errorf("listing internal patch sources while resolving %q: %w", name, err)
+		return out, fmt.Errorf("listing internal patch sources: %w", err)
 	}
 	if internal != nil {
-		matches = append(matches, matchSourceIDs(internal.PatchInternalSources, name)...)
+		out.Internal = internal.PatchInternalSources
 	}
 
 	external, err := c.ListPatchExternalSources(ctx)
 	if err != nil {
-		return types.Int64Null(), fmt.Errorf("listing external patch sources while resolving %q: %w", name, err)
+		return out, fmt.Errorf("listing external patch sources: %w", err)
 	}
 	if external != nil {
-		matches = append(matches, matchSourceIDs(external.PatchExternalSources, name)...)
+		out.External = external.PatchExternalSources
 	}
+	return out, nil
+}
+
+// sourceIDFromCatalogues resolves a patch source's numeric id from the name a title
+// reports, deciding over an already-read snapshot.
+//
+// The configurations endpoint names a title's patch source but never numbers it, while
+// source_id is what defines a title on create and therefore what the schema exposes. The
+// number is only ever needed where there is no prior state to carry it — an import, a
+// data source read, or list hydration.
+//
+// This is the one place the resolution law lives: every caller decides here, so the
+// ambiguous arm cannot mean "error" to one construct and "silently absent" to another. A
+// name matching in both catalogues is refused rather than guessed, since the two id
+// spaces are separate and a wrong number would put a destroy in the next plan of a
+// resource whose source_id forces replacement.
+//
+// Deciding is separate from fetching so the arms are testable without a client, and the
+// walk is linear rather than indexed because both catalogues are single-digit sized.
+func sourceIDFromCatalogues(catalogues providerdata.PatchSourceCatalogues, name string) (types.Int64, error) {
+	if name == "" {
+		return types.Int64Null(), errors.New("this title reports no patch source name at all")
+	}
+
+	matches := matchSourceIDs(catalogues.Internal, name)
+	matches = append(matches, matchSourceIDs(catalogues.External, name)...)
 
 	switch len(matches) {
 	case 0:
@@ -55,8 +79,23 @@ func resolveSourceID(ctx context.Context, c *proclassic.Client, name string) (ty
 	case 1:
 		return types.Int64Value(int64(matches[0])), nil
 	default:
-		return types.Int64Null(), fmt.Errorf("patch source name %q is not unique across this tenant's internal and external patch sources (ids %v); the provider cannot determine which source_id the title uses", name, matches)
+		return types.Int64Null(), fmt.Errorf("patch source name %q is not unique across this tenant's internal and external patch sources (ids %v); rename one of them in Jamf Pro so the two names differ, then run again", name, matches)
 	}
+}
+
+// resolveSourceID reads the catalogues straight from the tenant and resolves name
+// against them, without the shared cache.
+//
+// The resource's import path is the caller: it holds no cache and runs at most once per
+// import, so it pays the two reads there rather than threading a cache through the
+// resource. Every other caller resolves from the cached snapshot through
+// sourceIDFromCatalogues.
+func resolveSourceID(ctx context.Context, c *proclassic.Client, name string) (types.Int64, error) {
+	catalogues, err := fetchPatchSourceCatalogues(ctx, c)
+	if err != nil {
+		return types.Int64Null(), fmt.Errorf("reading the patch source catalogues while resolving %q: %w", name, err)
+	}
+	return sourceIDFromCatalogues(catalogues, name)
 }
 
 // matchSourceIDs returns the ids of every catalogue entry whose name matches
@@ -73,4 +112,44 @@ func matchSourceIDs(sources []proclassic.IDName, name string) []int {
 		out = append(out, *sources[i].ID)
 	}
 	return out
+}
+
+// unresolvedSourceIDDetail is the shared diagnostic detail for a title whose patch source
+// name did not resolve to exactly one id.
+//
+// An ambiguous name, a name matching nothing, and an unreadable catalogue all land here,
+// so every call site says the same thing about the same failure and points a practitioner
+// at the privileges the resolution needs without each construct restating them. A listing
+// that cannot read the catalogues at all uses unreadableCataloguesWarningDetail instead,
+// because that condition is not per title.
+func unresolvedSourceIDDetail(title, sourceName string, err error) string {
+	return fmt.Sprintf(
+		"Jamf Pro reports the patch source for %q as %q, but the provider could not match that name to a single patch source ID: %v. "+
+			"Resolving the name reads this tenant's internal and external patch source catalogues, so it also fails when the API integration does not hold "+
+			"Internal patch sources: Read and External patch sources: Read.",
+		title, sourceName, err,
+	)
+}
+
+// unresolvedSourceIDWarningDetail is unresolvedSourceIDDetail plus what the caller did
+// about it, for the two constructs where source_id is Computed and informational — the
+// data source and a list preview. The managed resource does not use it: there source_id
+// defines the title and forces replacement, so an unresolved name on import is fatal
+// rather than null.
+func unresolvedSourceIDWarningDetail(title, sourceName string, err error) string {
+	return unresolvedSourceIDDetail(title, sourceName, err) + " source_id is null in this result; every other attribute is unaffected."
+}
+
+// unreadableCataloguesWarningDetail is the diagnostic detail for a listing whose patch
+// source catalogues could not be read at all.
+//
+// It is separate from the per-title wording because the condition is list-wide: one
+// unreadable catalogue nulls source_id for every title in the result, so a listing says
+// so once instead of repeating a privilege problem beside each of a hundred titles.
+func unreadableCataloguesWarningDetail(err error) string {
+	return fmt.Sprintf(
+		"source_id is null for every title in this result because the tenant's internal and external patch sources could not be read: %v. "+
+			"Reading them requires the API integration to hold Internal patch sources: Read and External patch sources: Read. Every other attribute is unaffected.",
+		err,
+	)
 }

--- a/internal/resources/pro/patch_software_title/patch_sources_test.go
+++ b/internal/resources/pro/patch_software_title/patch_sources_test.go
@@ -1,0 +1,414 @@
+// Copyright Jamf Software LLC 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package patch_software_title
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform"
+	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/proclassic"
+
+	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/providerdata"
+)
+
+// newStubClient starts h behind an OAuth token endpoint and returns an SDK
+// client pointed at it.
+//
+// The seam is the HTTP boundary because the resolution takes a concrete
+// *proclassic.Client, and the stub is local rather than
+// testhelpers.NewMockClient because testhelpers reaches the provider package
+// under the acceptance build tag and the provider registers this package —
+// importing it from an in-package test makes that a cycle. Retries and the
+// request interval are disabled so a deliberate 4xx/5xx is answered once rather
+// than waited out.
+func newStubClient(t *testing.T, h http.Handler) *jamfplatform.Client {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/auth/token" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"access_token":"test-token","token_type":"Bearer","expires_in":3600}`))
+			return
+		}
+		h.ServeHTTP(w, r)
+	}))
+	t.Cleanup(server.Close)
+	return jamfplatform.NewClient(server.URL, "test-id", "test-secret",
+		jamfplatform.WithRetryPolicy(0, 0, 0),
+		jamfplatform.WithMinRequestInterval(0),
+	)
+}
+
+// These tests cover the source_id resolution law, which is load-bearing in a way
+// the rest of this package is not: the number it produces lands in source_id,
+// which is Required and RequiresReplace, so a wrong number puts a
+// destroy-and-recreate of a live patch title in the next plan. The arms are
+// exercised over sourceIDFromCatalogues rather than through a client because the
+// decision is pure — reading the catalogues is fetchPatchSourceCatalogues' job,
+// tested separately below over a mock server.
+
+// src builds a catalogue entry with both fields populated, the shape a healthy
+// Jamf Pro catalogue reports.
+func src(id int, name string) proclassic.IDName {
+	return proclassic.IDName{ID: &id, Name: &name}
+}
+
+// srcNoID builds a catalogue entry carrying a name but no id. The classic
+// payload makes both fields optional, so this is representable on the wire, and
+// an entry like it must not be counted as a match — nothing downstream can use
+// an absent id, and counting one would turn a unique match into an ambiguous
+// refusal.
+func srcNoID(name string) proclassic.IDName {
+	return proclassic.IDName{Name: &name}
+}
+
+// srcNoName builds a catalogue entry carrying an id but no name — the other half
+// of the same wire optionality.
+func srcNoName(id int) proclassic.IDName {
+	return proclassic.IDName{ID: &id}
+}
+
+// assertMessageNamesIDs fails unless every id appears as a standalone number in
+// msg. Matching on word boundaries rather than the exact rendering keeps the
+// assertion about the candidate ids being disclosed, not about how the list is
+// formatted — a practitioner cannot disambiguate two sources without them.
+func assertMessageNamesIDs(t *testing.T, msg string, ids ...int) {
+	t.Helper()
+	for _, id := range ids {
+		re := regexp.MustCompile(`(^|[^0-9])` + strconv.Itoa(id) + `([^0-9]|$)`)
+		if !re.MatchString(msg) {
+			t.Errorf("error message does not name candidate id %d: %s", id, msg)
+		}
+	}
+}
+
+// TestSourceIDFromCatalogues pins every arm of the resolution law: exactly one
+// match yields the id, and nothing else yields a number at all. The ambiguous
+// arm is the mutation-critical one — deleting the single-match arm so an
+// ambiguous name silently first-matches is invisible to every other test in this
+// package, and produces a plausible-looking wrong id in a RequiresReplace
+// attribute.
+func TestSourceIDFromCatalogues(t *testing.T) {
+	tests := []struct {
+		name        string
+		catalogues  providerdata.PatchSourceCatalogues
+		query       string
+		wantID      int64
+		wantErr     bool
+		errContains []string
+		errNamesIDs []int
+	}{
+		{
+			name: "internal catalogue only",
+			catalogues: providerdata.PatchSourceCatalogues{
+				Internal: []proclassic.IDName{src(1, "Jamf")},
+				External: []proclassic.IDName{src(7, "Acme Titles")},
+			},
+			query:  "Jamf",
+			wantID: 1,
+		},
+		{
+			name: "external catalogue only",
+			catalogues: providerdata.PatchSourceCatalogues{
+				Internal: []proclassic.IDName{src(1, "Jamf")},
+				External: []proclassic.IDName{src(7, "Acme Titles")},
+			},
+			query:  "Acme Titles",
+			wantID: 7,
+		},
+		{
+			name: "present in both catalogues is refused, naming both ids",
+			catalogues: providerdata.PatchSourceCatalogues{
+				Internal: []proclassic.IDName{src(1, "Shared Name")},
+				External: []proclassic.IDName{src(7, "Shared Name")},
+			},
+			query:       "Shared Name",
+			wantErr:     true,
+			errContains: []string{"not unique", `"Shared Name"`},
+			errNamesIDs: []int{1, 7},
+		},
+		{
+			name: "duplicated within one catalogue is refused, naming both ids",
+			catalogues: providerdata.PatchSourceCatalogues{
+				External: []proclassic.IDName{src(4, "Acme Titles"), src(9, "Acme Titles")},
+			},
+			query:       "Acme Titles",
+			wantErr:     true,
+			errContains: []string{"not unique"},
+			errNamesIDs: []int{4, 9},
+		},
+		{
+			name: "present in neither catalogue names the source",
+			catalogues: providerdata.PatchSourceCatalogues{
+				Internal: []proclassic.IDName{src(1, "Jamf")},
+				External: []proclassic.IDName{src(7, "Acme Titles")},
+			},
+			query:       "Renamed Since Create",
+			wantErr:     true,
+			errContains: []string{"no patch source named", `"Renamed Since Create"`},
+		},
+		{
+			name: "empty catalogues yield the no-match error",
+			// A tenant whose catalogues could not be populated, or a caller
+			// handed the zero value: the answer is "no match", not a panic.
+			catalogues:  providerdata.PatchSourceCatalogues{},
+			query:       "Jamf",
+			wantErr:     true,
+			errContains: []string{"no patch source named"},
+		},
+		{
+			name: "an empty name is refused as a missing name",
+			// The v3 configuration carries no patch source name at all. That is
+			// a property of the title, not of the client or the privileges, and
+			// the message has to say so or it sends a practitioner after the
+			// wrong thing.
+			catalogues: providerdata.PatchSourceCatalogues{
+				Internal: []proclassic.IDName{src(1, "Jamf")},
+			},
+			query:       "",
+			wantErr:     true,
+			errContains: []string{"no patch source name"},
+		},
+		{
+			name: "an entry with no id does not make a unique match ambiguous",
+			catalogues: providerdata.PatchSourceCatalogues{
+				Internal: []proclassic.IDName{src(1, "Jamf"), srcNoID("Jamf")},
+				External: []proclassic.IDName{srcNoID("Jamf")},
+			},
+			query:  "Jamf",
+			wantID: 1,
+		},
+		{
+			name: "an entry with no name is not matched",
+			catalogues: providerdata.PatchSourceCatalogues{
+				Internal: []proclassic.IDName{srcNoName(1)},
+			},
+			query:       "Jamf",
+			wantErr:     true,
+			errContains: []string{"no patch source named"},
+		},
+		{
+			name: "the match is case sensitive",
+			catalogues: providerdata.PatchSourceCatalogues{
+				Internal: []proclassic.IDName{src(1, "Jamf")},
+			},
+			query:       "jamf",
+			wantErr:     true,
+			errContains: []string{"no patch source named"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := sourceIDFromCatalogues(tc.catalogues, tc.query)
+
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected an error, got id %v", got)
+				}
+				if !got.IsNull() {
+					t.Errorf("a refused resolution must yield a null id, got %v", got)
+				}
+				for _, want := range tc.errContains {
+					if !strings.Contains(err.Error(), want) {
+						t.Errorf("error %q does not contain %q", err, want)
+					}
+				}
+				assertMessageNamesIDs(t, err.Error(), tc.errNamesIDs...)
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got.IsNull() || got.ValueInt64() != tc.wantID {
+				t.Errorf("expected id %d, got %v", tc.wantID, got)
+			}
+		})
+	}
+}
+
+// TestSourceIDFromCatalogues_EmptyNameDoesNotBlameTheClient pins the wording of
+// the empty-name arm specifically. It is the one arm that fires without either
+// catalogue being consulted, so a message mentioning the client or the
+// catalogues would point a practitioner at privileges when the title itself is
+// what reports no source.
+func TestSourceIDFromCatalogues_EmptyNameDoesNotBlameTheClient(t *testing.T) {
+	_, err := sourceIDFromCatalogues(providerdata.PatchSourceCatalogues{}, "")
+	if err == nil {
+		t.Fatal("expected an error for an empty patch source name")
+	}
+	for _, forbidden := range []string{"client", "catalogue"} {
+		if strings.Contains(strings.ToLower(err.Error()), forbidden) {
+			t.Errorf("the empty-name error must not blame %q: %s", forbidden, err)
+		}
+	}
+}
+
+// patchSourceServer serves the two classic catalogue endpoints, recording which
+// were asked for so a test can assert the second read is not issued after the
+// first fails. The classic surface answers XML — the SDK routes the decode off
+// the /proclassic/ path, not off the response content type — so these bodies are
+// the shapes ListPatchInternalSources / ListPatchExternalSources actually parse.
+type patchSourceServer struct {
+	internalReads int
+	externalReads int
+	internalCode  int
+	externalCode  int
+}
+
+func (s *patchSourceServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/xml")
+	switch r.URL.Path {
+	case "/proclassic/patchinternalsources":
+		s.internalReads++
+		if s.internalCode != 0 {
+			w.WriteHeader(s.internalCode)
+			return
+		}
+		_, _ = w.Write([]byte(`<patch_internal_sources><size>1</size>` +
+			`<patch_internal_source><id>1</id><name>Jamf</name></patch_internal_source>` +
+			`</patch_internal_sources>`))
+	case "/proclassic/patchexternalsources":
+		s.externalReads++
+		if s.externalCode != 0 {
+			w.WriteHeader(s.externalCode)
+			return
+		}
+		_, _ = w.Write([]byte(`<patch_external_sources><size>2</size>` +
+			`<patch_external_source><id>7</id><name>Acme Titles</name></patch_external_source>` +
+			`<patch_external_source><id>8</id><name>Widget Titles</name></patch_external_source>` +
+			`</patch_external_sources>`))
+	default:
+		w.WriteHeader(http.StatusNotFound)
+	}
+}
+
+// newPatchSourceClient wires a proclassic client onto the recording handler.
+func newPatchSourceClient(t *testing.T, h *patchSourceServer) *proclassic.Client {
+	t.Helper()
+	return proclassic.New(newStubClient(t, h))
+}
+
+// TestFetchPatchSourceCatalogues_BothCatalogues pins that the snapshot carries
+// both catalogues as read, and that both are always read — a name present in
+// both is ambiguous, and only reading both can establish that, so stopping at
+// the first hit would silently turn the ambiguous arm above into a first-match.
+func TestFetchPatchSourceCatalogues_BothCatalogues(t *testing.T) {
+	h := &patchSourceServer{}
+	got, err := fetchPatchSourceCatalogues(context.Background(), newPatchSourceClient(t, h))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(got.Internal) != 1 || got.Internal[0].ID == nil || *got.Internal[0].ID != 1 {
+		t.Errorf("internal catalogue: expected one entry with id 1, got %+v", got.Internal)
+	}
+	if len(got.External) != 2 || got.External[1].Name == nil || *got.External[1].Name != "Widget Titles" {
+		t.Errorf("external catalogue: expected two entries ending in Widget Titles, got %+v", got.External)
+	}
+	if h.internalReads != 1 || h.externalReads != 1 {
+		t.Errorf("reads: internal=%d external=%d, want one of each", h.internalReads, h.externalReads)
+	}
+
+	// The snapshot is what the resolution decides over, so resolve through it
+	// once to prove the two are wired to each other.
+	id, err := sourceIDFromCatalogues(got, "Acme Titles")
+	if err != nil {
+		t.Fatalf("resolving over the fetched snapshot: %v", err)
+	}
+	if id.ValueInt64() != 7 {
+		t.Errorf("expected id 7 from the fetched snapshot, got %v", id)
+	}
+}
+
+// TestFetchPatchSourceCatalogues_InternalReadFails pins that a failed internal
+// read is reported, names which catalogue failed, and short-circuits — the
+// caller cannot decide anything from half a snapshot, so the second request is
+// not worth issuing.
+func TestFetchPatchSourceCatalogues_InternalReadFails(t *testing.T) {
+	h := &patchSourceServer{internalCode: http.StatusForbidden}
+	_, err := fetchPatchSourceCatalogues(context.Background(), newPatchSourceClient(t, h))
+	if err == nil {
+		t.Fatal("expected an error when the internal catalogue cannot be read")
+	}
+	if !strings.Contains(err.Error(), "listing internal patch sources") {
+		t.Errorf("error does not name the internal catalogue read: %v", err)
+	}
+	if h.externalReads != 0 {
+		t.Errorf("expected no external read after the internal one failed, got %d", h.externalReads)
+	}
+}
+
+// TestFetchPatchSourceCatalogues_ExternalReadFails pins the other half: a
+// tenant whose internal catalogue reads cleanly still fails, naming the external
+// read. Nothing is asserted about the returned snapshot — it is partially filled
+// here and every caller discards it on error, which is what keeps a half-read
+// pair from resolving a name present in both catalogues to the internal id.
+func TestFetchPatchSourceCatalogues_ExternalReadFails(t *testing.T) {
+	h := &patchSourceServer{externalCode: http.StatusInternalServerError}
+	_, err := fetchPatchSourceCatalogues(context.Background(), newPatchSourceClient(t, h))
+	if err == nil {
+		t.Fatal("expected an error when the external catalogue cannot be read")
+	}
+	if !strings.Contains(err.Error(), "listing external patch sources") {
+		t.Errorf("error does not name the external catalogue read: %v", err)
+	}
+	if h.internalReads != 1 || h.externalReads != 1 {
+		t.Errorf("reads: internal=%d external=%d, want one of each — the external catalogue must be read even when the internal one already matched", h.internalReads, h.externalReads)
+	}
+}
+
+// TestFetchPatchSourceCatalogues_NilClient pins the unconfigured-client guard.
+// Configure can legitimately leave a construct without a client (the framework
+// calls it with nil ProviderData during early lifecycle), and resolution must
+// report that rather than panic mid-plan.
+func TestFetchPatchSourceCatalogues_NilClient(t *testing.T) {
+	_, err := fetchPatchSourceCatalogues(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected an error for a nil client")
+	}
+	if !strings.Contains(err.Error(), "not configured") {
+		t.Errorf("error does not say the client is not configured: %v", err)
+	}
+}
+
+// TestResolveSourceID_ReadsThenDecides pins the uncached path the resource's
+// import uses: it fetches both catalogues from the tenant and hands them to the
+// same decision every other caller makes.
+func TestResolveSourceID_ReadsThenDecides(t *testing.T) {
+	h := &patchSourceServer{}
+	got, err := resolveSourceID(context.Background(), newPatchSourceClient(t, h), "Jamf")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.ValueInt64() != 1 {
+		t.Errorf("expected id 1, got %v", got)
+	}
+}
+
+// TestResolveSourceID_WrapsFetchFailureWithTheName pins that an unreadable
+// catalogue on the import path says which name was being resolved. Import is the
+// one caller for which this failure is fatal, so the diagnostic has to identify
+// the title's source rather than only the HTTP error.
+func TestResolveSourceID_WrapsFetchFailureWithTheName(t *testing.T) {
+	h := &patchSourceServer{internalCode: http.StatusForbidden}
+	got, err := resolveSourceID(context.Background(), newPatchSourceClient(t, h), "Jamf")
+	if err == nil {
+		t.Fatal("expected an error when the catalogues cannot be read")
+	}
+	if !got.IsNull() {
+		t.Errorf("a failed resolution must yield a null id, got %v", got)
+	}
+	for _, want := range []string{"patch source catalogues", `"Jamf"`, "listing internal patch sources"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q does not contain %q", err, want)
+		}
+	}
+}

--- a/internal/resources/pro/patch_software_title/permissions.go
+++ b/internal/resources/pro/patch_software_title/permissions.go
@@ -10,50 +10,60 @@ import (
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/permissions"
 )
 
+// mergedPrivileges is the union of the two SDK families every construct in this
+// package spans: the Pro v3 configuration endpoints do the work, and ProClassic
+// supplies the id-minting create plus the patch-source catalogues source_id is
+// resolved from.
+var mergedPrivileges = permissions.Merge(proclassic.Privileges, pro.Privileges)
+
 // resourceSDKMethods lists the SDK methods the patch software title resource's
-// CRUD path calls. The classic /patchsoftwaretitles CRUD runs through the
-// ProClassic client (crud.go); extension-attribute read + accept run through the
-// Pro v3 client (extension_attributes.go, invoked from Create/Read/Update). It
-// drives the "Required Jamf permissions" table appended to the resource
+// CRUD path calls. Read/update/delete and the extension-attribute side-channel
+// run through the Pro v3 client (crud.go, extension_attributes.go); ProClassic
+// contributes the create that mints the id and the two source catalogues
+// source_id is resolved from on import (patch_sources.go). It drives the
+// "Required Jamf permissions" table appended to the resource
 // MarkdownDescription. permissions_test.go asserts this list stays in sync with
-// the actual <client>.<Method> calls in crud.go + extension_attributes.go and
-// with the SDK privilege registries.
+// the actual <client>.<Method> calls in those files and with the SDK privilege
+// registries.
 var resourceSDKMethods = []string{
 	"CreatePatchSoftwareTitleByID",
-	"GetPatchSoftwareTitleByID",
-	"UpdatePatchSoftwareTitleByID",
-	"DeletePatchSoftwareTitleByID",
-	"ListPatchSoftwareTitleExtensionAttributesV3",
+	"GetPatchSoftwareTitleConfigurationV3",
 	"UpdatePatchSoftwareTitleConfigurationV3",
+	"DeletePatchSoftwareTitleConfigurationV3",
+	"ListPatchSoftwareTitleDefinitionsV3",
+	"ListPatchSoftwareTitleExtensionAttributesV3",
+	"ListPatchInternalSources",
+	"ListPatchExternalSources",
 }
 
 // resourcePrivileges is the rendered "Required Jamf permissions" Markdown section
 // for the patch software title resource, appended to its MarkdownDescription.
-// The resource spans two SDK families (ProClassic CRUD + Pro v3 extension
-// attributes), so the registries are merged.
-var resourcePrivileges = permissions.Section(
-	permissions.Merge(proclassic.Privileges, pro.Privileges),
-	resourceSDKMethods...,
-)
+var resourcePrivileges = permissions.Section(mergedPrivileges, resourceSDKMethods...)
 
 // dataSourceSDKMethods lists the SDK methods the patch software title data
-// source calls (data_source.go). Lookup is read-only, by ID or by exact name
-// (lookupByName lists then gets by ID).
+// source calls (data_source.go, patch_sources.go). Lookup is read-only, by ID
+// or by exact name — the v3 configurations list returns whole objects, so a
+// name lookup needs no follow-up get.
 var dataSourceSDKMethods = []string{
-	"GetPatchSoftwareTitleByID",
-	"ListPatchSoftwareTitles",
+	"GetPatchSoftwareTitleConfigurationV3",
+	"ListPatchSoftwareTitleConfigurationsV3",
+	"ListPatchSoftwareTitleDefinitionsV3",
+	"ListPatchInternalSources",
+	"ListPatchExternalSources",
 }
 
 // dataSourcePrivileges is the rendered "Required Jamf permissions" Markdown
 // section for the patch software title data source.
-var dataSourcePrivileges = permissions.Section(proclassic.Privileges, dataSourceSDKMethods...)
+var dataSourcePrivileges = permissions.Section(mergedPrivileges, dataSourceSDKMethods...)
 
 // listResourceSDKMethods lists the SDK methods the patch software title list
 // resource calls (list_resource.go).
 var listResourceSDKMethods = []string{
-	"ListPatchSoftwareTitles",
+	"ListPatchSoftwareTitleConfigurationsV3",
+	"ListPatchInternalSources",
+	"ListPatchExternalSources",
 }
 
 // listResourcePrivileges is the rendered "Required Jamf permissions" Markdown
 // section for the patch software title list resource.
-var listResourcePrivileges = permissions.Section(proclassic.Privileges, listResourceSDKMethods...)
+var listResourcePrivileges = permissions.Section(mergedPrivileges, listResourceSDKMethods...)

--- a/internal/resources/pro/patch_software_title/permissions_test.go
+++ b/internal/resources/pro/patch_software_title/permissions_test.go
@@ -15,8 +15,9 @@ import (
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/permissions"
 )
 
-// mergedRegistry is the union of the SDK families this package's resource spans:
-// ProClassic CRUD + Pro v3 extension attributes.
+// mergedRegistry is the union of the SDK families every construct in this
+// package spans: Pro v3 configuration CRUD plus the ProClassic create and patch
+// source catalogues.
 var mergedRegistry = permissions.Merge(proclassic.Privileges, pro.Privileges)
 
 // callRe matches a "<receiver>.<Method>(" call. The test filters the captures to
@@ -71,7 +72,7 @@ func assertMatch(t *testing.T, declared []string, called map[string]bool, where 
 	}
 }
 
-// --- resource (CRUD across ProClassic + Pro v2) ---
+// --- resource (CRUD across Pro v3 + the ProClassic create) ---
 
 // TestResourceSDKMethods_KnownToSDK fails if a declared method has been renamed
 // or removed in the merged SDK privilege registry.
@@ -83,11 +84,12 @@ func TestResourceSDKMethods_KnownToSDK(t *testing.T) {
 
 // TestResourceSDKMethods_MatchCalls fails if the resource's CRUD path calls an
 // SDK method not declared in resourceSDKMethods, or declares one it does not
-// call. The classic CRUD lives in crud.go; the Pro v3 extension-attribute calls
-// live in extension_attributes.go (invoked from Create/Read/Update).
+// call. The v3 CRUD lives in crud.go, the extension-attribute side-channel in
+// extension_attributes.go (invoked from Create/Read/Update), and the patch
+// source catalogue reads behind source_id resolution in patch_sources.go.
 func TestResourceSDKMethods_MatchCalls(t *testing.T) {
-	called := sdkCallsIn(t, mergedRegistry, "crud.go", "extension_attributes.go")
-	assertMatch(t, resourceSDKMethods, called, "crud.go+extension_attributes.go")
+	called := sdkCallsIn(t, mergedRegistry, "crud.go", "extension_attributes.go", "patch_sources.go")
+	assertMatch(t, resourceSDKMethods, called, "crud.go+extension_attributes.go+patch_sources.go")
 }
 
 // TestResourcePrivileges_Rendered guards that the table actually rendered into
@@ -102,16 +104,17 @@ func TestResourcePrivileges_Rendered(t *testing.T) {
 
 // TestDataSourceSDKMethods_KnownToSDK fails on SDK drift for the data source.
 func TestDataSourceSDKMethods_KnownToSDK(t *testing.T) {
-	if missing := permissions.Missing(proclassic.Privileges, dataSourceSDKMethods...); len(missing) > 0 {
-		t.Fatalf("dataSourceSDKMethods not present in proclassic.Privileges (SDK drift): %v", missing)
+	if missing := permissions.Missing(mergedRegistry, dataSourceSDKMethods...); len(missing) > 0 {
+		t.Fatalf("dataSourceSDKMethods not present in merged SDK registry (SDK drift): %v", missing)
 	}
 }
 
 // TestDataSourceSDKMethods_MatchCalls keeps the data source's privilege list in
-// sync with data_source.go.
+// sync with data_source.go plus the patch source catalogue reads it resolves
+// source_id through.
 func TestDataSourceSDKMethods_MatchCalls(t *testing.T) {
-	called := sdkCallsIn(t, proclassic.Privileges, "data_source.go")
-	assertMatch(t, dataSourceSDKMethods, called, "data_source.go")
+	called := sdkCallsIn(t, mergedRegistry, "data_source.go", "patch_sources.go")
+	assertMatch(t, dataSourceSDKMethods, called, "data_source.go+patch_sources.go")
 }
 
 // TestDataSourcePrivileges_Rendered guards the data source table rendered.
@@ -125,15 +128,15 @@ func TestDataSourcePrivileges_Rendered(t *testing.T) {
 
 // TestListResourceSDKMethods_KnownToSDK fails on SDK drift for the list resource.
 func TestListResourceSDKMethods_KnownToSDK(t *testing.T) {
-	if missing := permissions.Missing(proclassic.Privileges, listResourceSDKMethods...); len(missing) > 0 {
-		t.Fatalf("listResourceSDKMethods not present in proclassic.Privileges (SDK drift): %v", missing)
+	if missing := permissions.Missing(mergedRegistry, listResourceSDKMethods...); len(missing) > 0 {
+		t.Fatalf("listResourceSDKMethods not present in merged SDK registry (SDK drift): %v", missing)
 	}
 }
 
 // TestListResourceSDKMethods_MatchCalls keeps the list resource's privilege list
 // in sync with list_resource.go.
 func TestListResourceSDKMethods_MatchCalls(t *testing.T) {
-	called := sdkCallsIn(t, proclassic.Privileges, "list_resource.go")
+	called := sdkCallsIn(t, mergedRegistry, "list_resource.go")
 	assertMatch(t, listResourceSDKMethods, called, "list_resource.go")
 }
 

--- a/internal/resources/pro/patch_software_title/permissions_test.go
+++ b/internal/resources/pro/patch_software_title/permissions_test.go
@@ -134,10 +134,14 @@ func TestListResourceSDKMethods_KnownToSDK(t *testing.T) {
 }
 
 // TestListResourceSDKMethods_MatchCalls keeps the list resource's privilege list
-// in sync with list_resource.go.
+// in sync with list_resource.go plus the patch source catalogue reads a listing
+// resolves source_id through. Those two reads live in patch_sources.go — the one
+// place they happen for every construct in this package — so the listing's
+// declaration is derived from the same pair of files as the resource's and the
+// data source's.
 func TestListResourceSDKMethods_MatchCalls(t *testing.T) {
-	called := sdkCallsIn(t, mergedRegistry, "list_resource.go")
-	assertMatch(t, listResourceSDKMethods, called, "list_resource.go")
+	called := sdkCallsIn(t, mergedRegistry, "list_resource.go", "patch_sources.go")
+	assertMatch(t, listResourceSDKMethods, called, "list_resource.go+patch_sources.go")
 }
 
 // TestListResourcePrivileges_Rendered guards the list resource table rendered.

--- a/internal/resources/pro/patch_software_title/resource.go
+++ b/internal/resources/pro/patch_software_title/resource.go
@@ -100,7 +100,7 @@ func (r *PatchSoftwareTitleResource) IdentitySchema(ctx context.Context, req res
 func (r *PatchSoftwareTitleResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		Version: 1,
-		MarkdownDescription: "Manages a Jamf Pro patch software title, found in the UI under **Computers → Patch management**. A configured title spans the tabs of that interface: the **Software Title Settings** tab (`name`, `category_id`, `site_id`, notifications), the **Definition** tab (per-version package assignments), and the **Extension Attribute** tab (`extension_attributes` / `accept_extension_attributes`). A title is defined by its `name_id` (catalog key) and `source_id` (patch source); the server populates the full catalog of `available_versions`. Assign packages to specific versions via `version_packages` (the **Definition** tab's per-version **Package** column) so patch policies can target them.\n\n" +
+		MarkdownDescription: "Manages a Jamf Pro patch software title, found in the UI under **Computers → Patch management**. A configured title spans the tabs of that interface: the **Software Title Settings** tab (`name`, `category_id`, `site_id`, notifications), the **Definition** tab (per-version package assignments), and the **Extension Attribute** tab (`extension_attributes` / `accept_extension_attributes`). A title is defined by its `name_id` (catalog key) and `source_id` (patch source); the server populates the full catalog of `available_versions`. Assign packages to specific versions via `version_packages` (the **Definition** tab's per-version **Package** column) so patch policies can target them." +
 			resourcePrivileges,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
@@ -135,7 +135,7 @@ func (r *PatchSoftwareTitleResource) Schema(ctx context.Context, req resource.Sc
 				},
 			},
 			"category_id": schema.StringAttribute{
-				MarkdownDescription: "Jamf Pro category ID (UI \"Category\"). Use `-1` (default) for \"No category assigned\".",
+				MarkdownDescription: "Jamf Pro category ID (UI \"Category\"). Set `-1` for \"No category assigned\" — the value a title starts out with. Only a positive ID or `-1` is accepted; `0` and other non-positive values are rejected when you plan. Removing this attribute from your configuration leaves the current category in place, so clear an assigned category by setting `-1` explicitly.",
 				Optional:            true,
 				Computed:            true,
 				Validators: []validator.String{
@@ -146,7 +146,7 @@ func (r *PatchSoftwareTitleResource) Schema(ctx context.Context, req resource.Sc
 				},
 			},
 			"site_id": schema.StringAttribute{
-				MarkdownDescription: "Jamf Pro site ID. Use `-1` (default) for \"NONE\".",
+				MarkdownDescription: "Jamf Pro site ID (UI \"Site\"). Set `-1` for \"None\" — the value a title starts out with. Only a positive ID or `-1` is accepted; `0` and other non-positive values are rejected when you plan. Removing this attribute from your configuration leaves the current site in place, so clear an assigned site by setting `-1` explicitly.",
 				Optional:            true,
 				Computed:            true,
 				Validators: []validator.String{
@@ -173,10 +173,11 @@ func (r *PatchSoftwareTitleResource) Schema(ctx context.Context, req resource.Sc
 				},
 			},
 			"version_packages": schema.MapAttribute{
-				MarkdownDescription: "Managed map of version→package assignments. Keys are `software_version` strings drawn from `available_versions`; values are Jamf Pro package ID strings. A patch policy can only target a version that has a package assigned here. Only the keys you declare are managed: other server-side assignments are left untouched, and removing a key clears that version's package on the next apply.",
+				MarkdownDescription: "Managed map of version→package assignments. Keys are `software_version` strings drawn from `available_versions`; values are Jamf Pro package ID strings. A patch policy can only target a version that has a package assigned here. Only the keys you declare are managed: other assignments on the title are left alone, and removing a key clears that version's package on the next apply. Omit the attribute entirely to manage no assignments — an empty map is not accepted.",
 				Optional:            true,
 				ElementType:         types.StringType,
 				Validators: []validator.Map{
+					mapvalidator.SizeAtLeast(1),
 					mapvalidator.ValueStringsAre(
 						stringvalidator.RegexMatches(packageIDPattern, "must be a positive integer package ID"),
 					),

--- a/internal/resources/pro/patch_software_title/resource.go
+++ b/internal/resources/pro/patch_software_title/resource.go
@@ -2,8 +2,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
 // Package patch_software_title implements the jamfplatform_pro_patch_software_title
-// resource, data source, and list resource backed by the Jamf ProClassic patch
-// software titles API.
+// resource, data source, and list resource backed by the Jamf Pro v3
+// patch-software-title-configurations API, plus the one classic
+// /patchsoftwaretitles call that mints a title's id (see crud.go header).
 package patch_software_title
 
 import (
@@ -31,20 +32,31 @@ import (
 )
 
 // minJamfProVersion is the minimum Jamf Pro tenant version required by this resource.
-// Empty: the classic /patchsoftwaretitles endpoint predates the provider's overall
-// floor (11.0.0). The provider-level advisory still fires through
-// providerdata.ConfigureProClassic when the tenant is below ProviderMinJamfProVersion.
+// Empty: both surfaces this resource uses — the v3 configurations endpoints and the
+// classic /patchsoftwaretitles create — predate the provider's overall floor
+// (11.0.0). The provider-level advisory still fires through
+// providerdata.ConfigurePro / ConfigureProClassic when the tenant is below
+// ProviderMinJamfProVersion.
 const minJamfProVersion = ""
 
 // packageIDPattern matches a positive integer string (Jamf package ID). Used to
 // validate version_packages map values at plan time.
 var packageIDPattern = regexp.MustCompile(`^[1-9]\d*$`)
 
-// PatchSoftwareTitleResource implements the Terraform resource for Jamf ProClassic
-// patch software titles. CRUD runs over the classic /patchsoftwaretitles endpoint
-// (client); extension-attribute read + accept use the modern v3
-// /patch-software-title-configurations endpoint (proClient), keyed by the same
-// id (the classic title id equals the configuration id — wire-verified).
+// refIDPattern matches the only category / site ids the configurations endpoint
+// accepts: a positive integer, or the "-1" not-assigned sentinel. Anything else
+// is refused outright ("id field must be string of positive numeric value or
+// -1"), so it is validated at plan time rather than surfacing as a 400
+// mid-apply.
+var refIDPattern = regexp.MustCompile(`^(-1|[1-9]\d*)$`)
+
+// PatchSoftwareTitleResource implements the Terraform resource for Jamf Pro patch
+// software titles. Read, update, delete and the extension-attribute side-channel
+// run over the v3 /patch-software-title-configurations endpoints (proClient). The
+// classic client is needed for two things only: the POST that mints a title's id,
+// which v3 has no equivalent for, and resolving a patch source's name back to the
+// source_id v3 omits. Both keys are the same number — the classic title id equals
+// the configuration id, wire-verified.
 type PatchSoftwareTitleResource struct {
 	client    *proclassic.Client
 	proClient *pro.Client
@@ -53,6 +65,7 @@ type PatchSoftwareTitleResource struct {
 var _ resource.Resource = &PatchSoftwareTitleResource{}
 var _ resource.ResourceWithImportState = &PatchSoftwareTitleResource{}
 var _ resource.ResourceWithIdentity = &PatchSoftwareTitleResource{}
+var _ resource.ResourceWithUpgradeState = &PatchSoftwareTitleResource{}
 
 const (
 	defaultCreateTimeout = 60 * time.Second
@@ -86,8 +99,8 @@ func (r *PatchSoftwareTitleResource) IdentitySchema(ctx context.Context, req res
 // Schema returns the Terraform schema for the patch software title resource.
 func (r *PatchSoftwareTitleResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
+		Version: 1,
 		MarkdownDescription: "Manages a Jamf Pro patch software title, found in the UI under **Computers → Patch management**. A configured title spans the tabs of that interface: the **Software Title Settings** tab (`name`, `category_id`, `site_id`, notifications), the **Definition** tab (per-version package assignments), and the **Extension Attribute** tab (`extension_attributes` / `accept_extension_attributes`). A title is defined by its `name_id` (catalog key) and `source_id` (patch source); the server populates the full catalog of `available_versions`. Assign packages to specific versions via `version_packages` (the **Definition** tab's per-version **Package** column) so patch policies can target them.\n\n" +
-			"> **Deprecation notice:** this resource is backed by the Jamf ProClassic `/patchsoftwaretitles` endpoints, which the Jamf API spec flags as deprecated in favour of `/patch-software-title-configurations`. The classic endpoints remain the only functional create surface: the configurations `POST` requires a `softwareTitleId`, which is the classic title id, and the only call that mints one also creates the configuration — so there is nothing for the provider to migrate create onto. Behaviour may change if Jamf removes the classic endpoints." +
 			resourcePrivileges,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
@@ -125,25 +138,23 @@ func (r *PatchSoftwareTitleResource) Schema(ctx context.Context, req resource.Sc
 				MarkdownDescription: "Jamf Pro category ID (UI \"Category\"). Use `-1` (default) for \"No category assigned\".",
 				Optional:            true,
 				Computed:            true,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(refIDPattern, "must be a positive integer ID, or \"-1\" for no category"),
+				},
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
-			},
-			"category_name": schema.StringAttribute{
-				MarkdownDescription: "Category display name. Returned by Jamf Pro; not user-settable.",
-				Computed:            true,
 			},
 			"site_id": schema.StringAttribute{
 				MarkdownDescription: "Jamf Pro site ID. Use `-1` (default) for \"NONE\".",
 				Optional:            true,
 				Computed:            true,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(refIDPattern, "must be a positive integer ID, or \"-1\" for no site"),
+				},
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
-			},
-			"site_name": schema.StringAttribute{
-				MarkdownDescription: "Site display name. Returned by Jamf Pro; not user-settable.",
-				Computed:            true,
 			},
 			"web_notification": schema.BoolAttribute{
 				MarkdownDescription: "Whether a Jamf Pro notification is raised for new versions (UI \"Jamf Pro Notification\"). Server-defaulted when omitted.",
@@ -216,9 +227,10 @@ func (r *PatchSoftwareTitleResource) Schema(ctx context.Context, req resource.Sc
 	}
 }
 
-// Configure wires both Jamf clients into the resource: the ProClassic client
-// (classic /patchsoftwaretitles CRUD) and the Pro client (v3 extension-attribute
-// read + accept). Both are built from the same provider data.
+// Configure wires both Jamf clients into the resource: the Pro client (the v3
+// configuration CRUD and extension-attribute side-channel) and the ProClassic
+// client (the id-minting create and patch-source name resolution). Both are
+// built from the same provider data.
 func (r *PatchSoftwareTitleResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
 	client, diags := providerdata.ConfigureProClassic(ctx, req.ProviderData, minJamfProVersion, "jamfplatform_pro_patch_software_title")
 	resp.Diagnostics.Append(diags...)

--- a/internal/resources/pro/patch_software_title/resource_acceptance_test.go
+++ b/internal/resources/pro/patch_software_title/resource_acceptance_test.go
@@ -475,6 +475,32 @@ func TestAccDataSource_ProPatchSoftwareTitle_ByIDAndName(t *testing.T) {
 	})
 }
 
+// TestAccDataSource_ProPatchSoftwareTitle_AmbiguousSelector asserts the data
+// source's ExactlyOneOf selector validator: supplying both id and name is
+// refused at plan time. The positive cases above cover each selector on its own,
+// which is exactly the coverage a silent removal of the validator would keep
+// green.
+//
+// The diagnostic wraps at ~80 cols, so the regex matches only the summary.
+func TestAccDataSource_ProPatchSoftwareTitle_AmbiguousSelector(t *testing.T) {
+	testhelpers.AccPreCheck(t)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testhelpers.AccTestProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+data "jamfplatform_pro_patch_software_title" "bad" {
+  id   = "1"
+  name = "x"
+}
+`,
+				ExpectError: regexp.MustCompile(`Invalid Attribute Combination`),
+			},
+		},
+	})
+}
+
 // TestAccListResource_ProPatchSoftwareTitle_Basic exercises the list resource via
 // the `terraform query` workflow. DisplayName / the filter match on the title's
 // display name.

--- a/internal/resources/pro/patch_software_title/resource_acceptance_test.go
+++ b/internal/resources/pro/patch_software_title/resource_acceptance_test.go
@@ -3,15 +3,16 @@
 
 //go:build acceptance
 
-// Tests in this file talk to the Jamf ProClassic /patchsoftwaretitles endpoint
-// (deprecated in the spec but the only functional CRUD surface — see crud.go).
-// Classic has known concurrency issues when multiple writes hit the same
-// resource type — keep these tests serial with any future classic acceptance
-// work in this package.
+// Tests in this file talk to the Jamf Pro v3 patch-software-title-configurations
+// endpoints, plus the one classic /patchsoftwaretitles call that mints a title's
+// id (see crud.go). That classic create has known concurrency issues when
+// multiple writes hit the same resource type — keep these tests serial with any
+// future classic acceptance work in this package.
 //
 // The fixtures use the real "8x8 Work" patch catalog entry: name_id "285",
-// source_id 1, with version "8.33.2.2". If the catalog entry or that version is
-// removed from the test tenant's patch source, these tests will need updating.
+// source_id 1, with versions "8.33.2.2" and "8.32.2.10". If the catalog entry or
+// either version is removed from the test tenant's patch source, these tests
+// will need updating.
 
 package patch_software_title_test
 
@@ -35,20 +36,19 @@ import (
 )
 
 const (
-	accTitleNameID    = "285" // 8x8 Work
-	accTitleSourceID  = 1
-	accTitleVersion   = "8.33.2.2"
-	patchSoftwareType = "jamfplatform_pro_patch_software_title"
+	accTitleNameID     = "285" // 8x8 Work
+	accTitleSourceID   = 1
+	accTitleVersion    = "8.33.2.2"
+	accTitleVersionAlt = "8.32.2.10"
+	patchSoftwareType  = "jamfplatform_pro_patch_software_title"
 )
 
 // testAccCheckPatchSoftwareTitleDestroy verifies titles created during the test
 // were destroyed.
 //
-// The read goes through the v3 patch software title configurations endpoint. The
-// resource itself is ProClassic-backed, but the classic by-id read is deprecated
-// in the Jamf API spec, and both endpoints address the same object: wire-probed
-// 2026-08-03, each returns 404 for an id that does not exist, so
-// helpers.IsNotFoundError classifies them identically.
+// The read goes through the same v3 configurations endpoint the resource itself
+// deletes through. Wire-probed 2026-09-02: the v3 DELETE removes the classic
+// title with it, so a 404 here means the object is gone from both surfaces.
 func testAccCheckPatchSoftwareTitleDestroy(t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		c := pro.New(testhelpers.NewAcceptanceClient(t))
@@ -131,11 +131,8 @@ func TestAccResource_ProPatchSoftwareTitle_Basic(t *testing.T) {
 		}
 	`, cat, site, pkgA, pkgA, suffix, accTitleNameID, accTitleSourceID, accTitleVersion)
 
-	// Step 3: point the same version at a different package (change) and drop the
-	// previous key by not declaring it for another version (remove → clear). Here
-	// we change which package version A points at, exercising re-assign; the
-	// clear path is covered by the eventual destroy and by the unit tests, but we
-	// also reduce to an empty map to verify clear-on-remove round-trips.
+	// Step 3: point the same version at a different package, exercising the
+	// re-assign path through the v3 packages array.
 	stepClear := fmt.Sprintf(`
 		resource "jamfplatform_pro_category" "cat" {
 			name     = %q
@@ -165,18 +162,16 @@ func TestAccResource_ProPatchSoftwareTitle_Basic(t *testing.T) {
 			web_notification   = true
 			email_notification = true
 
-			# Re-point version A at package B (change), and the prior key for
-			# version A is retained but now clears nothing extra. Removing version
-			# A entirely from the map on a later apply would emit the empty-package
-			# clear; here we re-assign to prove the assign path mutates in place.
+			# Re-point version A at package B to prove the assign path mutates in
+			# place rather than accumulating.
 			version_packages = {
 				%q = jamfplatform_pro_package.pkg_b.id
 			}
 		}
 	`, cat, site, pkgA, pkgA, pkgB, pkgB, suffix, accTitleNameID, accTitleSourceID, accTitleVersion)
 
-	// Step 4: remove the version_packages key entirely → exercises the
-	// empty-package clear/unassign path.
+	// Step 4: remove the version_packages key entirely → exercises the unassign
+	// path, where the key drops out of the replacement array Update sends.
 	stepUnassign := fmt.Sprintf(`
 		resource "jamfplatform_pro_package" "pkg_a" {
 			display_name = %q
@@ -205,9 +200,9 @@ func TestAccResource_ProPatchSoftwareTitle_Basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(patchSoftwareType+".test", "id"),
 					resource.TestCheckResourceAttr(patchSoftwareType+".test", "name_id", accTitleNameID),
 					resource.TestCheckResourceAttr(patchSoftwareType+".test", "source_id", "1"),
-					// Server defaults. The classic patch-title GET omits the <site>
-					// block on a no-sites tenant; siteValues collapses that to the
-					// "-1" NONE sentinel (like category) so site_id is always known.
+					// Server defaults. v3 reports an unassigned category or site as
+					// the literal "-1", the only non-positive id it accepts on a
+					// write, so both are always known.
 					resource.TestCheckResourceAttr(patchSoftwareType+".test", "category_id", "-1"),
 					resource.TestCheckResourceAttr(patchSoftwareType+".test", "site_id", "-1"),
 					// Catalog versions populated by the server.
@@ -238,7 +233,7 @@ func TestAccResource_ProPatchSoftwareTitle_Basic(t *testing.T) {
 			{
 				Config: stepUnassign,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					// version_packages fully cleared (empty-package unassign path).
+					// version_packages fully cleared (unassign path).
 					resource.TestCheckNoResourceAttr(patchSoftwareType+".test", "version_packages.%"),
 				),
 			},
@@ -249,12 +244,164 @@ func TestAccResource_ProPatchSoftwareTitle_Basic(t *testing.T) {
 				// timeouts: framework-only, never round-trips.
 				// version_packages: managed-subset map keyed off prior state; on
 				// import there is no prior state, so it cannot be reconstructed.
-				// available_versions / *_name: server-derived and at this step the
-				// state already matches, but version_packages is the import gap.
+				// available_versions: server-derived, and at this step the state
+				// already matches. source_id is resolved from the patch source
+				// name on import, so it round-trips.
 				ImportStateVerifyIgnore: []string{"timeouts", "version_packages"},
 			},
 		},
 	})
+}
+
+// TestAccResource_ProPatchSoftwareTitle_OutOfBandAssignmentSurvives pins the
+// managed-subset contract version_packages documents: only the versions
+// Terraform declares are managed, and a package an admin assigns to some other
+// version through the UI must still be there after the next apply.
+//
+// It earns an acceptance test because the v3 packages array is a full
+// replacement — the naive migration, sending the plan's assignments alone,
+// silently wipes every assignment Terraform does not know about, and no unit
+// test over the request builder can catch that. Step two mutates the title
+// outside Terraform, then forces an Update by renaming, so the read-modify-write
+// fold in crud.go Update is what keeps the out-of-band assignment alive.
+func TestAccResource_ProPatchSoftwareTitle_OutOfBandAssignmentSurvives(t *testing.T) {
+	testhelpers.AccPreCheck(t)
+	suffix := testhelpers.RunSuffix()
+
+	pkgA := "tf-acc-pst-oob-pkgA-" + suffix
+	pkgB := "tf-acc-pst-oob-pkgB-" + suffix
+
+	var titleID, pkgBID string
+
+	config := func(name string) string {
+		return fmt.Sprintf(`
+		resource "jamfplatform_pro_package" "pkg_a" {
+			display_name = %q
+			file_name    = "%s.pkg"
+		}
+
+		resource "jamfplatform_pro_package" "pkg_b" {
+			display_name = %q
+			file_name    = "%s.pkg"
+		}
+
+		resource "jamfplatform_pro_patch_software_title" "test" {
+			name      = %q
+			name_id   = %q
+			source_id = %d
+
+			version_packages = {
+				%q = jamfplatform_pro_package.pkg_a.id
+			}
+		}
+	`, pkgA, pkgA, pkgB, pkgB, name, accTitleNameID, accTitleSourceID, accTitleVersion)
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testhelpers.AccTestProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckPatchSoftwareTitleDestroy(t),
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_13_0),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: config("tf-acc 8x8 Work oob " + suffix),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(patchSoftwareType+".test", "version_packages."+accTitleVersion, "jamfplatform_pro_package.pkg_a", "id"),
+					testAccCapturePatchTitleAndPackage(&titleID, &pkgBID),
+				),
+			},
+			{
+				PreConfig: func() {
+					if err := testAccAssignPatchPackageOutOfBand(t, titleID, accTitleVersionAlt, pkgBID); err != nil {
+						t.Fatalf("assigning a package outside Terraform: %v", err)
+					}
+				},
+				Config: config("tf-acc 8x8 Work oob renamed " + suffix),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(patchSoftwareType+".test", "name", "tf-acc 8x8 Work oob renamed "+suffix),
+					// The managed key is unchanged and still the only one in state.
+					resource.TestCheckResourceAttrPair(patchSoftwareType+".test", "version_packages."+accTitleVersion, "jamfplatform_pro_package.pkg_a", "id"),
+					resource.TestCheckResourceAttr(patchSoftwareType+".test", "version_packages.%", "1"),
+					// The unmanaged key is untouched on the server.
+					testAccCheckPatchTitleAssignment(t, &titleID, accTitleVersionAlt, &pkgBID),
+				),
+			},
+		},
+	})
+}
+
+// testAccCapturePatchTitleAndPackage records the title id and the id of the
+// package the next step assigns outside Terraform. PreConfig takes no state, so
+// the ids have to be captured from a Check in the preceding step.
+func testAccCapturePatchTitleAndPackage(titleID, pkgBID *string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		title, ok := s.RootModule().Resources[patchSoftwareType+".test"]
+		if !ok {
+			return fmt.Errorf("patch software title not found in state")
+		}
+		pkg, ok := s.RootModule().Resources["jamfplatform_pro_package.pkg_b"]
+		if !ok {
+			return fmt.Errorf("package pkg_b not found in state")
+		}
+		*titleID = title.Primary.ID
+		*pkgBID = pkg.Primary.ID
+		return nil
+	}
+}
+
+// testAccAssignPatchPackageOutOfBand assigns a package to one version of a title
+// the way an administrator would in the UI: a v3 merge-patch the provider had no
+// part in. It reads the current assignments first and appends, because the
+// packages array replaces rather than merges.
+func testAccAssignPatchPackageOutOfBand(t *testing.T, titleID, version, packageID string) error {
+	t.Helper()
+	if titleID == "" || packageID == "" {
+		return fmt.Errorf("nothing captured from the previous step (title %q, package %q)", titleID, packageID)
+	}
+
+	c := pro.New(testhelpers.NewAcceptanceClient(t))
+	ctx := context.Background()
+
+	current, err := c.GetPatchSoftwareTitleConfigurationV3(ctx, titleID)
+	if err != nil {
+		return fmt.Errorf("reading title %s: %w", titleID, err)
+	}
+
+	packages := append([]pro.PatchSoftwareTitlePackages{}, current.Packages...)
+	v, p := version, packageID
+	packages = append(packages, pro.PatchSoftwareTitlePackages{Version: &v, PackageID: &p})
+
+	if _, err := c.UpdatePatchSoftwareTitleConfigurationV3(ctx, titleID, &pro.PatchSoftwareTitleConfigurationPatch{
+		Packages: &packages,
+	}); err != nil {
+		return fmt.Errorf("assigning package %s to version %s of title %s: %w", packageID, version, titleID, err)
+	}
+	return nil
+}
+
+// testAccCheckPatchTitleAssignment asserts the server still reports the given
+// version pointing at the given package. The ids are read through pointers
+// because they are only known once an earlier step has run.
+func testAccCheckPatchTitleAssignment(t *testing.T, titleID *string, version string, packageID *string) resource.TestCheckFunc {
+	t.Helper()
+	return func(*terraform.State) error {
+		c := pro.New(testhelpers.NewAcceptanceClient(t))
+		got, err := c.GetPatchSoftwareTitleConfigurationV3(context.Background(), *titleID)
+		if err != nil {
+			return fmt.Errorf("reading title %s: %w", *titleID, err)
+		}
+		for _, pkg := range got.Packages {
+			if pkg.Version == nil || *pkg.Version != version {
+				continue
+			}
+			if pkg.PackageID == nil || *pkg.PackageID != *packageID {
+				return fmt.Errorf("version %s points at package %v, want %s", version, pkg.PackageID, *packageID)
+			}
+			return nil
+		}
+		return fmt.Errorf("version %s has no package assignment; the apply wiped an assignment Terraform did not manage", version)
+	}
 }
 
 // TestAccResource_ProPatchSoftwareTitle_InvalidPackageID asserts the

--- a/internal/resources/pro/patch_software_title/schema_test.go
+++ b/internal/resources/pro/patch_software_title/schema_test.go
@@ -12,6 +12,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 )
 
+// TestPatchSoftwareTitleResource_Metadata pins the Terraform type name. It is
+// the resource's public address, so a change to it breaks every existing
+// configuration.
 func TestPatchSoftwareTitleResource_Metadata(t *testing.T) {
 	r := NewPatchSoftwareTitleResource()
 	req := resource.MetadataRequest{ProviderTypeName: "jamfplatform"}
@@ -23,6 +26,32 @@ func TestPatchSoftwareTitleResource_Metadata(t *testing.T) {
 	}
 }
 
+// TestPatchSoftwareTitleResource_SchemaVersion pins the schema version against
+// the state upgrader's registered key. The two are coupled by hand: bumping the
+// version without registering the matching upgrader makes every existing state
+// file unreadable, and registering one without bumping means it never runs.
+func TestPatchSoftwareTitleResource_SchemaVersion(t *testing.T) {
+	r := NewPatchSoftwareTitleResource().(*PatchSoftwareTitleResource)
+	var resp resource.SchemaResponse
+	r.Schema(context.Background(), resource.SchemaRequest{}, &resp)
+
+	if resp.Schema.Version != 1 {
+		t.Errorf("expected schema version 1, got %d", resp.Schema.Version)
+	}
+	if _, ok := r.UpgradeState(context.Background())[0]; !ok {
+		t.Error("schema version 1 needs an upgrader registered for version 0, or v0 state cannot be read")
+	}
+}
+
+// TestPatchSoftwareTitleResource_Schema pins the attribute set and each
+// attribute's Optional/Required/Computed mode, which together decide how the
+// framework plans the resource. Four of these are load-bearing beyond the
+// obvious: category_id / site_id / the notification bools are Optional+Computed
+// because the server defaults them; version_packages is Optional-only so a
+// managed subset never plans as a computed map; accept_extension_attributes is
+// Optional-only because it is one-way user intent rather than server state; and
+// extension_attributes is plain Computed so it goes Unknown when an accept
+// flips accepted false→true inside a single apply.
 func TestPatchSoftwareTitleResource_Schema(t *testing.T) {
 	r := NewPatchSoftwareTitleResource()
 	var resp resource.SchemaResponse
@@ -33,11 +62,14 @@ func TestPatchSoftwareTitleResource_Schema(t *testing.T) {
 	}
 
 	s := resp.Schema
-	want := []string{"id", "name", "name_id", "source_id", "category_id", "category_name", "site_id", "site_name", "web_notification", "email_notification", "version_packages", "available_versions", "accept_extension_attributes", "extension_attributes", "timeouts"}
+	want := []string{"id", "name", "name_id", "source_id", "category_id", "site_id", "web_notification", "email_notification", "version_packages", "available_versions", "accept_extension_attributes", "extension_attributes", "timeouts"}
 	for _, name := range want {
 		if _, ok := s.Attributes[name]; !ok {
 			t.Errorf("missing attribute %q", name)
 		}
+	}
+	if len(s.Attributes) != len(want) {
+		t.Errorf("expected exactly %d attributes, got %d", len(want), len(s.Attributes))
 	}
 
 	id := s.Attributes["id"]
@@ -51,7 +83,6 @@ func TestPatchSoftwareTitleResource_Schema(t *testing.T) {
 		}
 	}
 
-	// category_id / site_id / both notification bools are Optional+Computed.
 	for _, oc := range []string{"category_id", "site_id", "web_notification", "email_notification"} {
 		a := s.Attributes[oc]
 		if !a.IsOptional() || !a.IsComputed() {
@@ -59,16 +90,13 @@ func TestPatchSoftwareTitleResource_Schema(t *testing.T) {
 		}
 	}
 
-	// category_name / site_name / available_versions are Computed-only.
-	for _, c := range []string{"category_name", "site_name", "available_versions"} {
+	for _, c := range []string{"available_versions", "extension_attributes"} {
 		a := s.Attributes[c]
 		if a.IsOptional() || a.IsRequired() || !a.IsComputed() {
 			t.Errorf("%q must be computed-only, got optional=%v required=%v computed=%v", c, a.IsOptional(), a.IsRequired(), a.IsComputed())
 		}
 	}
 
-	// version_packages must be Optional-only (never Computed — avoids computed-map
-	// plan quirks).
 	vp := s.Attributes["version_packages"]
 	if !vp.IsOptional() {
 		t.Errorf("version_packages must be optional")
@@ -77,21 +105,31 @@ func TestPatchSoftwareTitleResource_Schema(t *testing.T) {
 		t.Errorf("version_packages must NOT be computed (managed-subset map)")
 	}
 
-	// accept_extension_attributes is an Optional-only one-way action flag (never
-	// Computed — it is a user intent input, not coupled to the computed list).
 	accept := s.Attributes["accept_extension_attributes"]
 	if !accept.IsOptional() || accept.IsComputed() || accept.IsRequired() {
 		t.Errorf("accept_extension_attributes must be optional-only, got optional=%v computed=%v required=%v", accept.IsOptional(), accept.IsComputed(), accept.IsRequired())
 	}
+}
 
-	// extension_attributes is Computed-only (no plan modifier) so it goes Unknown
-	// when an accept flips accepted=false→true in the same apply.
-	ea := s.Attributes["extension_attributes"]
-	if ea.IsOptional() || ea.IsRequired() || !ea.IsComputed() {
-		t.Errorf("extension_attributes must be computed-only, got optional=%v required=%v computed=%v", ea.IsOptional(), ea.IsRequired(), ea.IsComputed())
+// TestPatchSoftwareTitleResource_SchemaDropsV0NameAttributes pins the removal
+// the v1 schema exists for. The v3 configuration reports category and site as
+// ids only, so re-adding either display name would need a lookup per read for a
+// value Terraform never writes — and would need a second schema version to get
+// back out of.
+func TestPatchSoftwareTitleResource_SchemaDropsV0NameAttributes(t *testing.T) {
+	r := NewPatchSoftwareTitleResource()
+	var resp resource.SchemaResponse
+	r.(*PatchSoftwareTitleResource).Schema(context.Background(), resource.SchemaRequest{}, &resp)
+
+	for _, gone := range removedInV1 {
+		if _, ok := resp.Schema.Attributes[gone]; ok {
+			t.Errorf("%q was removed at schema v1 and must not be declared", gone)
+		}
 	}
 }
 
+// TestPatchSoftwareTitleDataSource_Metadata pins the data source's public
+// address, which shares the resource's type name.
 func TestPatchSoftwareTitleDataSource_Metadata(t *testing.T) {
 	d := NewPatchSoftwareTitleDataSource()
 	req := datasource.MetadataRequest{ProviderTypeName: "jamfplatform"}
@@ -103,6 +141,12 @@ func TestPatchSoftwareTitleDataSource_Metadata(t *testing.T) {
 	}
 }
 
+// TestPatchSoftwareTitleDataSource_Schema pins that id and name are the two
+// mutually-exclusive selectors — Optional so either can be supplied, Computed
+// so the other is filled from the response — and that every remaining attribute
+// is Computed-only, so nothing else can be mistaken for a lookup key.
+// category_name and site_name are gone here too: the data source reads the same
+// v3 body as the resource.
 func TestPatchSoftwareTitleDataSource_Schema(t *testing.T) {
 	d := NewPatchSoftwareTitleDataSource()
 	var resp datasource.SchemaResponse
@@ -113,7 +157,6 @@ func TestPatchSoftwareTitleDataSource_Schema(t *testing.T) {
 	}
 
 	s := resp.Schema
-	// id and name are the two mutually-exclusive selectors — Optional+Computed.
 	for _, sel := range []string{"id", "name"} {
 		a := s.Attributes[sel]
 		if !a.IsOptional() {
@@ -124,8 +167,7 @@ func TestPatchSoftwareTitleDataSource_Schema(t *testing.T) {
 		}
 	}
 
-	// Everything else is Computed-only.
-	for _, c := range []string{"name_id", "source_id", "category_id", "category_name", "site_id", "site_name", "web_notification", "email_notification", "version_packages", "available_versions"} {
+	for _, c := range []string{"name_id", "source_id", "category_id", "site_id", "web_notification", "email_notification", "version_packages", "available_versions"} {
 		a, ok := s.Attributes[c]
 		if !ok {
 			t.Errorf("missing attribute %q", c)
@@ -135,8 +177,17 @@ func TestPatchSoftwareTitleDataSource_Schema(t *testing.T) {
 			t.Errorf("%q must be computed-only, got optional=%v required=%v computed=%v", c, a.IsOptional(), a.IsRequired(), a.IsComputed())
 		}
 	}
+
+	for _, gone := range removedInV1 {
+		if _, ok := s.Attributes[gone]; ok {
+			t.Errorf("%q was removed with the v3 migration and must not be declared on the data source", gone)
+		}
+	}
 }
 
+// TestPatchSoftwareTitleDataSource_ConfigValidators_ExactlyOneSelector pins that
+// the id-or-name choice is enforced at plan time. Without the validator a config
+// supplying neither reaches the read and fails mid-apply against the API instead.
 func TestPatchSoftwareTitleDataSource_ConfigValidators_ExactlyOneSelector(t *testing.T) {
 	d := NewPatchSoftwareTitleDataSource().(*PatchSoftwareTitleDataSource)
 	got := d.ConfigValidators(context.Background())
@@ -145,6 +196,8 @@ func TestPatchSoftwareTitleDataSource_ConfigValidators_ExactlyOneSelector(t *tes
 	}
 }
 
+// TestPatchSoftwareTitleListResource_Metadata pins the list resource's public
+// address, which shares the resource's type name.
 func TestPatchSoftwareTitleListResource_Metadata(t *testing.T) {
 	r := NewPatchSoftwareTitleListResource()
 	req := resource.MetadataRequest{ProviderTypeName: "jamfplatform"}
@@ -156,6 +209,10 @@ func TestPatchSoftwareTitleListResource_Metadata(t *testing.T) {
 	}
 }
 
+// TestPatchSoftwareTitleListResource_Schema pins the filter block's presence.
+// The v3 configurations list takes no query parameters, so client-side
+// substring filtering on the display name is the only selectivity the list
+// resource has.
 func TestPatchSoftwareTitleListResource_Schema(t *testing.T) {
 	r := NewPatchSoftwareTitleListResource()
 	var resp list.ListResourceSchemaResponse

--- a/internal/resources/pro/patch_software_title/state_builders.go
+++ b/internal/resources/pro/patch_software_title/state_builders.go
@@ -7,56 +7,51 @@ import (
 	"context"
 	"strconv"
 
-	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/proclassic"
+	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/pro"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-
-	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/helpers"
 )
 
-// assignPatchSoftwareTitleResourceModel populates a resource model from a
-// PatchSoftwareTitle response. declaredKeys is the managed subset of
-// software_version keys the caller declared (plan keys on Create/Update, prior
-// state keys on Read): version_packages is rebuilt from only those keys by
-// looking each up in the server's versions and reading its assigned package id.
-// A declared key whose package is gone server-side is dropped from the map,
-// surfacing the drift. state.ID is only overwritten when the API ID is non-nil.
-func assignPatchSoftwareTitleResourceModel(ctx context.Context, state *PatchSoftwareTitleResourceModel, s *proclassic.PatchSoftwareTitle, declaredKeys []string) diag.Diagnostics {
+// assignPatchSoftwareTitleResourceModel populates a resource model from a v3
+// patch software title configuration plus the version catalog, which lives on
+// the separate /definitions sub-resource rather than the configuration body.
+// declaredKeys is the managed subset of software_version keys the caller
+// declared (plan keys on Create/Update, prior state keys on Read):
+// version_packages is rebuilt from only those keys by looking each up in the
+// configuration's package assignments. A declared key whose package is gone
+// server-side is dropped from the map, surfacing the drift.
+//
+// source_id is deliberately left untouched. The v3 configuration names its
+// patch source (patchSourceName) but never numbers it, and a title's source
+// cannot change once minted, so whatever is already in state stays correct.
+// Import is the one case with nothing in state to keep, and Read resolves the
+// number from the name there — see resolveSourceID.
+func assignPatchSoftwareTitleResourceModel(ctx context.Context, state *PatchSoftwareTitleResourceModel, s *pro.PatchSoftwareTitleConfiguration, availableVersions, declaredKeys []string) diag.Diagnostics {
 	var diags diag.Diagnostics
 	if s == nil {
 		return diags
 	}
-	if s.ID != nil {
-		state.ID = helpers.StringValueFromIntPtr(s.ID)
+	if s.ID != "" {
+		state.ID = types.StringValue(s.ID)
 	}
-	if s.Name != nil {
-		state.Name = helpers.StringPointerValueOrNull(s.Name)
-	}
-	if s.NameID != nil {
-		state.NameID = helpers.StringPointerValueOrNull(s.NameID)
-	}
-	if s.SourceID != nil {
-		state.SourceID = types.Int64Value(int64(*s.SourceID))
+	state.Name = types.StringValue(s.DisplayName)
+	if s.SoftwareTitleNameID != "" {
+		state.NameID = types.StringValue(s.SoftwareTitleNameID)
 	}
 
-	state.CategoryID, state.CategoryName = categoryValues(s.Category)
-	state.SiteID, state.SiteName = siteValues(s.Site)
+	state.CategoryID = refIDValue(s.CategoryID)
+	state.SiteID = refIDValue(s.SiteID)
+	state.WebNotification = types.BoolValue(s.UiNotifications)
+	state.EmailNotification = types.BoolValue(s.EmailNotifications)
 
-	web, email := notificationValues(s.Notifications)
-	state.WebNotification = web
-	state.EmailNotification = email
-
-	assigned := assignedPackagesByVersion(s.Versions)
-
-	avail := availableVersions(s.Versions)
-	availList, d := types.ListValueFrom(ctx, types.StringType, avail)
+	availList, d := types.ListValueFrom(ctx, types.StringType, orEmpty(availableVersions))
 	diags.Append(d...)
 	if diags.HasError() {
 		return diags
 	}
 	state.AvailableVersions = availList
 
-	vp, d := managedVersionPackages(ctx, declaredKeys, assigned)
+	vp, d := managedVersionPackages(ctx, declaredKeys, assignedPackagesByVersion(s.Packages))
 	diags.Append(d...)
 	if diags.HasError() {
 		return diags
@@ -68,123 +63,84 @@ func assignPatchSoftwareTitleResourceModel(ctx context.Context, state *PatchSoft
 
 // assignPatchSoftwareTitleDataSourceModel populates a data source model. The
 // data source surfaces the full server view, so version_packages is built from
-// every server version that has a package assigned (no managed-subset gating —
-// there is no prior state to scope against).
-func assignPatchSoftwareTitleDataSourceModel(ctx context.Context, state *PatchSoftwareTitleDataSourceModel, s *proclassic.PatchSoftwareTitle) diag.Diagnostics {
+// every assignment the configuration reports (no managed-subset gating — there
+// is no prior state to scope against). sourceID is resolved by the caller from
+// the configuration's patch source name.
+func assignPatchSoftwareTitleDataSourceModel(ctx context.Context, state *PatchSoftwareTitleDataSourceModel, s *pro.PatchSoftwareTitleConfiguration, availableVersions []string, sourceID types.Int64) diag.Diagnostics {
 	var diags diag.Diagnostics
 	if s == nil {
 		return diags
 	}
-	if s.ID != nil {
-		state.ID = helpers.StringValueFromIntPtr(s.ID)
-	}
-	state.Name = helpers.StringPointerValueOrNull(s.Name)
-	state.NameID = helpers.StringPointerValueOrNull(s.NameID)
-	if s.SourceID != nil {
-		state.SourceID = types.Int64Value(int64(*s.SourceID))
-	} else {
-		state.SourceID = types.Int64Null()
-	}
+	state.ID = types.StringValue(s.ID)
+	state.Name = types.StringValue(s.DisplayName)
+	state.NameID = types.StringValue(s.SoftwareTitleNameID)
+	state.SourceID = sourceID
 
-	state.CategoryID, state.CategoryName = categoryValues(s.Category)
-	state.SiteID, state.SiteName = siteValues(s.Site)
+	state.CategoryID = refIDValue(s.CategoryID)
+	state.SiteID = refIDValue(s.SiteID)
+	state.WebNotification = types.BoolValue(s.UiNotifications)
+	state.EmailNotification = types.BoolValue(s.EmailNotifications)
 
-	web, email := notificationValues(s.Notifications)
-	state.WebNotification = web
-	state.EmailNotification = email
-
-	assigned := assignedPackagesByVersion(s.Versions)
-
-	avail := availableVersions(s.Versions)
-	availList, d := types.ListValueFrom(ctx, types.StringType, avail)
+	availList, d := types.ListValueFrom(ctx, types.StringType, orEmpty(availableVersions))
 	diags.Append(d...)
 	if diags.HasError() {
 		return diags
 	}
 	state.AvailableVersions = availList
 
-	vpList, d := types.MapValueFrom(ctx, types.StringType, assigned)
+	vpMap, d := types.MapValueFrom(ctx, types.StringType, assignedPackagesByVersion(s.Packages))
 	diags.Append(d...)
 	if diags.HasError() {
 		return diags
 	}
-	state.VersionPackages = vpList
+	state.VersionPackages = vpMap
 
 	return diags
 }
 
-// categoryValues maps an SDK category object onto (id, name) Terraform strings.
-// A nil category yields null/null. The endpoint reports "no category" as id -1
-// (never assigned) or id 0 (explicitly cleared via the buildPatchSoftwareTitleUpdateInput
-// wire translation); both collapse to the "-1" user-facing sentinel so state
-// matches config regardless of which the server echoes. The derived name nulls on
-// the sentinel via helpers.DerivedRefName — the GET nondeterministically echoes
-// or omits the "NONE" name, so trusting it would flip category_name between reads.
-func categoryValues(c *proclassic.CategoryObject) (types.String, types.String) {
-	if c == nil {
-		return types.StringNull(), types.StringNull()
+// refIDValue maps a v3 category or site id onto its Terraform value. The
+// configurations endpoint reports "not assigned" as the string "-1" and rejects
+// any other non-positive id on a write, so that sentinel round-trips as-is.
+// Two other shapes are normalised to it defensively: an empty string (a field
+// the server omitted), and the literal "0" — which no v3 write can produce but
+// a title last written through the classic /patchsoftwaretitles endpoint can
+// still carry, because that endpoint cleared a category by storing wire id 0.
+func refIDValue(id string) types.String {
+	if id == "" {
+		return types.StringValue("-1")
 	}
-	if c.ID == nil || *c.ID <= 0 {
-		return types.StringValue("-1"), helpers.DerivedRefName(c.ID, c.Name)
+	if n, err := strconv.Atoi(id); err == nil && n <= 0 {
+		return types.StringValue("-1")
 	}
-	return helpers.StringValueFromIntPtr(c.ID), helpers.DerivedRefName(c.ID, c.Name)
+	return types.StringValue(id)
 }
 
-// siteValues maps an SDK site object onto (id, name) Terraform strings. Both a
-// missing <site> block (the classic GET omits it entirely on a tenant with no
-// sites configured) and an id <= 0 (explicitly "NONE") collapse to the "-1"
-// user-facing sentinel. site_id is Optional+Computed with UseStateForUnknown, so
-// it must never resolve to null: otherwise a plan that carried "-1" forward would
-// hit "inconsistent result after apply" the moment the server drops the block.
-// Mirrors categoryValues' "-1" treatment. site_name nulls on the sentinel via
-// helpers.DerivedRefName — the GET nondeterministically echoes or omits the "NONE"
-// name, so trusting it would flip site_name between reads (ImportStateVerify fail).
-func siteValues(s *proclassic.SiteObject) (types.String, types.String) {
-	if s == nil {
-		return types.StringValue("-1"), types.StringNull()
-	}
-	if s.ID == nil || *s.ID <= 0 {
-		return types.StringValue("-1"), helpers.DerivedRefName(s.ID, s.Name)
-	}
-	return helpers.StringValueFromIntPtr(s.ID), helpers.DerivedRefName(s.ID, s.Name)
-}
-
-// notificationValues maps the notifications block onto (web, email) bools. A nil
-// block yields null/null.
-func notificationValues(n *proclassic.PatchSoftwareTitleNotifications) (types.Bool, types.Bool) {
-	if n == nil {
-		return types.BoolNull(), types.BoolNull()
-	}
-	return helpers.BoolPointerValueOrNull(n.WebNotification), helpers.BoolPointerValueOrNull(n.EmailNotification)
-}
-
-// availableVersions returns every software_version string the server publishes
-// for the title, preserving server order (newest first).
-func availableVersions(v *proclassic.PatchSoftwareTitleVersions) []string {
-	if v == nil || v.Version == nil {
-		return []string{}
-	}
-	out := make([]string, 0, len(*v.Version))
-	for _, item := range *v.Version {
-		if item.SoftwareVersion != nil {
-			out = append(out, *item.SoftwareVersion)
+// definitionVersions returns every version string the patch source publishes for
+// the title, preserving server order. The /definitions default sort is
+// absoluteOrderId:asc, which Jamf orders newest-first — the same order the
+// classic <versions> block used, so available_versions needs no re-sorting.
+func definitionVersions(defs []pro.PatchSoftwareTitleDefinition) []string {
+	out := make([]string, 0, len(defs))
+	for i := range defs {
+		if defs[i].Version != "" {
+			out = append(out, defs[i].Version)
 		}
 	}
 	return out
 }
 
-// assignedPackagesByVersion returns a software_version → package_id map for every
-// server version that has a non-empty package id assigned.
-func assignedPackagesByVersion(v *proclassic.PatchSoftwareTitleVersions) map[string]string {
+// assignedPackagesByVersion returns a software_version → package_id map for
+// every package assignment the configuration reports.
+func assignedPackagesByVersion(pkgs []pro.PatchSoftwareTitlePackages) map[string]string {
 	out := map[string]string{}
-	if v == nil || v.Version == nil {
-		return out
-	}
-	for _, item := range *v.Version {
-		if item.SoftwareVersion == nil || item.Package == nil || item.Package.ID == nil {
+	for i := range pkgs {
+		if pkgs[i].Version == nil || pkgs[i].PackageID == nil {
 			continue
 		}
-		out[*item.SoftwareVersion] = strconv.Itoa(*item.Package.ID)
+		if *pkgs[i].Version == "" || *pkgs[i].PackageID == "" {
+			continue
+		}
+		out[*pkgs[i].Version] = *pkgs[i].PackageID
 	}
 	return out
 }
@@ -210,4 +166,13 @@ func managedVersionPackages(ctx context.Context, declaredKeys []string, assigned
 	m, d := types.MapValueFrom(ctx, types.StringType, managed)
 	diags.Append(d...)
 	return m, diags
+}
+
+// orEmpty substitutes an empty slice for nil so a Computed list attribute lands
+// as an empty list rather than null.
+func orEmpty(in []string) []string {
+	if in == nil {
+		return []string{}
+	}
+	return in
 }

--- a/internal/resources/pro/patch_software_title/state_builders.go
+++ b/internal/resources/pro/patch_software_title/state_builders.go
@@ -129,19 +129,41 @@ func definitionVersions(defs []pro.PatchSoftwareTitleDefinition) []string {
 	return out
 }
 
-// assignedPackagesByVersion returns a software_version → package_id map for
-// every package assignment the configuration reports.
-func assignedPackagesByVersion(pkgs []pro.PatchSoftwareTitlePackages) map[string]string {
+// assignedPackagesByVersionCounted returns a software_version → package_id map
+// for every package assignment the configuration reports, plus the number of
+// reported assignments it could not read (no version or no package id, either
+// missing or empty).
+//
+// The count exists because this fold also feeds a write: Update sends the folded
+// set as the v3 `packages` array, which is a FULL REPLACEMENT, so an assignment
+// missing from the fold is cleared server-side. Dropping one silently would
+// break the promise version_packages makes, that assignments made outside
+// Terraform survive an apply — hence a caller that writes must be able to say
+// how many it is about to clear.
+func assignedPackagesByVersionCounted(pkgs []pro.PatchSoftwareTitlePackages) (map[string]string, int) {
 	out := map[string]string{}
+	unreadable := 0
 	for i := range pkgs {
 		if pkgs[i].Version == nil || pkgs[i].PackageID == nil {
+			unreadable++
 			continue
 		}
 		if *pkgs[i].Version == "" || *pkgs[i].PackageID == "" {
+			unreadable++
 			continue
 		}
 		out[*pkgs[i].Version] = *pkgs[i].PackageID
 	}
+	return out, unreadable
+}
+
+// assignedPackagesByVersion returns a software_version → package_id map for
+// every package assignment the configuration reports, discarding the ones it
+// cannot read. It is the read-path form, where a discard only shapes state; a
+// caller folding the map into a write wants assignedPackagesByVersionCounted so
+// the discards can be reported.
+func assignedPackagesByVersion(pkgs []pro.PatchSoftwareTitlePackages) map[string]string {
+	out, _ := assignedPackagesByVersionCounted(pkgs)
 	return out
 }
 
@@ -166,6 +188,19 @@ func managedVersionPackages(ctx context.Context, declaredKeys []string, assigned
 	m, d := types.MapValueFrom(ctx, types.StringType, managed)
 	diags.Append(d...)
 	return m, diags
+}
+
+// stringsFromList reads a Terraform list of strings back into a Go slice,
+// yielding nil for a null or unknown list. It is how a caller recovers the value
+// already held for a Computed list attribute when the read that would refresh it
+// failed — see readAvailableVersionsBestEffort.
+func stringsFromList(ctx context.Context, l types.List) ([]string, diag.Diagnostics) {
+	if l.IsNull() || l.IsUnknown() {
+		return nil, nil
+	}
+	var out []string
+	diags := l.ElementsAs(ctx, &out, false)
+	return out, diags
 }
 
 // orEmpty substitutes an empty slice for nil so a Computed list attribute lands

--- a/internal/resources/pro/patch_software_title/state_builders_test.go
+++ b/internal/resources/pro/patch_software_title/state_builders_test.go
@@ -5,128 +5,219 @@ package patch_software_title
 
 import (
 	"context"
-	"encoding/xml"
+	"encoding/json"
 	"testing"
 
+	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/pro"
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/proclassic"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-// liveWire is a trimmed real /patchsoftwaretitles GET (8x8 Work, id 6) with one
-// version assigned (8.33.2.2 → package 79), default category/site (id -1) and
-// both notifications true. Pins the decode + mapping contract.
-const liveWire = `<?xml version="1.0" encoding="UTF-8"?><patch_software_title>
-  <id>6</id>
-  <name>8x8 Work</name>
-  <name_id>285</name_id>
-  <source_id>1</source_id>
-  <notifications>
-    <web_notification>true</web_notification>
-    <email_notification>true</email_notification>
-  </notifications>
-  <category><id>-1</id><name>No category assigned</name></category>
-  <site><id>-1</id><name>NONE</name></site>
-  <versions>
-    <version><software_version>8.33.2.2</software_version><package><id>79</id><name>acs-pkg-sophos.pkg</name></package></version>
-    <version><software_version>8.32.2.10</software_version><package></package></version>
-    <version><software_version>8.31.3.1</software_version><package></package></version>
-  </versions>
-</patch_software_title>`
+// liveConfigJSON is a real GET /pro/v3/patch-software-title-configurations/147
+// body captured on Jamf Pro 11.31.1 (title "8x8 Work", name_id 285, patch
+// source "Jamf") with one version assigned, a real category, no site and both
+// notifications off. Decoding a captured body rather than hand-building the SDK
+// struct is what catches a field the SDK has mis-tagged: every value below has
+// to survive the wire names Jamf actually sends.
+const liveConfigJSON = `{
+  "id" : "147",
+  "jamfOfficial" : true,
+  "displayName" : "8x8 Work",
+  "categoryId" : "58",
+  "siteId" : "-1",
+  "uiNotifications" : false,
+  "emailNotifications" : false,
+  "softwareTitleId" : "147",
+  "extensionAttributes" : [ ],
+  "softwareTitleName" : "8x8 Work",
+  "softwareTitleNameId" : "285",
+  "softwareTitlePublisher" : "8x8",
+  "patchSourceName" : "Jamf",
+  "patchSourceEnabled" : true,
+  "packages" : [ {
+    "packageId" : "1",
+    "version" : "8.33.2.2",
+    "displayName" : "gen-pkg-datajar-reissue-fv-images.pkg"
+  } ]
+}`
 
-func decodeLiveWire(t *testing.T) *proclassic.PatchSoftwareTitle {
+// liveDefinitionsJSON is a real GET
+// /pro/v3/patch-software-title-configurations/147/definitions fragment under
+// the default sort (absoluteOrderId:asc), which Jamf orders newest-first.
+const liveDefinitionsJSON = `{ "totalCount": 84, "results": [
+  {"version":"8.36.2.3","releaseDate":"2026-08-04T07:46:54Z","standalone":true,"minimumOperatingSystem":"12.0","rebootRequired":false,"killApps":[{"appName":"8x8 Work"}],"absoluteOrderId":"0"},
+  {"version":"8.35.2.6","releaseDate":"2026-07-06T06:46:10Z","standalone":true,"minimumOperatingSystem":"12.0","rebootRequired":false,"killApps":[{"appName":"8x8 Work"}],"absoluteOrderId":"1"}
+] }`
+
+func decodeLiveConfig(t *testing.T) *pro.PatchSoftwareTitleConfiguration {
 	t.Helper()
-	var p proclassic.PatchSoftwareTitle
-	if err := xml.Unmarshal([]byte(liveWire), &p); err != nil {
-		t.Fatalf("unmarshal live wire: %v", err)
+	var c pro.PatchSoftwareTitleConfiguration
+	if err := json.Unmarshal([]byte(liveConfigJSON), &c); err != nil {
+		t.Fatalf("unmarshal live configuration: %v", err)
 	}
-	return &p
+	return &c
 }
 
+func decodeLiveDefinitions(t *testing.T) []pro.PatchSoftwareTitleDefinition {
+	t.Helper()
+	var d pro.PatchSoftwareTitleDefinitions
+	if err := json.Unmarshal([]byte(liveDefinitionsJSON), &d); err != nil {
+		t.Fatalf("unmarshal live definitions: %v", err)
+	}
+	return d.Results
+}
+
+func stateStrings(t *testing.T, l types.List) []string {
+	t.Helper()
+	out := []string{}
+	if diags := l.ElementsAs(context.Background(), &out, false); diags.HasError() {
+		t.Fatalf("read list elements: %v", diags)
+	}
+	return out
+}
+
+func stateMap(t *testing.T, m types.Map) map[string]string {
+	t.Helper()
+	out := map[string]string{}
+	if diags := m.ElementsAs(context.Background(), &out, false); diags.HasError() {
+		t.Fatalf("read map elements: %v", diags)
+	}
+	return out
+}
+
+// TestLiveWireUnmarshal pins the decode contract against a captured v3 body.
+// The configuration reports ids as strings and its notification flags as bare
+// bools, so a mis-tagged SDK field lands as a zero value that reads as real
+// state — "no category assigned", "notifications off" — rather than as an
+// error. Decoding the captured body is the only place that is caught.
 func TestLiveWireUnmarshal(t *testing.T) {
-	p := decodeLiveWire(t)
-	if p.ID == nil || *p.ID != 6 {
-		t.Errorf("id: %v", p.ID)
+	c := decodeLiveConfig(t)
+
+	if c.ID != "147" {
+		t.Errorf("id: %q", c.ID)
 	}
-	if p.NameID == nil || *p.NameID != "285" {
-		t.Errorf("name_id: %v", p.NameID)
+	if c.DisplayName != "8x8 Work" {
+		t.Errorf("displayName: %q", c.DisplayName)
 	}
-	if p.SourceID == nil || *p.SourceID != 1 {
-		t.Errorf("source_id: %v", p.SourceID)
+	if c.SoftwareTitleNameID != "285" {
+		t.Errorf("softwareTitleNameId: %q", c.SoftwareTitleNameID)
 	}
-	if p.Versions == nil || p.Versions.Version == nil || len(*p.Versions.Version) != 3 {
-		t.Fatalf("expected 3 versions")
+	if c.CategoryID != "58" {
+		t.Errorf("categoryId: %q", c.CategoryID)
 	}
-	// First version has a package; the empty <package></package> decodes to a
-	// non-nil package with nil ID (treated as unassigned).
-	first := (*p.Versions.Version)[0]
-	if first.Package == nil || first.Package.ID == nil || *first.Package.ID != 79 {
-		t.Errorf("first version package id: %+v", first.Package)
+	if c.SiteID != "-1" {
+		t.Errorf("siteId: %q", c.SiteID)
 	}
-	second := (*p.Versions.Version)[1]
-	if second.Package != nil && second.Package.ID != nil {
-		t.Errorf("empty <package></package> must decode to nil ID, got %d", *second.Package.ID)
+	if c.UiNotifications || c.EmailNotifications {
+		t.Errorf("notifications: ui=%v email=%v", c.UiNotifications, c.EmailNotifications)
+	}
+	if c.PatchSourceName != "Jamf" {
+		t.Errorf("patchSourceName: %q", c.PatchSourceName)
+	}
+	if len(c.Packages) != 1 {
+		t.Fatalf("expected 1 package assignment, got %d", len(c.Packages))
+	}
+	pkg := c.Packages[0]
+	if pkg.Version == nil || *pkg.Version != "8.33.2.2" {
+		t.Errorf("package version: %v", pkg.Version)
+	}
+	if pkg.PackageID == nil || *pkg.PackageID != "1" {
+		t.Errorf("package id: %v", pkg.PackageID)
+	}
+	if len(c.ExtensionAttributes) != 0 {
+		t.Errorf("expected no extension attributes, got %d", len(c.ExtensionAttributes))
 	}
 }
 
+// TestDefinitionVersions_PreservesServerOrder pins that the version catalogue
+// is passed through in the order /definitions returns it. The endpoint's
+// default absoluteOrderId:asc sort is newest-first, which is the order
+// available_versions documents and the order a user reads to pick the version
+// to assign a package to; sorting the strings would put 8.35 above 8.36 and
+// quietly invert that.
+func TestDefinitionVersions_PreservesServerOrder(t *testing.T) {
+	got := definitionVersions(decodeLiveDefinitions(t))
+
+	want := []string{"8.36.2.3", "8.35.2.6"}
+	if len(got) != len(want) {
+		t.Fatalf("expected %v, got %v", want, got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("position %d: expected %q, got %q", i, want[i], got[i])
+		}
+	}
+}
+
+// TestDefinitionVersions_SkipsEmptyVersions guards against an empty string
+// reaching available_versions, where it would look like a selectable version a
+// package could be assigned to.
+func TestDefinitionVersions_SkipsEmptyVersions(t *testing.T) {
+	got := definitionVersions([]pro.PatchSoftwareTitleDefinition{
+		{Version: "1.0"},
+		{Version: ""},
+		{Version: "0.9"},
+	})
+	if len(got) != 2 || got[0] != "1.0" || got[1] != "0.9" {
+		t.Errorf("expected [1.0 0.9], got %v", got)
+	}
+}
+
+// TestAssignResourceModel_ManagedSubsetReconcile pins the read half of the
+// managed-subset contract: version_packages is rebuilt from the keys the user
+// declared, so a declared key whose server-side package is gone drops out
+// (surfacing the drift as a diff) while a version the server has assigned but
+// the user never declared stays out of state entirely.
 func TestAssignResourceModel_ManagedSubsetReconcile(t *testing.T) {
-	p := decodeLiveWire(t)
-	// User declared only 8.33.2.2 (which is assigned) and 8.30.0.0 (which the
-	// server does not have / has no package). Read must include only 8.33.2.2.
+	c := decodeLiveConfig(t)
 	declared := []string{"8.33.2.2", "8.30.0.0"}
 	state := PatchSoftwareTitleResourceModel{}
-	diags := assignPatchSoftwareTitleResourceModel(context.Background(), &state, p, declared)
+
+	diags := assignPatchSoftwareTitleResourceModel(context.Background(), &state, c, definitionVersions(decodeLiveDefinitions(t)), declared)
 	if diags.HasError() {
 		t.Fatalf("diags: %v", diags)
 	}
 
-	if state.ID.ValueString() != "6" {
+	if state.ID.ValueString() != "147" {
 		t.Errorf("id: %q", state.ID.ValueString())
 	}
 	if state.Name.ValueString() != "8x8 Work" {
 		t.Errorf("name: %q", state.Name.ValueString())
 	}
-	if state.SourceID.ValueInt64() != 1 {
-		t.Errorf("source_id: %d", state.SourceID.ValueInt64())
+	if state.NameID.ValueString() != "285" {
+		t.Errorf("name_id: %q", state.NameID.ValueString())
 	}
-	if state.CategoryID.ValueString() != "-1" {
+	if state.CategoryID.ValueString() != "58" {
 		t.Errorf("category_id: %q", state.CategoryID.ValueString())
 	}
-	// Sentinel category/site (id -1): the derived name is nulled, not echoed —
-	// the classic GET nondeterministically echoes or omits the "none" name, so
-	// DerivedRefName collapses it to null for a stable round-trip.
-	if !state.CategoryName.IsNull() {
-		t.Errorf("category_name should be null on the sentinel, got %q", state.CategoryName.ValueString())
+	if state.SiteID.ValueString() != "-1" {
+		t.Errorf("site_id: %q", state.SiteID.ValueString())
 	}
-	if state.SiteID.ValueString() != "-1" || !state.SiteName.IsNull() {
-		t.Errorf("site: id=%q name=%q (name should be null on the sentinel)", state.SiteID.ValueString(), state.SiteName.ValueString())
-	}
-	if !state.WebNotification.ValueBool() || !state.EmailNotification.ValueBool() {
+	if state.WebNotification.ValueBool() || state.EmailNotification.ValueBool() {
 		t.Errorf("notifications: web=%v email=%v", state.WebNotification.ValueBool(), state.EmailNotification.ValueBool())
 	}
 
-	// version_packages must be exactly {8.33.2.2: 79} — declared-but-unassigned
-	// 8.30.0.0 is dropped (surfaces drift).
 	if state.VersionPackages.IsNull() {
 		t.Fatalf("version_packages must be non-null when a declared key is assigned")
 	}
-	vp := map[string]string{}
-	state.VersionPackages.ElementsAs(context.Background(), &vp, false)
-	if len(vp) != 1 || vp["8.33.2.2"] != "79" {
-		t.Errorf("expected {8.33.2.2:79}, got %+v", vp)
+	vp := stateMap(t, state.VersionPackages)
+	if len(vp) != 1 || vp["8.33.2.2"] != "1" {
+		t.Errorf("expected {8.33.2.2:1}, got %+v", vp)
 	}
 
-	// available_versions surfaces every server version in order.
-	av := []string{}
-	state.AvailableVersions.ElementsAs(context.Background(), &av, false)
-	if len(av) != 3 || av[0] != "8.33.2.2" || av[2] != "8.31.3.1" {
+	av := stateStrings(t, state.AvailableVersions)
+	if len(av) != 2 || av[0] != "8.36.2.3" || av[1] != "8.35.2.6" {
 		t.Errorf("available_versions wrong: %+v", av)
 	}
 }
 
+// TestAssignResourceModel_NoDeclaredKeysYieldsNullMap pins that a config with
+// no version_packages block reads back null rather than an empty map. The
+// attribute is Optional-only, so an empty map in state against an absent block
+// in config is a permanent diff.
 func TestAssignResourceModel_NoDeclaredKeysYieldsNullMap(t *testing.T) {
-	p := decodeLiveWire(t)
 	state := PatchSoftwareTitleResourceModel{}
-	diags := assignPatchSoftwareTitleResourceModel(context.Background(), &state, p, nil)
+	diags := assignPatchSoftwareTitleResourceModel(context.Background(), &state, decodeLiveConfig(t), nil, nil)
 	if diags.HasError() {
 		t.Fatalf("diags: %v", diags)
 	}
@@ -135,35 +226,63 @@ func TestAssignResourceModel_NoDeclaredKeysYieldsNullMap(t *testing.T) {
 	}
 }
 
+// TestAssignResourceModel_DeclaredKeyDroppedWhenPackageGone pins the drift case
+// where every declared key has lost its package: the map collapses to null, not
+// to an empty map, for the same round-trip reason.
 func TestAssignResourceModel_DeclaredKeyDroppedWhenPackageGone(t *testing.T) {
-	p := decodeLiveWire(t)
-	// Declared only a version whose package is empty server-side → map drops to null.
 	state := PatchSoftwareTitleResourceModel{}
-	diags := assignPatchSoftwareTitleResourceModel(context.Background(), &state, p, []string{"8.32.2.10"})
+	diags := assignPatchSoftwareTitleResourceModel(context.Background(), &state, decodeLiveConfig(t), nil, []string{"8.32.2.10"})
 	if diags.HasError() {
 		t.Fatalf("diags: %v", diags)
 	}
 	if !state.VersionPackages.IsNull() {
-		t.Errorf("declared key with no server package must drop → null map, got %v", state.VersionPackages)
+		t.Errorf("a declared key with no server package must drop → null map, got %v", state.VersionPackages)
 	}
 }
 
-func TestAssignResourceModel_PreservesIDWhenAPINil(t *testing.T) {
-	name := "refreshed"
+// TestAssignResourceModel_LeavesSourceIDUntouched pins the one attribute the v3
+// read must not write. The configuration names its patch source but never
+// numbers it, so deriving source_id here would need a catalogue lookup on every
+// read; instead whatever state holds is kept, which is always correct because
+// source_id is RequiresReplace. A read that zeroed or nulled it would force a
+// replacement of a live title on the next plan.
+func TestAssignResourceModel_LeavesSourceIDUntouched(t *testing.T) {
+	state := PatchSoftwareTitleResourceModel{SourceID: types.Int64Value(1)}
+	diags := assignPatchSoftwareTitleResourceModel(context.Background(), &state, decodeLiveConfig(t), nil, nil)
+	if diags.HasError() {
+		t.Fatalf("diags: %v", diags)
+	}
+	if state.SourceID.IsNull() || state.SourceID.ValueInt64() != 1 {
+		t.Errorf("source_id must survive the read untouched, got %v", state.SourceID)
+	}
+}
+
+// TestAssignResourceModel_PreservesIDWhenResponseOmitsIt pins that an id
+// already in state is not overwritten by an empty one. The Update path assigns
+// straight from the PATCH response, so an id the server left out of that body
+// would otherwise blank the resource's own identifier.
+func TestAssignResourceModel_PreservesIDWhenResponseOmitsIt(t *testing.T) {
 	state := PatchSoftwareTitleResourceModel{ID: types.StringValue("42")}
-	api := &proclassic.PatchSoftwareTitle{ID: nil, Name: &name}
-	diags := assignPatchSoftwareTitleResourceModel(context.Background(), &state, api, nil)
+	api := &pro.PatchSoftwareTitleConfiguration{DisplayName: "refreshed"}
+
+	diags := assignPatchSoftwareTitleResourceModel(context.Background(), &state, api, nil, nil)
 	if diags.HasError() {
 		t.Fatalf("diags: %v", diags)
 	}
 	if state.ID.ValueString() != "42" {
 		t.Errorf("expected ID preserved as 42, got %q", state.ID.ValueString())
 	}
+	if state.Name.ValueString() != "refreshed" {
+		t.Errorf("expected the response's display name to land, got %q", state.Name.ValueString())
+	}
 }
 
+// TestAssignResourceModel_NilAPIIsNoop pins that a nil configuration leaves
+// state alone rather than blanking every attribute, so a caller that has
+// already raised a diagnostic cannot also corrupt state on its way out.
 func TestAssignResourceModel_NilAPIIsNoop(t *testing.T) {
 	state := PatchSoftwareTitleResourceModel{ID: types.StringValue("7"), Name: types.StringValue("Keep")}
-	diags := assignPatchSoftwareTitleResourceModel(context.Background(), &state, nil, nil)
+	diags := assignPatchSoftwareTitleResourceModel(context.Background(), &state, nil, nil, nil)
 	if diags.HasError() {
 		t.Fatalf("diags: %v", diags)
 	}
@@ -172,57 +291,203 @@ func TestAssignResourceModel_NilAPIIsNoop(t *testing.T) {
 	}
 }
 
+// TestAssignDataSourceModel_FullServerView pins the deliberate difference from
+// the resource: a data source has no prior state to scope against, so it
+// surfaces every assignment the configuration reports rather than a managed
+// subset. source_id comes from the caller, which resolved it from the patch
+// source name.
 func TestAssignDataSourceModel_FullServerView(t *testing.T) {
-	p := decodeLiveWire(t)
 	state := PatchSoftwareTitleDataSourceModel{}
-	diags := assignPatchSoftwareTitleDataSourceModel(context.Background(), &state, p)
+
+	diags := assignPatchSoftwareTitleDataSourceModel(context.Background(), &state, decodeLiveConfig(t), definitionVersions(decodeLiveDefinitions(t)), types.Int64Value(1))
 	if diags.HasError() {
 		t.Fatalf("diags: %v", diags)
 	}
-	// Data source surfaces every assigned version, no managed-subset gating.
-	vp := map[string]string{}
-	state.VersionPackages.ElementsAs(context.Background(), &vp, false)
-	if len(vp) != 1 || vp["8.33.2.2"] != "79" {
-		t.Errorf("expected {8.33.2.2:79}, got %+v", vp)
+
+	if state.ID.ValueString() != "147" {
+		t.Errorf("id: %q", state.ID.ValueString())
 	}
 	if state.NameID.ValueString() != "285" {
 		t.Errorf("name_id: %q", state.NameID.ValueString())
 	}
+	if state.SourceID.ValueInt64() != 1 {
+		t.Errorf("source_id must come from the caller, got %v", state.SourceID)
+	}
+	if state.CategoryID.ValueString() != "58" || state.SiteID.ValueString() != "-1" {
+		t.Errorf("category/site: %q / %q", state.CategoryID.ValueString(), state.SiteID.ValueString())
+	}
+	if state.VersionPackages.IsNull() {
+		t.Fatalf("version_packages must be populated from the server view")
+	}
+	vp := stateMap(t, state.VersionPackages)
+	if len(vp) != 1 || vp["8.33.2.2"] != "1" {
+		t.Errorf("expected {8.33.2.2:1}, got %+v", vp)
+	}
+	av := stateStrings(t, state.AvailableVersions)
+	if len(av) != 2 || av[0] != "8.36.2.3" {
+		t.Errorf("available_versions wrong: %+v", av)
+	}
 }
 
-func TestCategorySiteNotificationValues_NilBlocks(t *testing.T) {
-	cid, cname := categoryValues(nil)
-	if !cid.IsNull() || !cname.IsNull() {
-		t.Errorf("nil category must yield null/null")
+// TestAssignDataSourceModel_NilAPIIsNoop pins the same defensive no-op as the
+// resource path, so a failed lookup cannot half-populate a data source result.
+func TestAssignDataSourceModel_NilAPIIsNoop(t *testing.T) {
+	state := PatchSoftwareTitleDataSourceModel{ID: types.StringValue("7")}
+	diags := assignPatchSoftwareTitleDataSourceModel(context.Background(), &state, nil, nil, types.Int64Null())
+	if diags.HasError() {
+		t.Fatalf("diags: %v", diags)
 	}
-	// site_id is a tri-state attribute: a nil site means "no site", which the
-	// read path collapses to the "-1" sentinel (never null) so the value
-	// round-trips. site_name stays null when absent.
-	sid, sname := siteValues(nil)
-	if sid.ValueString() != "-1" || !sname.IsNull() {
-		t.Errorf("nil site must yield id=-1/name=null, got id=%q name-null=%v", sid.ValueString(), sname.IsNull())
-	}
-	web, email := notificationValues(nil)
-	if !web.IsNull() || !email.IsNull() {
-		t.Errorf("nil notifications must yield null/null")
+	if state.ID.ValueString() != "7" {
+		t.Errorf("expected state unchanged, got id=%q", state.ID.ValueString())
 	}
 }
 
-// TestCategoryValues_NoCategorySentinel locks the read side of the wire-probed
-// quirk: the endpoint reports "no category" as id -1 (never assigned) or id 0
-// (explicitly cleared); both must collapse to the "-1" user-facing sentinel so
-// state round-trips against a config of "-1".
-func TestCategoryValues_NoCategorySentinel(t *testing.T) {
-	for _, id := range []int{-1, 0} {
-		v := id
-		cid, _ := categoryValues(&proclassic.CategoryObject{ID: &v})
-		if cid.ValueString() != "-1" {
-			t.Errorf("server category id %d must normalise to \"-1\", got %q", id, cid.ValueString())
-		}
+// TestRefIDValue_NoAssignmentSentinel pins the read side of the v3 id
+// vocabulary. category_id and site_id are Optional+Computed, so state has to
+// hold a value that a config of "-1" round-trips against; collapsing every
+// non-positive spelling the server can report — "-1", an omitted field, and the
+// "0" a classic-era title still carries — onto the one sentinel is what stops a
+// permanent diff.
+func TestRefIDValue_NoAssignmentSentinel(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "omitted field", in: "", want: "-1"},
+		{name: "classic zero", in: "0", want: "-1"},
+		{name: "sentinel", in: "-1", want: "-1"},
+		{name: "other negative", in: "-7", want: "-1"},
+		{name: "real id", in: "58", want: "58"},
+		{name: "non-numeric", in: "abc", want: "abc"},
 	}
-	real := 58
-	cid, _ := categoryValues(&proclassic.CategoryObject{ID: &real})
-	if cid.ValueString() != "58" {
-		t.Errorf("real category id must pass through, got %q", cid.ValueString())
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := refIDValue(tc.in)
+			if got.IsNull() {
+				t.Fatalf("must never be null — the attribute is Optional+Computed")
+			}
+			if got.ValueString() != tc.want {
+				t.Errorf("expected %q, got %q", tc.want, got.ValueString())
+			}
+		})
+	}
+}
+
+// TestAssignedPackagesByVersion_SkipsIncompleteEntries pins that a package
+// entry missing either half of the pair is ignored. A nil or empty version
+// would key the map on "", and a nil or empty package id would read as an
+// assignment to package "" — both of which would then be sent back as a real
+// assignment by the full-replacement patch.
+func TestAssignedPackagesByVersion_SkipsIncompleteEntries(t *testing.T) {
+	ver, pkg, empty := "1.0", "5", ""
+	got := assignedPackagesByVersion([]pro.PatchSoftwareTitlePackages{
+		{Version: &ver, PackageID: &pkg},
+		{Version: &ver, PackageID: nil},
+		{Version: nil, PackageID: &pkg},
+		{Version: &empty, PackageID: &pkg},
+		{Version: &ver, PackageID: &empty},
+	})
+
+	if len(got) != 1 || got["1.0"] != "5" {
+		t.Errorf("expected {1.0:5}, got %+v", got)
+	}
+}
+
+// TestManagedVersionPackages_NoDeclaredKeysIsNull pins the null-versus-empty
+// choice at its source: the helper returns a null map both when nothing is
+// declared and when nothing declared still has a package, so neither case
+// writes an empty map against an absent config block.
+func TestManagedVersionPackages_NoDeclaredKeysIsNull(t *testing.T) {
+	assigned := map[string]string{"1.0": "5"}
+
+	for _, tc := range []struct {
+		name     string
+		declared []string
+	}{
+		{name: "nothing declared", declared: nil},
+		{name: "declared key has no package", declared: []string{"9.9"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, diags := managedVersionPackages(context.Background(), tc.declared, assigned)
+			if diags.HasError() {
+				t.Fatalf("diags: %v", diags)
+			}
+			if !got.IsNull() {
+				t.Errorf("expected a null map, got %v", got)
+			}
+		})
+	}
+}
+
+// TestMatchSourceIDs pins the exact-name match used to recover source_id from
+// the patch source name v3 reports. The match must be exact and must return
+// every hit rather than the first: the internal and external catalogues have
+// separate id spaces, so a name in both is ambiguous and the caller has to be
+// able to see that instead of writing a guessed number into a RequiresReplace
+// attribute.
+func TestMatchSourceIDs(t *testing.T) {
+	id1, id2, id3 := 1, 2, 3
+	jamf, jamfLower, other := "Jamf", "jamf", "Other"
+	sources := []proclassic.IDName{
+		{ID: &id1, Name: &jamf},
+		{ID: &id2, Name: &jamfLower},
+		{ID: &id3, Name: &other},
+		{ID: nil, Name: &jamf},
+		{ID: &id1, Name: nil},
+	}
+
+	tests := []struct {
+		name  string
+		query string
+		want  []int
+	}{
+		{name: "exact match only", query: "Jamf", want: []int{1}},
+		{name: "case sensitive", query: "jamf", want: []int{2}},
+		{name: "no match", query: "Missing", want: nil},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := matchSourceIDs(sources, tc.query)
+			if len(got) != len(tc.want) {
+				t.Fatalf("expected %v, got %v", tc.want, got)
+			}
+			for i := range tc.want {
+				if got[i] != tc.want[i] {
+					t.Errorf("position %d: expected %d, got %d", i, tc.want[i], got[i])
+				}
+			}
+		})
+	}
+}
+
+// TestMatchSourceIDs_ReportsEveryDuplicate pins the ambiguity signal: two
+// entries sharing a name must both come back so resolveSourceID can refuse
+// rather than silently take the first.
+func TestMatchSourceIDs_ReportsEveryDuplicate(t *testing.T) {
+	id4, id9 := 4, 9
+	name := "Jamf"
+	got := matchSourceIDs([]proclassic.IDName{
+		{ID: &id4, Name: &name},
+		{ID: &id9, Name: &name},
+	}, "Jamf")
+
+	if len(got) != 2 || got[0] != 4 || got[1] != 9 {
+		t.Errorf("expected [4 9], got %v", got)
+	}
+}
+
+// TestOrEmpty pins that a nil version catalogue lands as an empty list rather
+// than null. available_versions is Computed with no plan modifier, so a null
+// where the framework expects a value after apply is an "inconsistent result"
+// error rather than a diff.
+func TestOrEmpty(t *testing.T) {
+	if got := orEmpty(nil); got == nil || len(got) != 0 {
+		t.Errorf("expected a non-nil empty slice, got %v", got)
+	}
+	if got := orEmpty([]string{"1.0"}); len(got) != 1 || got[0] != "1.0" {
+		t.Errorf("expected [1.0], got %v", got)
 	}
 }

--- a/internal/resources/pro/patch_software_title/state_upgrader.go
+++ b/internal/resources/pro/patch_software_title/state_upgrader.go
@@ -1,0 +1,93 @@
+// Copyright Jamf Software LLC 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package patch_software_title
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+)
+
+// removedInV1 are the attributes dropped from the schema at v1. Both were
+// display names the classic /patchsoftwaretitles payload carried inline
+// alongside the id; the v3 configuration reports ids only, and resolving each
+// name would cost a lookup per read for a value Terraform never writes.
+var removedInV1 = []string{"category_name", "site_name"}
+
+// UpgradeState migrates prior state versions to the current schema.
+//
+// v0 → v1: category_name and site_name were removed when read/update/delete
+// moved from the classic /patchsoftwaretitles endpoints to Jamf Pro v3
+// /patch-software-title-configurations, which does not report them. The
+// framework cannot decode prior state carrying attributes the current schema
+// has no home for, so the keys are stripped from the raw prior state JSON and
+// the remainder re-emitted through the current schema type. Every other
+// attribute is carried across verbatim as raw JSON, so no value is
+// reinterpreted or lost.
+func (r *PatchSoftwareTitleResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
+	return map[int64]resource.StateUpgrader{
+		0: {
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				if req.RawState == nil {
+					return
+				}
+
+				rewritten, err := dropRemovedAttributes(req.RawState.JSON, removedInV1)
+				if err != nil {
+					resp.Diagnostics.AddError(
+						"Unable to upgrade jamfplatform_pro_patch_software_title state from v0 to v1",
+						fmt.Sprintf("Could not remove the withdrawn category_name / site_name attributes from prior state: %s", err),
+					)
+					return
+				}
+
+				var schemaResp resource.SchemaResponse
+				r.Schema(ctx, resource.SchemaRequest{}, &schemaResp)
+				schemaType := schemaResp.Schema.Type().TerraformType(ctx)
+
+				upgraded := tfprotov6.RawState{JSON: rewritten}
+				value, err := upgraded.Unmarshal(schemaType)
+				if err != nil {
+					resp.Diagnostics.AddError(
+						"Unable to upgrade jamfplatform_pro_patch_software_title state from v0 to v1",
+						fmt.Sprintf("Could not decode rewritten prior state against the current schema: %s", err),
+					)
+					return
+				}
+
+				dynamicValue, err := tfprotov6.NewDynamicValue(schemaType, value)
+				if err != nil {
+					resp.Diagnostics.AddError(
+						"Unable to upgrade jamfplatform_pro_patch_software_title state from v0 to v1",
+						fmt.Sprintf("Could not re-encode the upgraded state: %s", err),
+					)
+					return
+				}
+
+				resp.DynamicValue = &dynamicValue
+			},
+		},
+	}
+}
+
+// dropRemovedAttributes deletes the named top-level keys from a raw state JSON
+// object. A key that is already absent is not an error — state written by a
+// build that never set it is still valid v0 state.
+func dropRemovedAttributes(raw []byte, names []string) ([]byte, error) {
+	var state map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &state); err != nil {
+		return nil, fmt.Errorf("decode prior state: %w", err)
+	}
+	for _, name := range names {
+		delete(state, name)
+	}
+	out, err := json.Marshal(state)
+	if err != nil {
+		return nil, fmt.Errorf("re-encode prior state: %w", err)
+	}
+	return out, nil
+}

--- a/internal/resources/pro/patch_software_title/state_upgrader_test.go
+++ b/internal/resources/pro/patch_software_title/state_upgrader_test.go
@@ -7,11 +7,13 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"math/big"
 	"slices"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
 
 // State upgraders are unit-tested rather than acceptance-tested: the acceptance
@@ -63,6 +65,22 @@ func TestDropRemovedAttributes_RemovesOnlyTheWithdrawnKeys(t *testing.T) {
 	var after map[string]json.RawMessage
 	if err := json.Unmarshal(got, &after); err != nil {
 		t.Fatalf("rewritten state is not valid JSON: %s", err)
+	}
+
+	// Named literals, not removedInV1: every other assertion in this test reads
+	// the list under test, so widening it to include a surviving attribute would
+	// be skipped by the loop below and accounted for by the count above. These
+	// two are the only keys the v1 schema dropped and the only ones allowed to
+	// disappear, so they are spelled out.
+	for _, gone := range []string{"category_name", "site_name"} {
+		if _, ok := after[gone]; ok {
+			t.Errorf("%q must be removed from upgraded state", gone)
+		}
+	}
+	for _, kept := range []string{"version_packages", "available_versions", "source_id", "extension_attributes"} {
+		if _, ok := after[kept]; !ok {
+			t.Errorf("%q must survive the rewrite — only category_name and site_name were withdrawn at v1", kept)
+		}
 	}
 
 	for _, gone := range removedInV1 {
@@ -131,11 +149,17 @@ func TestDropRemovedAttributes_RejectsMalformedState(t *testing.T) {
 }
 
 // TestUpgradeState_V0StateDecodesAtV1 drives the registered upgrader end to end
-// over realistic v0 state and pins that it produces a value against the current
-// schema with no diagnostics. This is the whole reason the upgrader exists: the
-// framework's raw-state decode rejects an attribute the current schema does not
-// declare, so without the rewrite every pre-migration state file fails to load
-// with a framework error rather than a plannable diff.
+// over realistic v0 state and pins both halves of what it must produce: a value
+// against the current schema with no diagnostics, and the surviving attributes
+// still carrying their v0 values.
+//
+// This is the whole reason the upgrader exists: the framework's raw-state decode
+// rejects an attribute the current schema does not declare, so without the
+// rewrite every pre-migration state file fails to load with a framework error
+// rather than a plannable diff. Asserting the carried-across values matters as
+// much as the decode — a rewrite that dropped or blanked them would still decode
+// cleanly and would silently re-plan a live title's category, notifications and
+// package assignments.
 func TestUpgradeState_V0StateDecodesAtV1(t *testing.T) {
 	ctx := context.Background()
 	r := NewPatchSoftwareTitleResource().(*PatchSoftwareTitleResource)
@@ -159,6 +183,67 @@ func TestUpgradeState_V0StateDecodesAtV1(t *testing.T) {
 	if resp.DynamicValue == nil {
 		t.Fatal("expected an upgraded DynamicValue, got nil")
 	}
+
+	var schemaResp resource.SchemaResponse
+	r.Schema(ctx, resource.SchemaRequest{}, &schemaResp)
+	schemaType := schemaResp.Schema.Type().TerraformType(ctx)
+
+	decoded, err := resp.DynamicValue.Unmarshal(schemaType)
+	if err != nil {
+		t.Fatalf("the upgraded value does not decode against the current schema: %s", err)
+	}
+	var attrs map[string]tftypes.Value
+	if err := decoded.As(&attrs); err != nil {
+		t.Fatalf("upgraded value is not an object: %s", err)
+	}
+
+	if got := stringAttr(t, attrs, "id"); got != "147" {
+		t.Errorf("id did not survive the upgrade: got %q, want %q", got, "147")
+	}
+
+	var sourceID *big.Float
+	if err := attrs["source_id"].As(&sourceID); err != nil {
+		t.Fatalf("source_id is not a number: %s", err)
+	}
+	if sourceID == nil {
+		t.Error("source_id did not survive the upgrade — it backs a RequiresReplace attribute, so a null here re-plans a destroy")
+	} else if n, _ := sourceID.Int64(); n != 1 {
+		t.Errorf("source_id did not survive the upgrade: got %v, want 1", sourceID)
+	}
+
+	var available []tftypes.Value
+	if err := attrs["available_versions"].As(&available); err != nil {
+		t.Fatalf("available_versions is not a list: %s", err)
+	}
+	if len(available) != 3 {
+		t.Errorf("available_versions did not survive the upgrade: got %d entries, want 3", len(available))
+	}
+
+	var packages map[string]tftypes.Value
+	if err := attrs["version_packages"].As(&packages); err != nil {
+		t.Fatalf("version_packages is not a map: %s", err)
+	}
+	assigned, ok := packages["8.33.2.2"]
+	if !ok {
+		t.Fatalf("version_packages lost its 8.33.2.2 assignment, got keys %v", packages)
+	}
+	var pkgID string
+	if err := assigned.As(&pkgID); err != nil {
+		t.Fatalf("version_packages value is not a string: %s", err)
+	}
+	if pkgID != "1" {
+		t.Errorf("version_packages[8.33.2.2] did not survive the upgrade: got %q, want %q", pkgID, "1")
+	}
+}
+
+// stringAttr reads one string attribute out of a decoded state object.
+func stringAttr(t *testing.T, attrs map[string]tftypes.Value, name string) string {
+	t.Helper()
+	var out string
+	if err := attrs[name].As(&out); err != nil {
+		t.Fatalf("%s is not a string: %s", name, err)
+	}
+	return out
 }
 
 // TestUpgradeState_RawV0StateIsUndecodableWithoutTheRewrite pins the failure the

--- a/internal/resources/pro/patch_software_title/state_upgrader_test.go
+++ b/internal/resources/pro/patch_software_title/state_upgrader_test.go
@@ -1,0 +1,219 @@
+// Copyright Jamf Software LLC 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package patch_software_title
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"slices"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+)
+
+// State upgraders are unit-tested rather than acceptance-tested: the acceptance
+// harness always writes state at the current schema version, so the v0→v1 path
+// is unreachable from it. These tests are the only coverage the upgrader gets.
+
+// v0StateJSON is a realistic schema-v0 state object for one title, as written
+// by the build that read the classic /patchsoftwaretitles endpoints: it still
+// carries the category_name and site_name attributes the v1 schema has no home
+// for, alongside every attribute that survived.
+const v0StateJSON = `{
+  "id": "147",
+  "name": "8x8 Work",
+  "name_id": "285",
+  "source_id": 1,
+  "category_id": "58",
+  "category_name": "Productivity",
+  "site_id": "-1",
+  "site_name": "NONE",
+  "web_notification": false,
+  "email_notification": false,
+  "version_packages": {"8.33.2.2": "1"},
+  "available_versions": ["8.36.2.3", "8.35.2.6", "8.33.2.2"],
+  "accept_extension_attributes": true,
+  "extension_attributes": [
+    {"ea_id": "jamf-patch-8x8-work", "display_name": "8x8 Work Bundle Version", "accepted": true}
+  ],
+  "timeouts": null
+}`
+
+// TestDropRemovedAttributes_RemovesOnlyTheWithdrawnKeys pins the rewrite at the
+// heart of the upgrade: the two withdrawn keys go, and every other key keeps
+// its raw JSON value byte for byte once insignificant whitespace is normalised.
+// Comparing raw bytes rather than decoded values is the point — the rewrite
+// carries each value across as json.RawMessage precisely so nothing is
+// reinterpreted, and a comparison through Go types would hide a number
+// reformatted, a string re-escaped or an object's keys reordered.
+func TestDropRemovedAttributes_RemovesOnlyTheWithdrawnKeys(t *testing.T) {
+	var before map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(v0StateJSON), &before); err != nil {
+		t.Fatalf("v0 fixture is not valid JSON: %s", err)
+	}
+
+	got, err := dropRemovedAttributes([]byte(v0StateJSON), removedInV1)
+	if err != nil {
+		t.Fatalf("dropRemovedAttributes returned error: %s", err)
+	}
+
+	var after map[string]json.RawMessage
+	if err := json.Unmarshal(got, &after); err != nil {
+		t.Fatalf("rewritten state is not valid JSON: %s", err)
+	}
+
+	for _, gone := range removedInV1 {
+		if _, ok := after[gone]; ok {
+			t.Errorf("%q must be removed from upgraded state", gone)
+		}
+	}
+	if len(after) != len(before)-len(removedInV1) {
+		t.Errorf("expected %d keys after the rewrite, got %d", len(before)-len(removedInV1), len(after))
+	}
+	for k, want := range before {
+		if slices.Contains(removedInV1, k) {
+			continue
+		}
+		gotVal, ok := after[k]
+		if !ok {
+			t.Errorf("%q was dropped but only category_name and site_name should be", k)
+			continue
+		}
+		if compactJSON(t, gotVal) != compactJSON(t, want) {
+			t.Errorf("%q value changed: want %s, got %s", k, want, gotVal)
+		}
+	}
+}
+
+// compactJSON strips the insignificant whitespace a fixture carries for
+// readability, so a value comparison is byte-exact on everything that matters:
+// number formatting, string escaping and key order all survive it.
+func compactJSON(t *testing.T, in []byte) string {
+	t.Helper()
+	var buf bytes.Buffer
+	if err := json.Compact(&buf, in); err != nil {
+		t.Fatalf("compact %s: %s", in, err)
+	}
+	return buf.String()
+}
+
+// TestDropRemovedAttributes_AbsentKeysAreNotAnError pins that state written by
+// a build which never set the withdrawn attributes still upgrades. Terraform
+// omits a null attribute from state, so most real v0 states carry neither key,
+// and treating that as a failure would block the upgrade for the common case.
+func TestDropRemovedAttributes_AbsentKeysAreNotAnError(t *testing.T) {
+	in := `{"id": "147", "name": "8x8 Work"}`
+
+	got, err := dropRemovedAttributes([]byte(in), removedInV1)
+	if err != nil {
+		t.Fatalf("dropRemovedAttributes returned error: %s", err)
+	}
+
+	var after map[string]json.RawMessage
+	if err := json.Unmarshal(got, &after); err != nil {
+		t.Fatalf("rewritten state is not valid JSON: %s", err)
+	}
+	if len(after) != 2 || string(after["id"]) != `"147"` {
+		t.Errorf("expected the two surviving keys unchanged, got %s", got)
+	}
+}
+
+// TestDropRemovedAttributes_RejectsMalformedState pins that a state body which
+// is not a JSON object is reported rather than silently replaced with an empty
+// one, which would destroy the resource's state.
+func TestDropRemovedAttributes_RejectsMalformedState(t *testing.T) {
+	if _, err := dropRemovedAttributes([]byte(`["not", "an", "object"]`), removedInV1); err == nil {
+		t.Error("expected an error for a non-object state body")
+	}
+}
+
+// TestUpgradeState_V0StateDecodesAtV1 drives the registered upgrader end to end
+// over realistic v0 state and pins that it produces a value against the current
+// schema with no diagnostics. This is the whole reason the upgrader exists: the
+// framework's raw-state decode rejects an attribute the current schema does not
+// declare, so without the rewrite every pre-migration state file fails to load
+// with a framework error rather than a plannable diff.
+func TestUpgradeState_V0StateDecodesAtV1(t *testing.T) {
+	ctx := context.Background()
+	r := NewPatchSoftwareTitleResource().(*PatchSoftwareTitleResource)
+
+	upgraders := r.UpgradeState(ctx)
+	u, ok := upgraders[0]
+	if !ok {
+		t.Fatalf("no upgrader registered for schema version 0, got versions %v", upgraders)
+	}
+	if u.StateUpgrader == nil {
+		t.Fatal("the v0 entry needs a StateUpgrader — this upgrade rewrites raw state, not a decoded prior schema")
+	}
+
+	req := resource.UpgradeStateRequest{RawState: &tfprotov6.RawState{JSON: []byte(v0StateJSON)}}
+	var resp resource.UpgradeStateResponse
+	u.StateUpgrader(ctx, req, &resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("upgrade diagnostics: %v", resp.Diagnostics)
+	}
+	if resp.DynamicValue == nil {
+		t.Fatal("expected an upgraded DynamicValue, got nil")
+	}
+}
+
+// TestUpgradeState_RawV0StateIsUndecodableWithoutTheRewrite pins the failure the
+// upgrader is preventing, so the test above cannot pass vacuously: raw v0 state
+// still carrying category_name is refused by the framework's own decode against
+// the v1 schema type. If this ever stops erroring the upgrader has become
+// unnecessary — and if the rewrite regresses, this is the error users would see.
+func TestUpgradeState_RawV0StateIsUndecodableWithoutTheRewrite(t *testing.T) {
+	ctx := context.Background()
+	r := NewPatchSoftwareTitleResource().(*PatchSoftwareTitleResource)
+
+	var schemaResp resource.SchemaResponse
+	r.Schema(ctx, resource.SchemaRequest{}, &schemaResp)
+	schemaType := schemaResp.Schema.Type().TerraformType(ctx)
+
+	raw := tfprotov6.RawState{JSON: []byte(v0StateJSON)}
+	if _, err := raw.Unmarshal(schemaType); err == nil {
+		t.Error("expected v0 state carrying the withdrawn attributes to be undecodable against the v1 schema")
+	}
+}
+
+// TestUpgradeState_NilRawStateIsNoop pins that a missing prior state produces
+// neither a value nor an error. The framework treats an empty response as
+// "nothing to upgrade", whereas an error would fail an operation on a resource
+// that has no state to migrate in the first place.
+func TestUpgradeState_NilRawStateIsNoop(t *testing.T) {
+	ctx := context.Background()
+	r := NewPatchSoftwareTitleResource().(*PatchSoftwareTitleResource)
+
+	var resp resource.UpgradeStateResponse
+	r.UpgradeState(ctx)[0].StateUpgrader(ctx, resource.UpgradeStateRequest{}, &resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Errorf("a nil prior state must not raise diagnostics, got %v", resp.Diagnostics)
+	}
+	if resp.DynamicValue != nil {
+		t.Error("a nil prior state must not produce an upgraded value")
+	}
+}
+
+// TestUpgradeState_MalformedStateRaisesADiagnostic pins that an undecodable
+// state body surfaces as a Terraform diagnostic naming the resource rather than
+// a panic or a silently empty upgrade.
+func TestUpgradeState_MalformedStateRaisesADiagnostic(t *testing.T) {
+	ctx := context.Background()
+	r := NewPatchSoftwareTitleResource().(*PatchSoftwareTitleResource)
+
+	req := resource.UpgradeStateRequest{RawState: &tfprotov6.RawState{JSON: []byte(`{"id":`)}}
+	var resp resource.UpgradeStateResponse
+	r.UpgradeState(ctx)[0].StateUpgrader(ctx, req, &resp)
+
+	if !resp.Diagnostics.HasError() {
+		t.Error("expected an error diagnostic for malformed prior state")
+	}
+	if resp.DynamicValue != nil {
+		t.Error("a failed upgrade must not produce a value")
+	}
+}

--- a/templates/guides/platform-api-ga.md
+++ b/templates/guides/platform-api-ga.md
@@ -326,6 +326,24 @@ upgrade, so the benchmark continues to target the same device group; the removal
 configuration edit only, never a re-scope. The attribute has also been removed from the
 corresponding data source.
 
+### Removed: `category_name` and `site_name` on `jamfplatform_pro_patch_software_title`
+
+**Action needed only if either attribute is referenced: read the name from the object that owns
+it.** Both were read-only display names, and the Jamf Pro endpoints this resource now uses report
+category and site by ID alone:
+
+```hcl
+# category_name = jamfplatform_pro_patch_software_title.example.category_name
+category_name = jamfplatform_pro_category.example.name
+```
+
+State migrates automatically — the provider strips both attributes during the state upgrade, so
+no `terraform state` surgery is needed. They have also been removed from the corresponding data
+source. Nothing else about the resource changes: patch software titles are now read, updated and
+deleted through Jamf Pro's `/patch-software-title-configurations` endpoints rather than the
+deprecated ProClassic `/patchsoftwaretitles` ones, and every other attribute behaves as before,
+`version_packages` included — an assignment made outside Terraform still survives an apply.
+
 ### Deprecated, not yet removed: the flat blueprint component attributes
 
 **No action needed yet.** The flat top-level component attributes on

--- a/templates/guides/platform-api-ga.md
+++ b/templates/guides/platform-api-ga.md
@@ -71,17 +71,21 @@ during the public beta; the second only at GA.
    them cannot produce a plan of any kind. See [Removed constructs](#removed-constructs).
 2. **Set `base_url` to the GA gateway in the same change as the provider upgrade.** The host and
    the provider version are paired. See [Base URL](#base-url).
-3. Take a state backup, as for any breaking provider upgrade.
+3. **Extend the integration's permissions where a workspace uses
+   `jamfplatform_pro_patch_software_title`.** Its data source, list resource and `terraform import`
+   now read the tenant's patch source catalogues, so two read permissions must be added. See
+   [Attribute removals and deprecations](#attribute-removals-and-deprecations).
+4. Take a state backup, as for any breaking provider upgrade.
 
-Existing beta credentials and `tenant_id` continue to work through this upgrade. Nothing else is
-required to adopt the release before GA.
+Existing beta credentials and `tenant_id` continue to work through this upgrade, and nothing else
+is required to adopt the release before GA.
 
 **At GA:**
 
-4. **Register a replacement API integration and update the provider credentials.** Record the
+5. **Register a replacement API integration and update the provider credentials.** Record the
    permissions held by each beta integration beforehand, so the equivalents can be selected. See
    [API integration credentials](#api-integration-credentials).
-5. **Replace `tenant_id` with `environment_id`.** Register the replacement as
+6. **Replace `tenant_id` with `environment_id`.** Register the replacement as
    environment-scoped unless single-product access is deliberately what you want: tenant scope is
    the legacy option, costs one integration per tenant per product, and cannot hold the blueprint
    or compliance-benchmark permissions at all. See [Scope](#scope).
@@ -328,21 +332,59 @@ corresponding data source.
 
 ### Removed: `category_name` and `site_name` on `jamfplatform_pro_patch_software_title`
 
-**Action needed only if either attribute is referenced: read the name from the object that owns
-it.** Both were read-only display names, and the Jamf Pro endpoints this resource now uses report
-category and site by ID alone:
+**Action needed if either attribute is referenced: read the name from the object that owns it.**
+Both were read-only display names, and the Jamf Pro endpoints this resource now uses report
+category and site by ID alone. Where the category is managed by Terraform, read the name from that
+resource. Where it is not — the usual case, since these attributes were read-only and the
+assignment is commonly made in the Jamf Pro UI — look it up by the ID the title reports:
 
 ```hcl
-# category_name = jamfplatform_pro_patch_software_title.example.category_name
-category_name = jamfplatform_pro_category.example.name
+# the category is managed by Terraform
+output "category_name" {
+  # value = jamfplatform_pro_patch_software_title.example.category_name
+  value = jamfplatform_pro_category.example.name
+}
+
+# the category is not managed by Terraform
+data "jamfplatform_pro_category" "title" {
+  id = jamfplatform_pro_patch_software_title.example.category_id
+}
+
+output "category_name" {
+  value = data.jamfplatform_pro_category.title.name
+}
 ```
+
+`jamfplatform_pro_site` covers `site_name` the same way, selected by either `id` or `name`.
 
 State migrates automatically — the provider strips both attributes during the state upgrade, so
 no `terraform state` surgery is needed. They have also been removed from the corresponding data
-source. Nothing else about the resource changes: patch software titles are now read, updated and
-deleted through Jamf Pro's `/patch-software-title-configurations` endpoints rather than the
-deprecated ProClassic `/patchsoftwaretitles` ones, and every other attribute behaves as before,
-`version_packages` included — an assignment made outside Terraform still survives an apply.
+source.
+
+**Grant two further permissions.** The data source, the list resource and `terraform import`
+resolve a title's `source_id` from the tenant's patch source catalogues, because the endpoints
+this resource now uses name its patch source without numbering it. An integration reaching this
+resource through any of those three paths therefore needs **App lifecycle management → External
+patch sources → Read** and **App lifecycle management → Internal patch sources → Read** alongside
+**Patch titles**. Without them the read fails with `403 BAD_PERMISSIONS`, reported as `Unable to
+determine the patch software title's source_id`. Planning and applying a title already in state
+is unaffected, as `source_id` is carried forward rather than resolved again. The **Required Jamf
+permissions** table on each of the three documentation pages lists the full set.
+
+**`category_id` and `site_id` no longer accept `"0"`.** Use `-1`, the default, for "No category
+assigned" and "NONE"; a configuration setting either attribute to `"0"` is now rejected at plan
+time. This is the reverse of the retired endpoint's convention, under which `0` cleared the
+assignment and `-1` was a silent no-op. A title whose state still holds `"0"` needs no state edit,
+as the next refresh reads it back as `-1`; only a configuration setting the value explicitly has to
+change.
+
+Otherwise the resource behaves as before: patch software titles are now read, updated and deleted
+through Jamf Pro's `/patch-software-title-configurations` endpoints rather than the deprecated
+ProClassic `/patchsoftwaretitles` ones, and every attribute that remains keeps its meaning.
+`version_packages` still manages only the versions it names, but it now delivers that by reading
+the title's current assignments and rewriting the whole set rather than by the endpoint merging
+each version in turn. An assignment created in the Jamf Pro UI between that read and the write can
+therefore be lost, so avoid editing a title's **Definition** tab while an apply is in flight.
 
 ### Deprecated, not yet removed: the flat blueprint component attributes
 


### PR DESCRIPTION
Moves `jamfplatform_pro_patch_software_title` off the deprecated ProClassic
`/patchsoftwaretitles` XML endpoints and onto Jamf Pro v3
`/patch-software-title-configurations`.

**One classic call remains, and cannot be retired.** The POST to `id="0"` is the only
thing that mints a title id, and the v3 POST requires that id as its `softwareTitleId`
— so there is nothing to migrate create onto. It keeps its `//nolint:staticcheck`.

| Op | Before | After |
|---|---|---|
| Create | classic POST + PUT + GET | classic POST + v3 PATCH |
| Read | classic GET | v3 GET + `/definitions` |
| Update | classic PUT (201, empty body) + GET | v3 PATCH — returns the object, no read-back |
| Delete | classic DELETE | v3 DELETE |
| Name lookup | classic list + GET | v3 list (whole objects, so the match *is* the answer) |
| List | classic 4-field stub | v3 full objects |

## Wire law behind the change

Probed 2026-09-02 on Jamf Pro 11.31.1 in production EU. Recorded in the `crud.go` header.

- `PATCH` needs `Content-Type: application/merge-patch+json`; plain `application/json` is
  refused `415`.
- **`packages` is a FULL REPLACEMENT** where the classic endpoint merged per version. A
  supplied array is the complete set; `[]` clears everything; omitting the key retains.
- `categoryId` / `siteId` take a positive id or the literal `"-1"` and **reject `"0"`**
  (`400 INVALID_ID`) — the opposite of the classic convention, where `0` cleared a
  category and `-1` was a silent no-op. Both translation hacks are gone.
- `DELETE` answers `204` **and removes the classic title with it** (classic GET then
  404s), so nothing is orphaned. A second DELETE 404s cleanly.
- `/definitions` default sort (`absoluteOrderId:asc`) is newest-first — the same order
  the classic `<versions>` block used, so `available_versions` needs no re-sorting.

## The trap this PR is really about

Full-replace `packages` means sending the plan's assignments alone **silently wipes every
assignment Terraform does not manage** — breaking the managed-subset contract
`version_packages` documents. `Update` therefore reads the live set and folds the plan
over it (`unionVersionPackages`), so an assignment made in the UI survives an apply.

`TestAccResource_ProPatchSoftwareTitle_OutOfBandAssignmentSurvives` pins it, and it is
**mutation-verified**: swapping the union for `planPackages` makes it fail with
`version 8.32.2.10 has no package assignment; the apply wiped an assignment Terraform did
not manage`.

## Breaking change: two attributes removed

`category_name` and `site_name` are **removed** from the resource and the data source. v3
reports ids only, and resolving a display name would cost a lookup per read for a value
Terraform never writes.

Schema goes to **v1** with a raw-JSON state upgrader that strips both keys, so no
`terraform state` surgery is needed. Unit-tested rather than acceptance-tested — this repo
cannot drive state upgraders from acceptance tests. The removal is documented under
"Attribute removals and deprecations" in `templates/guides/platform-api-ga.md`.

## `source_id` has no v3 carrier

v3 names a title's patch source (`patchSourceName`) but never numbers it. Since a title's
source cannot change, prior state is authoritative and `assignPatchSoftwareTitleResourceModel`
never touches the attribute; `Read` resolves it from the name **only on import**, where
state holds no number. The data source and list hydration resolve always (no prior state).

`patch_sources.go` walks the two classic source catalogues and **errors on a name matching
both** rather than guessing — it backs a Required + `RequiresReplace` attribute, so a wrong
number would plan a destroy of the freshly imported title.

## Also in here

- The v3 list returns whole configuration objects, so the **list resource now hydrates**
  category, site, notifications and package assignments. `available_versions` and
  `extension_attributes` stay null — both would cost a call per item.
- `category_id` / `site_id` gained a **plan-time validator** (`-1` or a positive integer),
  moving what was a `400` mid-apply to a plan error.
- Every user-facing deprecation notice is gone from the schema descriptions.
- Unit tests rewritten against the v3 types: 22 → 79 cases.

## Verification

- `go build ./...`, `go vet` under both build tags, full `go test ./...` — clean.
- `golangci-lint run ./internal/resources/pro/patch_software_title/...` — 0 issues.
- `make generate` — docs regenerated.
- **Acceptance 6/6 green** on the EU tenant: `_Basic`, `_OutOfBandAssignmentSurvives`,
  `_InvalidPackageID`, `_ExtensionAttributeAccept`, the data source, and the list resource.

🤖 Generated with [Claude Code](https://claude.com/claude-code)