### PR TITLE
docs(platform_api_ga): pin rc.6, and cover the additions since rc.5

### DIFF
--- a/docs/guides/platform-api-ga.md
+++ b/docs/guides/platform-api-ga.md
@@ -40,7 +40,7 @@ terraform {
   required_providers {
     jamfplatform = {
       source  = "Jamf-Concepts/jamfplatform"
-      version = "0.29.0-rc.5"
+      version = "0.29.0-rc.6"
     }
   }
 }
@@ -287,7 +287,7 @@ Both attributes may also be supplied through `JAMFPLATFORM_ENVIRONMENT_ID` and
 one or the other, `environment_id` is preferred, and `tenant_id` is the legacy method of targeting
 integrations without a platform environment. A tenant-scoped GA integration remains valid for
 single-product access, and `jamfplatform_pro_*` and `jamfplatform_security_cloud_*` work under
-either scope. Two sets of constructs are out of its reach, for two different reasons:
+either scope. Three sets of constructs are out of its reach, for three different reasons:
 
 - **AI Governance** is refused by the provider, at configure time, with a diagnostic naming the
   construct. `jamfplatform_ai_governance_policy` and the tool catalogue require environment scope.
@@ -296,6 +296,13 @@ either scope. Two sets of constructs are out of its reach, for two different rea
   integration can never hold them and the calls fail with `403 BAD_PERMISSIONS`. The provider
   cannot pre-empt this, as a permission absent from the integration is indistinguishable from any
   other privilege gap — so choose environment scope if the configuration manages either.
+- **Jamf Account** requires a third scope, *organization management*, which neither of these
+  attributes selects. `jamfplatform_account_*` is the only family that scope reaches, and it is the
+  only scope that reaches the family; the provider refuses each direction at configure time with a
+  diagnostic naming the construct. Configure it by setting **neither** `environment_id` nor
+  `tenant_id` and exporting neither variable — the gateway resolves the organization from the access
+  token, so no identifier is supplied. An organization-scoped integration therefore belongs in its
+  own provider block, aliased, or its own workspace.
 
 Three failure modes follow from the change, in decreasing order of how easily they are diagnosed:
 
@@ -452,14 +459,37 @@ deleted, and the provider names the referrer in the diagnostic rather than surfa
 unqualified `409`. A Security Cloud device group referenced by a ZTNA app deletes successfully and
 empties the app's assignment. The behaviour differs per construct.
 
-New in this pre-release, and the one change here anyone already on `v0.29.0-rc.4` will notice: a
-ZTNA gateway apply now waits for the gateway to report a settled status instead of returning as
-soon as Jamf accepts the write. Creating or re-provisioning a dedicated internet gateway therefore
-takes about five minutes rather than seconds, which is what makes its
-`dedicated_egress_ip_addresses` usable from the same apply — previously the first apply recorded an
-empty list, and a region change recorded the *previous* region's addresses. Raise `create` or
-`update` in the resource's `timeouts` block if a region provisions more slowly than the default ten
-minutes allows. Further detail: [Jamf Security Cloud](security-cloud).
+Two behaviours are worth knowing before the first apply. A ZTNA gateway apply waits for the
+gateway to report a settled status rather than returning as soon as Jamf accepts the write, so
+creating or re-provisioning a dedicated internet gateway takes about five minutes rather than
+seconds — which is what makes its `dedicated_egress_ip_addresses` usable from the same apply.
+Raise `create` or `update` in the resource's `timeouts` block if a region provisions more slowly
+than the default ten minutes allows. And **destroying a `uem_connect` connector in
+`platform_tenant` form leaves a live Jamf Pro API integration behind**: Jamf Security Cloud creates
+one named `JSC Connector` to authenticate with, nothing removes it, and the provider holds no Jamf
+Pro credentials for that tenant to remove it with. The role carries 31 privileges, including
+fleet-wide profile and group writes, so audit **Settings > API roles and clients** on the Jamf Pro
+instance after any destroy and delete the orphans. Further detail:
+[Jamf Security Cloud](security-cloud).
+
+### Jamf Account
+
+New in this pre-release. `jamfplatform_account_sso_domain` claims a DNS domain for your Jamf
+Account organization's single sign-on, with singular and plural data sources, a list resource, and
+the `jamfplatform_account_sso_domain_verify` action that re-checks the domain's DNS ownership
+record. This is the provider's first *organization-scoped* family and the only one that scope
+reaches: configure it by setting neither `environment_id` nor `tenant_id`, as described under
+[Scope](#scope). It is served only from the US gateway.
+
+Three things differ from every other resource in the provider, all of them wire behaviour rather
+than design choices. Jamf Account exposes no read, update or patch for a single domain, so every
+attribute is `RequiresReplace` and `terraform import` is **by domain name** rather than by ID —
+the ID is not stable, since reclaiming a domain mints a new one. Verification is an action rather
+than resource state, and it never polls: a failed check returns `200` with the status unchanged,
+still moves the fourteen-day deadline, and the five-minute rate limit is measured from the moment
+the domain was claimed, so the first check straight after a create is always refused. Publish the
+`verification_txt_record` value — exported whole, prefix included, as the console shows it — wait
+five minutes, then run the action.
 
 ### Jamf AI Governance
 
@@ -477,8 +507,17 @@ environment scope, described under [Scope](#scope). Further detail:
 - `environment_id` and the `jamfplatform_pro_tenant_id` data source, both described under
   [Scope](#scope).
 - `custom_headers` and `authorization_header_name`, for networks in which Terraform reaches Jamf
-  through a proxy that authenticates callers itself. See
+  through a proxy that authenticates callers itself. `Cookie`, `Content-Type` and `Accept` are
+  refused in both, because a supplied header replaces rather than adds and would displace a value
+  the provider chose per request. See
   [Reverse proxies and custom headers](reverse-proxy).
+- The `jamfplatform_pro_patch_policy` list resource now names any patch policy it could not
+  enumerate, in a warning on the list result, instead of dropping it silently. A
+  `plan -generate-config-out` run that came back one resource short of the tenant said nothing
+  about it before.
+- `jamfplatform_security_cloud_uem_connect` validates `sync_refresh_interval_minutes` against the
+  intervals the service actually accepts — `60`, `120`, `240`, `480`, `720` and `1440` — at plan
+  time, rather than letting any other value fail the apply with an unattributed `422`.
 - An incorrect `base_url` is now reported as such, rather than presenting as a network failure.
 - Built against Jamf Pro 11.31.0 and Classic API 11.28.0.
 - The required-permission tables throughout this documentation are regenerated against the GA

--- a/docs/guides/platform-api-ga.md
+++ b/docs/guides/platform-api-ga.md
@@ -12,8 +12,8 @@ date will be announced separately.
 > **This guide is provisional and may change without notice.** The Platform API is still moving
 > ahead of GA, and a late change to it changes this page: the constructs listed as removed, the
 > attribute and scope behaviour, and the version numbers quoted throughout are all subject to
-> revision. Re-read it against the release you are actually upgrading to rather than working from
-> a copy taken earlier.
+> revision. Re-read it against the release you are actually upgrading to, not against a copy
+> taken earlier.
 
 **Action is needed in every configuration built against the public beta.** Nothing carries over
 untouched: the gateway host, the credentials and the scope attribute all change, and several
@@ -62,8 +62,8 @@ validated against your own configuration.
 
 ## Action needed
 
-In summary, per workspace. The first group applies whenever this release is adopted, including
-during the public beta; the second only at GA.
+Per workspace. The first group applies whenever this release is adopted, including during the
+public beta; the second only at GA.
 
 **On upgrading to this release:**
 
@@ -162,9 +162,10 @@ list. The privileges themselves are retained in a new form, described under
 
 ### Actions (configuration edit only)
 
-**Action needed: delete the blocks.** `POST /v2/mdm/commands` was unpublished, and it was the
-only means of queuing an MDM command through the Platform API. Actions hold no state, so removing
-the `action` block and any `lifecycle { action_trigger }` referring to it is sufficient.
+**Action needed: delete the blocks, and any trigger referring to them.** `POST /v2/mdm/commands`
+was unpublished, and it was the only means of queuing an MDM command through the Platform API.
+Actions hold no state, so removing the `action` block and any `lifecycle { action_trigger }`
+naming it is the whole of it.
 
 Removed: `jamfplatform_pro_device_lock`, `jamfplatform_pro_enable_lost_mode`,
 `jamfplatform_pro_disable_lost_mode`, `jamfplatform_pro_play_lost_mode_sound`,
@@ -207,9 +208,9 @@ permissions** table written the way the picker reads — the section, the permis
 to tick, and the API capability behind them. Use those tables to select permissions for the
 replacement integration, granting only what the constructs in use require.
 
-Two consequences of the new model are worth knowing before granting anything. An action covers
-only itself, so an integration that reads a record before modifying it needs the read action as
-well as the update action. And the pre-GA computer and mobile privilege pairs have collapsed into
+Grant with two consequences of the new model in mind. An action covers only itself, so an
+integration that reads a record before modifying it needs the read action as well as the update
+action. And the pre-GA computer and mobile privilege pairs have collapsed into
 single device-level permissions — `devices`, `device-groups`, `extension-attributes`,
 `configuration-profiles`, `enrollment-invitations`, `advanced-device-searches` and
 `prestage-enrollments` — so a computers-only integration is no longer expressible. Jamf's
@@ -226,7 +227,7 @@ School, Jamf Protect or Jamf Security Cloud tenant. Jamf describes it as the leg
 targeting an integration without a platform environment, and it is one integration per tenant per
 product — a Jamf Pro tenant and a Jamf Protect tenant are two integrations to create and two
 credential pairs to rotate. Treat it as the exception, for a deliberately single-product
-integration, rather than the default. An *organization management* scope reaches organization-level
+integration, not the default. An *organization management* scope reaches organization-level
 resources — the `jamfplatform_account_*` family — and is the only scope that reaches them; it is
 configured by setting *neither* `environment_id` nor `tenant_id`, since the gateway resolves the
 organization from the access token. Every resource and data source reports the scope it needs when
@@ -287,7 +288,7 @@ Both attributes may also be supplied through `JAMFPLATFORM_ENVIRONMENT_ID` and
 one or the other, `environment_id` is preferred, and `tenant_id` is the legacy method of targeting
 integrations without a platform environment. A tenant-scoped GA integration remains valid for
 single-product access, and `jamfplatform_pro_*` and `jamfplatform_security_cloud_*` work under
-either scope. Three sets of constructs are out of its reach, for three different reasons:
+either scope. Three sets of constructs are out of its reach, each for a different reason:
 
 - **AI Governance** is refused by the provider, at configure time, with a diagnostic naming the
   construct. `jamfplatform_ai_governance_policy` and the tool catalogue require environment scope.
@@ -304,7 +305,7 @@ either scope. Three sets of constructs are out of its reach, for three different
   token, so no identifier is supplied. An organization-scoped integration therefore belongs in its
   own provider block, aliased, or its own workspace.
 
-Three failure modes follow from the change, in decreasing order of how easily they are diagnosed:
+Three failure modes follow from the change, easiest to diagnose first:
 
 - Retaining `tenant_id` alongside `environment_id` is rejected at configure time with a
   `Conflicting API Integration Scope` error. The old attribute must be removed, not left in place.
@@ -391,9 +392,10 @@ Otherwise the resource behaves as before: patch software titles are now read, up
 through Jamf Pro's `/patch-software-title-configurations` endpoints rather than the deprecated
 ProClassic `/patchsoftwaretitles` ones, and every attribute that remains keeps its meaning.
 `version_packages` still manages only the versions it names, but it now delivers that by reading
-the title's current assignments and rewriting the whole set rather than by the endpoint merging
-each version in turn. An assignment created in the Jamf Pro UI between that read and the write can
-therefore be lost, so avoid editing a title's **Definition** tab while an apply is in flight.
+the title's current assignments and rewriting the whole set, instead of leaving the endpoint to
+merge each version in turn. An assignment created in the Jamf Pro UI between that read and the
+write can therefore be lost, so avoid editing a title's **Definition** tab while an apply is in
+flight.
 
 ### Deprecated, not yet removed: the flat blueprint component attributes
 
@@ -428,9 +430,9 @@ Nothing about how your devices are treated changes — the setting never took ef
 
 ### Retained: `personal_device_enrollment_type`
 
-**No action needed.** On `jamfplatform_pro_user_initiated_enrollment_settings`. This is a Jamf
-Pro deprecation rather than a provider one: Jamf Pro has ignored the value since 11.25 and always
-reports `USERENROLLMENT`. The attribute is read-only and is retained.
+**No action needed.** On `jamfplatform_pro_user_initiated_enrollment_settings`. The deprecation
+is Jamf Pro's, not the provider's: Jamf Pro has ignored the value since 11.25 and always reports
+`USERENROLLMENT`. The attribute is read-only and is retained.
 
 ## Additions since v0.28.1
 
@@ -459,18 +461,18 @@ deleted, and the provider names the referrer in the diagnostic rather than surfa
 unqualified `409`. A Security Cloud device group referenced by a ZTNA app deletes successfully and
 empties the app's assignment. The behaviour differs per construct.
 
-Two behaviours are worth knowing before the first apply. A ZTNA gateway apply waits for the
-gateway to report a settled status rather than returning as soon as Jamf accepts the write, so
-creating or re-provisioning a dedicated internet gateway takes about five minutes rather than
-seconds — which is what makes its `dedicated_egress_ip_addresses` usable from the same apply.
-Raise `create` or `update` in the resource's `timeouts` block if a region provisions more slowly
-than the default ten minutes allows. And **destroying a `uem_connect` connector in
-`platform_tenant` form leaves a live Jamf Pro API integration behind**: Jamf Security Cloud creates
-one named `JSC Connector` to authenticate with, nothing removes it, and the provider holds no Jamf
-Pro credentials for that tenant to remove it with. The role carries 31 privileges, including
-fleet-wide profile and group writes, so audit **Settings > API roles and clients** on the Jamf Pro
-instance after any destroy and delete the orphans. Further detail:
-[Jamf Security Cloud](security-cloud).
+Expect two further things on a first apply. A ZTNA gateway apply waits for the gateway to report
+a settled status instead of returning the moment Jamf accepts the write, so creating or
+re-provisioning a dedicated internet gateway takes about five minutes. That wait is what makes its
+`dedicated_egress_ip_addresses` usable from the same apply. Raise `create` or `update` in the
+resource's `timeouts` block if a region provisions more slowly than the default ten minutes allows.
+
+And **destroying a `uem_connect` connector in `platform_tenant` form leaves a live Jamf Pro API
+integration behind.** Jamf Security Cloud creates one named `JSC Connector` to authenticate with,
+nothing removes it, and the provider holds no Jamf Pro credentials for that tenant to remove it
+with. The role carries 31 privileges, including fleet-wide profile and group writes. Audit
+**Settings > API roles and clients** on the Jamf Pro instance after any destroy and delete the
+orphans. Further detail: [Jamf Security Cloud](security-cloud).
 
 ### Jamf Account
 
@@ -481,14 +483,16 @@ record. This is the provider's first *organization-scoped* family and the only o
 reaches: configure it by setting neither `environment_id` nor `tenant_id`, as described under
 [Scope](#scope). It is served only from the US gateway.
 
-Three things differ from every other resource in the provider, all of them wire behaviour rather
-than design choices. Jamf Account exposes no read, update or patch for a single domain, so every
-attribute is `RequiresReplace` and `terraform import` is **by domain name** rather than by ID —
-the ID is not stable, since reclaiming a domain mints a new one. Verification is an action rather
-than resource state, and it never polls: a failed check returns `200` with the status unchanged,
-still moves the fourteen-day deadline, and the five-minute rate limit is measured from the moment
-the domain was claimed, so the first check straight after a create is always refused. Publish the
-`verification_txt_record` value — exported whole, prefix included, as the console shows it — wait
+Two behaviours here come from the API rather than from any design choice, and both will surprise
+you. Jamf Account exposes no read, update or patch for a single domain, so every attribute is
+`RequiresReplace` and `terraform import` takes the domain **name** in place of an ID. The ID would
+not serve anyway: reclaiming a domain mints a new one.
+
+Verification is an action, not resource state, and it never polls. A failed check returns `200`
+with the status unchanged, so the status code tells you nothing; it still pushes the fourteen-day
+deadline out; and the five-minute rate limit runs from the moment the domain was claimed, which
+means the first check straight after a create is always refused. Publish the
+`verification_txt_record` value (exported whole, prefix included, as the console shows it), wait
 five minutes, then run the action.
 
 ### Jamf AI Governance
@@ -515,9 +519,9 @@ environment scope, described under [Scope](#scope). Further detail:
   enumerate, in a warning on the list result, instead of dropping it silently. A
   `plan -generate-config-out` run that came back one resource short of the tenant said nothing
   about it before.
-- `jamfplatform_security_cloud_uem_connect` validates `sync_refresh_interval_minutes` against the
-  intervals the service actually accepts — `60`, `120`, `240`, `480`, `720` and `1440` — at plan
-  time, rather than letting any other value fail the apply with an unattributed `422`.
+- `jamfplatform_security_cloud_uem_connect` validates `sync_refresh_interval_minutes` at plan time
+  against the intervals the service actually accepts (`60`, `120`, `240`, `480`, `720` and
+  `1440`), instead of letting any other value fail the apply with an unattributed `422`.
 - An incorrect `base_url` is now reported as such, rather than presenting as a network failure.
 - Built against Jamf Pro 11.31.0 and Classic API 11.28.0.
 - The required-permission tables throughout this documentation are regenerated against the GA

--- a/templates/guides/platform-api-ga.md
+++ b/templates/guides/platform-api-ga.md
@@ -40,7 +40,7 @@ terraform {
   required_providers {
     jamfplatform = {
       source  = "Jamf-Concepts/jamfplatform"
-      version = "0.29.0-rc.5"
+      version = "0.29.0-rc.6"
     }
   }
 }
@@ -287,7 +287,7 @@ Both attributes may also be supplied through `JAMFPLATFORM_ENVIRONMENT_ID` and
 one or the other, `environment_id` is preferred, and `tenant_id` is the legacy method of targeting
 integrations without a platform environment. A tenant-scoped GA integration remains valid for
 single-product access, and `jamfplatform_pro_*` and `jamfplatform_security_cloud_*` work under
-either scope. Two sets of constructs are out of its reach, for two different reasons:
+either scope. Three sets of constructs are out of its reach, for three different reasons:
 
 - **AI Governance** is refused by the provider, at configure time, with a diagnostic naming the
   construct. `jamfplatform_ai_governance_policy` and the tool catalogue require environment scope.
@@ -296,6 +296,13 @@ either scope. Two sets of constructs are out of its reach, for two different rea
   integration can never hold them and the calls fail with `403 BAD_PERMISSIONS`. The provider
   cannot pre-empt this, as a permission absent from the integration is indistinguishable from any
   other privilege gap — so choose environment scope if the configuration manages either.
+- **Jamf Account** requires a third scope, *organization management*, which neither of these
+  attributes selects. `jamfplatform_account_*` is the only family that scope reaches, and it is the
+  only scope that reaches the family; the provider refuses each direction at configure time with a
+  diagnostic naming the construct. Configure it by setting **neither** `environment_id` nor
+  `tenant_id` and exporting neither variable — the gateway resolves the organization from the access
+  token, so no identifier is supplied. An organization-scoped integration therefore belongs in its
+  own provider block, aliased, or its own workspace.
 
 Three failure modes follow from the change, in decreasing order of how easily they are diagnosed:
 
@@ -452,14 +459,37 @@ deleted, and the provider names the referrer in the diagnostic rather than surfa
 unqualified `409`. A Security Cloud device group referenced by a ZTNA app deletes successfully and
 empties the app's assignment. The behaviour differs per construct.
 
-New in this pre-release, and the one change here anyone already on `v0.29.0-rc.4` will notice: a
-ZTNA gateway apply now waits for the gateway to report a settled status instead of returning as
-soon as Jamf accepts the write. Creating or re-provisioning a dedicated internet gateway therefore
-takes about five minutes rather than seconds, which is what makes its
-`dedicated_egress_ip_addresses` usable from the same apply — previously the first apply recorded an
-empty list, and a region change recorded the *previous* region's addresses. Raise `create` or
-`update` in the resource's `timeouts` block if a region provisions more slowly than the default ten
-minutes allows. Further detail: [Jamf Security Cloud](security-cloud).
+Two behaviours are worth knowing before the first apply. A ZTNA gateway apply waits for the
+gateway to report a settled status rather than returning as soon as Jamf accepts the write, so
+creating or re-provisioning a dedicated internet gateway takes about five minutes rather than
+seconds — which is what makes its `dedicated_egress_ip_addresses` usable from the same apply.
+Raise `create` or `update` in the resource's `timeouts` block if a region provisions more slowly
+than the default ten minutes allows. And **destroying a `uem_connect` connector in
+`platform_tenant` form leaves a live Jamf Pro API integration behind**: Jamf Security Cloud creates
+one named `JSC Connector` to authenticate with, nothing removes it, and the provider holds no Jamf
+Pro credentials for that tenant to remove it with. The role carries 31 privileges, including
+fleet-wide profile and group writes, so audit **Settings > API roles and clients** on the Jamf Pro
+instance after any destroy and delete the orphans. Further detail:
+[Jamf Security Cloud](security-cloud).
+
+### Jamf Account
+
+New in this pre-release. `jamfplatform_account_sso_domain` claims a DNS domain for your Jamf
+Account organization's single sign-on, with singular and plural data sources, a list resource, and
+the `jamfplatform_account_sso_domain_verify` action that re-checks the domain's DNS ownership
+record. This is the provider's first *organization-scoped* family and the only one that scope
+reaches: configure it by setting neither `environment_id` nor `tenant_id`, as described under
+[Scope](#scope). It is served only from the US gateway.
+
+Three things differ from every other resource in the provider, all of them wire behaviour rather
+than design choices. Jamf Account exposes no read, update or patch for a single domain, so every
+attribute is `RequiresReplace` and `terraform import` is **by domain name** rather than by ID —
+the ID is not stable, since reclaiming a domain mints a new one. Verification is an action rather
+than resource state, and it never polls: a failed check returns `200` with the status unchanged,
+still moves the fourteen-day deadline, and the five-minute rate limit is measured from the moment
+the domain was claimed, so the first check straight after a create is always refused. Publish the
+`verification_txt_record` value — exported whole, prefix included, as the console shows it — wait
+five minutes, then run the action.
 
 ### Jamf AI Governance
 
@@ -477,8 +507,17 @@ environment scope, described under [Scope](#scope). Further detail:
 - `environment_id` and the `jamfplatform_pro_tenant_id` data source, both described under
   [Scope](#scope).
 - `custom_headers` and `authorization_header_name`, for networks in which Terraform reaches Jamf
-  through a proxy that authenticates callers itself. See
+  through a proxy that authenticates callers itself. `Cookie`, `Content-Type` and `Accept` are
+  refused in both, because a supplied header replaces rather than adds and would displace a value
+  the provider chose per request. See
   [Reverse proxies and custom headers](reverse-proxy).
+- The `jamfplatform_pro_patch_policy` list resource now names any patch policy it could not
+  enumerate, in a warning on the list result, instead of dropping it silently. A
+  `plan -generate-config-out` run that came back one resource short of the tenant said nothing
+  about it before.
+- `jamfplatform_security_cloud_uem_connect` validates `sync_refresh_interval_minutes` against the
+  intervals the service actually accepts — `60`, `120`, `240`, `480`, `720` and `1440` — at plan
+  time, rather than letting any other value fail the apply with an unattributed `422`.
 - An incorrect `base_url` is now reported as such, rather than presenting as a network failure.
 - Built against Jamf Pro 11.31.0 and Classic API 11.28.0.
 - The required-permission tables throughout this documentation are regenerated against the GA

--- a/templates/guides/platform-api-ga.md
+++ b/templates/guides/platform-api-ga.md
@@ -12,8 +12,8 @@ date will be announced separately.
 > **This guide is provisional and may change without notice.** The Platform API is still moving
 > ahead of GA, and a late change to it changes this page: the constructs listed as removed, the
 > attribute and scope behaviour, and the version numbers quoted throughout are all subject to
-> revision. Re-read it against the release you are actually upgrading to rather than working from
-> a copy taken earlier.
+> revision. Re-read it against the release you are actually upgrading to, not against a copy
+> taken earlier.
 
 **Action is needed in every configuration built against the public beta.** Nothing carries over
 untouched: the gateway host, the credentials and the scope attribute all change, and several
@@ -62,8 +62,8 @@ validated against your own configuration.
 
 ## Action needed
 
-In summary, per workspace. The first group applies whenever this release is adopted, including
-during the public beta; the second only at GA.
+Per workspace. The first group applies whenever this release is adopted, including during the
+public beta; the second only at GA.
 
 **On upgrading to this release:**
 
@@ -162,9 +162,10 @@ list. The privileges themselves are retained in a new form, described under
 
 ### Actions (configuration edit only)
 
-**Action needed: delete the blocks.** `POST /v2/mdm/commands` was unpublished, and it was the
-only means of queuing an MDM command through the Platform API. Actions hold no state, so removing
-the `action` block and any `lifecycle { action_trigger }` referring to it is sufficient.
+**Action needed: delete the blocks, and any trigger referring to them.** `POST /v2/mdm/commands`
+was unpublished, and it was the only means of queuing an MDM command through the Platform API.
+Actions hold no state, so removing the `action` block and any `lifecycle { action_trigger }`
+naming it is the whole of it.
 
 Removed: `jamfplatform_pro_device_lock`, `jamfplatform_pro_enable_lost_mode`,
 `jamfplatform_pro_disable_lost_mode`, `jamfplatform_pro_play_lost_mode_sound`,
@@ -207,9 +208,9 @@ permissions** table written the way the picker reads — the section, the permis
 to tick, and the API capability behind them. Use those tables to select permissions for the
 replacement integration, granting only what the constructs in use require.
 
-Two consequences of the new model are worth knowing before granting anything. An action covers
-only itself, so an integration that reads a record before modifying it needs the read action as
-well as the update action. And the pre-GA computer and mobile privilege pairs have collapsed into
+Grant with two consequences of the new model in mind. An action covers only itself, so an
+integration that reads a record before modifying it needs the read action as well as the update
+action. And the pre-GA computer and mobile privilege pairs have collapsed into
 single device-level permissions — `devices`, `device-groups`, `extension-attributes`,
 `configuration-profiles`, `enrollment-invitations`, `advanced-device-searches` and
 `prestage-enrollments` — so a computers-only integration is no longer expressible. Jamf's
@@ -226,7 +227,7 @@ School, Jamf Protect or Jamf Security Cloud tenant. Jamf describes it as the leg
 targeting an integration without a platform environment, and it is one integration per tenant per
 product — a Jamf Pro tenant and a Jamf Protect tenant are two integrations to create and two
 credential pairs to rotate. Treat it as the exception, for a deliberately single-product
-integration, rather than the default. An *organization management* scope reaches organization-level
+integration, not the default. An *organization management* scope reaches organization-level
 resources — the `jamfplatform_account_*` family — and is the only scope that reaches them; it is
 configured by setting *neither* `environment_id` nor `tenant_id`, since the gateway resolves the
 organization from the access token. Every resource and data source reports the scope it needs when
@@ -287,7 +288,7 @@ Both attributes may also be supplied through `JAMFPLATFORM_ENVIRONMENT_ID` and
 one or the other, `environment_id` is preferred, and `tenant_id` is the legacy method of targeting
 integrations without a platform environment. A tenant-scoped GA integration remains valid for
 single-product access, and `jamfplatform_pro_*` and `jamfplatform_security_cloud_*` work under
-either scope. Three sets of constructs are out of its reach, for three different reasons:
+either scope. Three sets of constructs are out of its reach, each for a different reason:
 
 - **AI Governance** is refused by the provider, at configure time, with a diagnostic naming the
   construct. `jamfplatform_ai_governance_policy` and the tool catalogue require environment scope.
@@ -304,7 +305,7 @@ either scope. Three sets of constructs are out of its reach, for three different
   token, so no identifier is supplied. An organization-scoped integration therefore belongs in its
   own provider block, aliased, or its own workspace.
 
-Three failure modes follow from the change, in decreasing order of how easily they are diagnosed:
+Three failure modes follow from the change, easiest to diagnose first:
 
 - Retaining `tenant_id` alongside `environment_id` is rejected at configure time with a
   `Conflicting API Integration Scope` error. The old attribute must be removed, not left in place.
@@ -391,9 +392,10 @@ Otherwise the resource behaves as before: patch software titles are now read, up
 through Jamf Pro's `/patch-software-title-configurations` endpoints rather than the deprecated
 ProClassic `/patchsoftwaretitles` ones, and every attribute that remains keeps its meaning.
 `version_packages` still manages only the versions it names, but it now delivers that by reading
-the title's current assignments and rewriting the whole set rather than by the endpoint merging
-each version in turn. An assignment created in the Jamf Pro UI between that read and the write can
-therefore be lost, so avoid editing a title's **Definition** tab while an apply is in flight.
+the title's current assignments and rewriting the whole set, instead of leaving the endpoint to
+merge each version in turn. An assignment created in the Jamf Pro UI between that read and the
+write can therefore be lost, so avoid editing a title's **Definition** tab while an apply is in
+flight.
 
 ### Deprecated, not yet removed: the flat blueprint component attributes
 
@@ -428,9 +430,9 @@ Nothing about how your devices are treated changes — the setting never took ef
 
 ### Retained: `personal_device_enrollment_type`
 
-**No action needed.** On `jamfplatform_pro_user_initiated_enrollment_settings`. This is a Jamf
-Pro deprecation rather than a provider one: Jamf Pro has ignored the value since 11.25 and always
-reports `USERENROLLMENT`. The attribute is read-only and is retained.
+**No action needed.** On `jamfplatform_pro_user_initiated_enrollment_settings`. The deprecation
+is Jamf Pro's, not the provider's: Jamf Pro has ignored the value since 11.25 and always reports
+`USERENROLLMENT`. The attribute is read-only and is retained.
 
 ## Additions since v0.28.1
 
@@ -459,18 +461,18 @@ deleted, and the provider names the referrer in the diagnostic rather than surfa
 unqualified `409`. A Security Cloud device group referenced by a ZTNA app deletes successfully and
 empties the app's assignment. The behaviour differs per construct.
 
-Two behaviours are worth knowing before the first apply. A ZTNA gateway apply waits for the
-gateway to report a settled status rather than returning as soon as Jamf accepts the write, so
-creating or re-provisioning a dedicated internet gateway takes about five minutes rather than
-seconds — which is what makes its `dedicated_egress_ip_addresses` usable from the same apply.
-Raise `create` or `update` in the resource's `timeouts` block if a region provisions more slowly
-than the default ten minutes allows. And **destroying a `uem_connect` connector in
-`platform_tenant` form leaves a live Jamf Pro API integration behind**: Jamf Security Cloud creates
-one named `JSC Connector` to authenticate with, nothing removes it, and the provider holds no Jamf
-Pro credentials for that tenant to remove it with. The role carries 31 privileges, including
-fleet-wide profile and group writes, so audit **Settings > API roles and clients** on the Jamf Pro
-instance after any destroy and delete the orphans. Further detail:
-[Jamf Security Cloud](security-cloud).
+Expect two further things on a first apply. A ZTNA gateway apply waits for the gateway to report
+a settled status instead of returning the moment Jamf accepts the write, so creating or
+re-provisioning a dedicated internet gateway takes about five minutes. That wait is what makes its
+`dedicated_egress_ip_addresses` usable from the same apply. Raise `create` or `update` in the
+resource's `timeouts` block if a region provisions more slowly than the default ten minutes allows.
+
+And **destroying a `uem_connect` connector in `platform_tenant` form leaves a live Jamf Pro API
+integration behind.** Jamf Security Cloud creates one named `JSC Connector` to authenticate with,
+nothing removes it, and the provider holds no Jamf Pro credentials for that tenant to remove it
+with. The role carries 31 privileges, including fleet-wide profile and group writes. Audit
+**Settings > API roles and clients** on the Jamf Pro instance after any destroy and delete the
+orphans. Further detail: [Jamf Security Cloud](security-cloud).
 
 ### Jamf Account
 
@@ -481,14 +483,16 @@ record. This is the provider's first *organization-scoped* family and the only o
 reaches: configure it by setting neither `environment_id` nor `tenant_id`, as described under
 [Scope](#scope). It is served only from the US gateway.
 
-Three things differ from every other resource in the provider, all of them wire behaviour rather
-than design choices. Jamf Account exposes no read, update or patch for a single domain, so every
-attribute is `RequiresReplace` and `terraform import` is **by domain name** rather than by ID —
-the ID is not stable, since reclaiming a domain mints a new one. Verification is an action rather
-than resource state, and it never polls: a failed check returns `200` with the status unchanged,
-still moves the fourteen-day deadline, and the five-minute rate limit is measured from the moment
-the domain was claimed, so the first check straight after a create is always refused. Publish the
-`verification_txt_record` value — exported whole, prefix included, as the console shows it — wait
+Two behaviours here come from the API rather than from any design choice, and both will surprise
+you. Jamf Account exposes no read, update or patch for a single domain, so every attribute is
+`RequiresReplace` and `terraform import` takes the domain **name** in place of an ID. The ID would
+not serve anyway: reclaiming a domain mints a new one.
+
+Verification is an action, not resource state, and it never polls. A failed check returns `200`
+with the status unchanged, so the status code tells you nothing; it still pushes the fourteen-day
+deadline out; and the five-minute rate limit runs from the moment the domain was claimed, which
+means the first check straight after a create is always refused. Publish the
+`verification_txt_record` value (exported whole, prefix included, as the console shows it), wait
 five minutes, then run the action.
 
 ### Jamf AI Governance
@@ -515,9 +519,9 @@ environment scope, described under [Scope](#scope). Further detail:
   enumerate, in a warning on the list result, instead of dropping it silently. A
   `plan -generate-config-out` run that came back one resource short of the tenant said nothing
   about it before.
-- `jamfplatform_security_cloud_uem_connect` validates `sync_refresh_interval_minutes` against the
-  intervals the service actually accepts — `60`, `120`, `240`, `480`, `720` and `1440` — at plan
-  time, rather than letting any other value fail the apply with an unattributed `422`.
+- `jamfplatform_security_cloud_uem_connect` validates `sync_refresh_interval_minutes` at plan time
+  against the intervals the service actually accepts (`60`, `120`, `240`, `480`, `720` and
+  `1440`), instead of letting any other value fail the apply with an unattributed `422`.
 - An incorrect `base_url` is now reported as such, rather than presenting as a network failure.
 - Built against Jamf Pro 11.31.0 and Classic API 11.28.0.
 - The required-permission tables throughout this documentation are regenerated against the GA


### PR DESCRIPTION
Prepares the Platform API GA guide for the `v0.29.0-rc.6` pre-release, cut off `feat/platform-api-ga`. Docs only — no Go changes, no schema changes.

## What changed

**Pinned the install snippet to `0.29.0-rc.6`.**

**Jamf Account gets its own Additions section.** The organization-scope prose landed with the `ConfigureAccount` plumbing, but the family it exists for did not — so the guide described a scope that reached nothing a reader could name. Covers `jamfplatform_account_sso_domain`, its two data sources, the list resource and the `jamfplatform_account_sso_domain_verify` action, plus the three behaviours nobody would guess: every attribute is `RequiresReplace` and import is by domain **name** (no single-domain read, and a reclaimed domain mints a new id); verification is an action that never polls; and the five-minute rate limit is measured from the claim, so the first check after a create is always refused.

**The Scope section grows a third bullet.** It counted two sets of constructs out of a tenant integration's reach; there are now three — and the third is out of an *environment* integration's reach too, which neither existing bullet could carry.

**The Security Cloud section's "new in this pre-release" paragraph was stale** — it described the ZTNA gateway wait, which was new in rc.5. Rewritten as the two behaviours worth knowing before a first apply, the second being the `platform_tenant` credential leak: destroying a `uem_connect` connector leaves an enabled 31-privilege `JSC Connector` integration on the Jamf Pro instance, and nothing on either side removes it.

**Three entries under Elsewhere:** `Cookie`, `Content-Type` and `Accept` refused in `custom_headers` and `authorization_header_name`; the `patch_policy` list resource now names a policy it could not enumerate instead of dropping it silently; and `sync_refresh_interval_minutes` validated at plan time against the six intervals the service accepts.

## Notes for review

- `docs/guides/platform-api-ga.md` is regenerated, not hand-edited — the change is in `templates/guides/platform-api-ga.md` and `make generate` produced the rest.
- Two claims were corrected against the source while writing this: the interval attribute is `sync_refresh_interval_minutes` (not `sync_interval`) and accepts six values, not two; and the credential leak is a `~>` note on the resource page, not a runtime warning diagnostic.
- Epic-branch PRs get no CI here — `integration-tests.yml` is `main`-only. Ran locally: `make fix fmt lint test` and `make generate` are clean in an isolated worktree.

Once merged, `v0.29.0-rc.6` gets tagged on `feat/platform-api-ga`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)