### PR TITLE
chore: stop golangci-lint walking the gitignored local-testing directory

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,22 @@
+# golangci-lint configuration.
+#
+# This file exists for ONE reason: to keep `make lint` off local-testing/.
+# That directory holds manual API request workflows for development, it is
+# gitignored (.gitignore:93), and it is deliberately not held to the provider's
+# standards — but its 20 packages are inside the module, so `./...` walks them
+# and `golangci-lint run` reports their nits. CI never noticed, because a
+# gitignored directory is not checked out, so the lint job was green while
+# `make lint` failed for every developer who had ever run a probe. Excluding it
+# here rather than in GNUmakefile keeps the CLI and the golangci-lint-action
+# CI job (which takes no arguments) in agreement.
+#
+# The linter SELECTION is deliberately left alone: no `linters.default` key, so
+# the default `standard` set stays in force (errcheck, govet, ineffassign,
+# staticcheck, unused). Do not use this file to quieten a finding in internal/
+# or examples/ — fix the code.
+version: "2"
+
+linters:
+  exclusions:
+    paths:
+      - local-testing


### PR DESCRIPTION
## What

Adds a `.golangci.yml` whose only job is excluding `local-testing/`.

## Why

`local-testing/` holds manual API request workflows for development. It is gitignored (`.gitignore:93`) and deliberately not held to the provider's standards — but its ~20 packages sit **inside the module**, so `./...` walks them and `golangci-lint run` reports their findings.

CI never noticed, because a gitignored directory is not checked out. So the lint job stayed green while `make lint` failed for every developer who had ever written a probe:

```
local-testing/probe-charmatrix/main.go:274:23: Error return value of `resp.Body.Close` is not checked (errcheck)
local-testing/probe-mobile-cr/main.go:178:23: Error return value of `resp.Body.Close` is not checked (errcheck)
local-testing/probe-charmatrix/main.go:77:15: ST1018: string literal contains the Unicode format character U+200F (staticcheck)
local-testing/probe-mobile-cr/main.go:75:2: var numericRef is unused (unused)
4 issues:
make: *** [lint] Error 1
```

## Two deliberate choices

**The exclusion lives in config, not in `GNUmakefile`.** CI runs `golangci-lint-action` with no arguments, so a path list in the Makefile would fix the CLI and leave CI on different rules.

**The linter selection is untouched.** There is no `linters.default` key, so golangci-lint v2's default `standard` set stays in force. Verified identical before and after with `golangci-lint linters`:

> errcheck, govet, ineffassign, staticcheck, unused

The file says explicitly not to use it to quieten a finding in `internal/` or `examples/`.

## Verification

`make lint` → `0 issues.` on both invocations. No other target affected; the repo had no golangci-lint configuration at all before this.

## Review notes

Found while working on #379, unrelated to it, so it is split out rather than bundled. Independent of the other two PRs in that group and can merge in any order — though merging it first means `make lint` passes locally while reviewing them.