### PR TITLE
ci(release): label pre-releases, and take the notes GitHub already writes

### DIFF
--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -55,41 +55,24 @@ signs:
       - "--detach-sign"
       - "${artifact}"
 release:
+  # Tags carrying a pre-release suffix (v0.29.0-rc.6) are published as GitHub
+  # pre-releases; a bare version tag (v0.29.0) is published as a full release and
+  # becomes "Latest". Without this, GoReleaser defaults to prerelease: false and
+  # every release candidate ships labelled as production-ready.
+  prerelease: auto
   extra_files:
     - glob: "terraform-registry-manifest.json"
       name_template: "{{ .ProjectName }}_{{ .Version }}_manifest.json"
   # If you want to manually examine the release before its live, uncomment this line:
   # draft: true
 changelog:
-  use: git
-  sort: asc
-  groups:
-    - title: Breaking Changes
-      regexp: "(?i)^.*(breaking|!:|BREAKING CHANGE).*"
-      order: 0
-    - title: Features
-      regexp: '(?i)^.*feat(\(.+\))?!?:.*'
-      order: 1
-    - title: Bug Fixes
-      regexp: '(?i)^.*fix(\(.+\))?!?:.*'
-      order: 2
-    - title: Performance
-      regexp: '(?i)^.*perf(\(.+\))?!?:.*'
-      order: 3
-    - title: Refactors
-      regexp: '(?i)^.*refactor(\(.+\))?!?:.*'
-      order: 4
-    - title: Documentation
-      regexp: '(?i)^.*docs(\(.+\))?!?:.*'
-      order: 5
-    - title: Tests
-      regexp: '(?i)^.*test(\(.+\))?!?:.*'
-      order: 6
-    - title: Other
-      order: 999
-  filters:
-    exclude:
-      - "^chore"
-      - "^ci"
-      - "Merge pull request"
-      - "Merge branch"
+  # GitHub generates the notes, which is what has actually been appearing on
+  # every release: PR titles, their authors, and a Full Changelog compare link.
+  # GoReleaser's own `use: git` changelog cannot produce any of those, and the
+  # grouped config that used to sit here never reached a published release.
+  #
+  # `github-native` ignores `groups`, `filters` and `sort`, so they are gone
+  # rather than left here looking effective. To categorise the notes, add
+  # .github/release.yml and label the pull requests — GitHub's generator reads
+  # that file; GoReleaser is not involved.
+  use: github-native


### PR DESCRIPTION
Two corrections to `goreleaser.yml`, found by comparing what the published releases actually contain against what the config implies. Blocks tagging `v0.29.0-rc.6`.

## Every release candidate has shipped labelled as production-ready

`release.prerelease` was never set, GoReleaser defaults it to `false`, and the GitHub API confirms the result:

| tag | `prerelease` | `draft` |
|---|---|---|
| `v0.29.0-rc.5` | `false` | false |
| `v0.29.0-rc.4` | `false` | false |
| `v0.29.0-rc.2` | `false` | false |
| `v0.29.0-rc.1` | `false` | false |
| `v0.28.1` | `false` | false |

`prerelease: auto` keys the flag off the tag: a suffixed tag (`v0.29.0-rc.6`) becomes a GitHub pre-release, a bare one (`v0.29.0`) a full release that takes Latest.

Worth being precise about the blast radius, because it looks harmless today: `GET /releases/latest` does still return `v0.28.1`, so no RC has actually stolen the Latest badge. But `make_latest` is unset too, so nothing was guaranteeing that — it was luck, not configuration.

## The changelog block described notes nobody has ever seen

It declared `use: git` with eight conventional-commit groups (Breaking Changes, Features, Bug Fixes, Performance, Refactors, Documentation, Tests, Other) and filters excluding `^chore`, `^ci` and merge commits.

Every published release body is in GitHub's native format instead:

```
## What's Changed
* docs(platform_api_ga): pin rc.5, and note the gateway wait by @neilmartin83 in https://github.com/.../pull/356

**Full Changelog**: https://github.com/.../compare/v0.29.0-rc.4...v0.29.0-rc.5
```

PR links and `by @author` are things `use: git` cannot produce — they only come from GitHub's own generator. So those groups were dead config that read as though it were shaping releases. `use: github-native` asks GitHub for what it was already producing, which also stops the result depending on whether anyone edits the body afterwards.

## What this deliberately does not do

The eight groups are not reimplemented. `github-native` ignores `groups`, `filters` and `sort`, and GitHub's generator categorises by **pull-request label**, not commit prefix. Restoring categories therefore means adding `.github/release.yml` *and* labelling PRs — and right now only Dependabot's PRs carry any labels, so every human PR would land in a catch-all. That's a separate decision, not a mechanical port, so it's called out in a comment in the file rather than guessed at here.

Net effect on rc.6's notes: same flat "What's Changed" list as rc.5 had, plus the Pre-release badge that rc.5 should have had.

## Verification

- `goreleaser.yml` parses as valid YAML; `use: github-native` is a valid enum value per GoReleaser's published JSON schema (`git`, `github`, `github-native`, `gitlab`).
- Not exercised end-to-end: the only real test is a tag push, which publishes. The first proof will be rc.6 itself carrying the Pre-release badge — worth a glance at the release page right after the workflow finishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)