### PR TITLE
test: omit-retains contract on the block-gated classic resources (#383)

### DIFF
--- a/internal/common/accountprivileges/accountprivileges.go
+++ b/internal/common/accountprivileges/accountprivileges.go
@@ -7,16 +7,21 @@
 // Jamf Pro administrator accounts and account groups carry a privilege grid
 // split into seven wire categories (jss_objects, jss_settings, jss_actions,
 // casper_admin, casper_remote, casper_imaging, recon), each a list of
-// free-text privilege strings. Two server behaviours make this grid awkward to
-// manage declaratively (both wire-probed 2026-06-12):
+// free-text privilege strings. Three server behaviours make this grid awkward
+// to manage declaratively (the first two wire-probed 2026-06-12, the third
+// 2026-09-06 on Jamf Pro 11.31.1):
 //
 //   - The server SILENTLY EXPANDS a submitted set, adding dependency
 //     privileges the caller did not request — sometimes in a different
-//     category (e.g. submitting jss_objects=["Update Buildings"] yields a
-//     stored jss_settings=["Read Activation Code"]). Re-submitting the same
-//     subset reproduces the same superset, stably.
+//     category (e.g. submitting jss_objects=["Read Buildings"] yields a stored
+//     jss_settings=["Read License Information"]). Re-submitting the same subset
+//     reproduces the same superset, stably.
 //   - The server SILENTLY DROPS an unrecognised privilege string, returning
 //     201/200 with the bad value simply absent — no error.
+//   - A sent <privileges> element REPLACES THE WHOLE GRID on both
+//     /accounts/groupid and /accounts/userid: every category absent from the
+//     body is emptied, while omitting the element leaves the grid untouched.
+//     There is no per-category merge on the wire (issue #385).
 //
 // To keep a correct configuration free of perpetual diffs we use
 // INTERSECT-ON-READ: refresh-Read stores, per category, only the intersection
@@ -29,6 +34,13 @@
 // after apply" abort. The plan-time Validator (discovering the tenant's catalog
 // from an Administrator account/group) is what keeps invalid privileges from
 // reaching apply in the first place.
+//
+// The user-facing contract for a category is the one the scope helper uses:
+// declared (including []) means Terraform owns it, omitted means it is left as
+// configured outside Terraform. Because the wire replaces the whole grid, the
+// second half is emulated with a read-merge-write: a write GETs the live grid,
+// overlays the declared categories via MergeGrid and sends every merged
+// category, so an undeclared category survives exactly as the server held it.
 package accountprivileges
 
 // Category describes one of the seven privilege buckets: its Jamf classic wire

--- a/internal/common/accountprivileges/accountprivileges_test.go
+++ b/internal/common/accountprivileges/accountprivileges_test.go
@@ -221,6 +221,91 @@ func TestModelToMap_OmitsNullCategories(t *testing.T) {
 	}
 }
 
+// TestMergeGrid_DeclaredReplacesUndeclaredCarried is the write-side contract
+// behind issue #385: a declared category wins over the live value, and a
+// category the configuration does not declare is carried from the live grid,
+// server-injected dependency privileges included, so the full-replace PUT cannot
+// empty it.
+func TestMergeGrid_DeclaredReplacesUndeclaredCarried(t *testing.T) {
+	declared := &Model{JamfProServerObjects: mustSet(t, "Read Buildings", "Read Departments")}
+	server := map[string][]string{
+		"jss_objects":  {"Read Computers"},
+		"jss_settings": {"Read License Information", "Read SMTP Server"},
+		"jss_actions":  {"Send Computer Remote Lock Command"},
+	}
+	got, diags := MergeGrid(context.Background(), declared, server)
+	if diags.HasError() {
+		t.Fatalf("diags: %v", diags)
+	}
+	want := map[string][]string{
+		"jss_objects":  {"Read Buildings", "Read Departments"},
+		"jss_settings": {"Read License Information", "Read SMTP Server"},
+		"jss_actions":  {"Send Computer Remote Lock Command"},
+	}
+	for k, w := range want {
+		g := got[k]
+		sort.Strings(g)
+		if !reflect.DeepEqual(g, w) {
+			t.Errorf("category %s: got %v want %v", k, g, w)
+		}
+	}
+	if len(got) != len(want) {
+		t.Errorf("merged grid has %d categories, want %d: %v", len(got), len(want), got)
+	}
+	if !reflect.DeepEqual(server["jss_objects"], []string{"Read Computers"}) {
+		t.Errorf("server grid mutated: %v", server["jss_objects"])
+	}
+}
+
+// TestMergeGrid_DeclaredEmptyClears keeps a declared [] as a present key with an
+// empty slice, so ToGroupPrivileges emits an empty element and the category is
+// cleared rather than carried from the live grid.
+func TestMergeGrid_DeclaredEmptyClears(t *testing.T) {
+	declared := &Model{JamfProServerActions: mustSet(t)}
+	server := map[string][]string{"jss_actions": {"Send Computer Remote Lock Command"}}
+	got, diags := MergeGrid(context.Background(), declared, server)
+	if diags.HasError() {
+		t.Fatalf("diags: %v", diags)
+	}
+	v, ok := got["jss_actions"]
+	if !ok {
+		t.Fatalf("declared empty category dropped from merged grid: %v", got)
+	}
+	if v == nil || len(v) != 0 {
+		t.Errorf("declared empty category should be a non-nil empty slice, got %#v", v)
+	}
+	if grid := ToGroupPrivileges(got); grid == nil || grid.JssActions == nil {
+		t.Errorf("empty category should still be emitted as an element: %+v", grid)
+	}
+}
+
+// TestMergeGrid_NilServer covers Create, where nothing exists yet: the merged
+// grid is exactly the declared categories.
+func TestMergeGrid_NilServer(t *testing.T) {
+	declared := &Model{Recon: mustSet(t, "Use Recon")}
+	got, diags := MergeGrid(context.Background(), declared, nil)
+	if diags.HasError() {
+		t.Fatalf("diags: %v", diags)
+	}
+	if !reflect.DeepEqual(got, map[string][]string{"recon": {"Use Recon"}}) {
+		t.Errorf("got %v", got)
+	}
+}
+
+// TestMergeGrid_NilDeclared returns a copy of the live grid when nothing is
+// declared, so a caller that does reach it with no configuration re-sends the
+// server's own grid rather than an empty one.
+func TestMergeGrid_NilDeclared(t *testing.T) {
+	server := map[string][]string{"casper_admin": {"Use Casper Admin"}}
+	got, diags := MergeGrid(context.Background(), nil, server)
+	if diags.HasError() {
+		t.Fatalf("diags: %v", diags)
+	}
+	if !reflect.DeepEqual(got, server) {
+		t.Errorf("got %v want %v", got, server)
+	}
+}
+
 // fakeDiscoverer serves a fixed account/group topology for Discover tests.
 type fakeDiscoverer struct {
 	groups map[int]*proclassic.Group

--- a/internal/common/accountprivileges/model.go
+++ b/internal/common/accountprivileges/model.go
@@ -14,8 +14,10 @@ import (
 
 // Model is the Terraform model for the privileges single-nested block. Each
 // field is a Set of privilege strings for one category. A nil/null Set means
-// the category is unmanaged by the configuration (omit-on-write, stays null on
-// read).
+// the category is unmanaged by the configuration: it stays null on read
+// (IntersectIntoState) and on write it is carried from the live server grid
+// rather than omitted (MergeGrid), because the classic endpoints replace the
+// whole grid on any sent <privileges> element.
 type Model struct {
 	JamfProServerObjects  types.Set `tfsdk:"jamf_pro_server_objects"`
 	JamfProServerSettings types.Set `tfsdk:"jamf_pro_server_settings"`
@@ -72,9 +74,11 @@ func declaredStrings(ctx context.Context, s types.Set) ([]string, diag.Diagnosti
 }
 
 // ToMap converts the declared (non-null) categories of a Model into a map keyed
-// by wire key. Null/unknown categories are omitted entirely so the caller can
-// honour omit-on-write semantics (the classic PUT merges, retaining categories
-// that are not sent).
+// by wire key. Null/unknown categories are omitted from the map. The result is
+// NOT a wire-ready grid: the classic /accounts endpoints replace the whole
+// privilege grid on any sent <privileges> element, so a partial map sent as-is
+// empties every category it does not name. Callers building a write go through
+// MergeGrid, which fills the undeclared categories from the live server grid.
 func (m *Model) ToMap(ctx context.Context) (map[string][]string, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	out := make(map[string][]string)
@@ -89,6 +93,48 @@ func (m *Model) ToMap(ctx context.Context) (map[string][]string, diag.Diagnostic
 			return nil, diags
 		}
 		out[c.WireKey] = vals
+	}
+	return out, diags
+}
+
+// MergeGrid builds the wire-ready privilege grid for a write: the live server
+// grid with every category the configuration declares replaced by the declared
+// value. It emulates, client-side, the per-category retention the classic API
+// does not provide. Wire-probed 2026-09-06 on Jamf Pro 11.31.1, through the SDK,
+// on both PUT /accounts/groupid/{id} and PUT /accounts/userid/{id}: a sent
+// <privileges> element replaces the entire grid, so every category absent from
+// the body is emptied on the server (jss_settings kept only the server-injected
+// "Read License Information"; jss_actions was cleared) while omitting the
+// element altogether leaves the grid untouched (issue #385). Read hides that
+// loss, because IntersectIntoState treats a null category as unmanaged and never
+// refreshes it, which made the wipe invisible to a plan.
+//
+// The merge is category-granular, the same shape as the shared scope helper's
+// per-category ownership (STYLE_GUIDE §Scope helper): a declared category,
+// including a declared empty set, wins over the server value and an empty set
+// is kept as a present key so it marshals as an empty element and clears the
+// category; an undeclared category is carried from server verbatim, including
+// any dependency privileges the server injected, which the server would
+// re-inject anyway and which Read's intersect already keeps out of state. A nil
+// server grid (Create, before anything exists) yields just the declared
+// categories. server is never mutated.
+func MergeGrid(ctx context.Context, declared *Model, server map[string][]string) (map[string][]string, diag.Diagnostics) {
+	out := make(map[string][]string, len(Categories))
+	for k, v := range server {
+		out[k] = append([]string(nil), v...)
+	}
+	if declared == nil {
+		return out, nil
+	}
+	declaredMap, diags := declared.ToMap(ctx)
+	if diags.HasError() {
+		return nil, diags
+	}
+	for k, v := range declaredMap {
+		if v == nil {
+			v = []string{}
+		}
+		out[k] = v
 	}
 	return out, diags
 }

--- a/internal/common/accountprivileges/sdk.go
+++ b/internal/common/accountprivileges/sdk.go
@@ -89,9 +89,12 @@ func FromGroupPrivileges(p *proclassic.GroupPrivileges) map[string][]string {
 }
 
 // ToAccountPrivileges builds an SDK account privilege grid from a wire-keyed
-// map. Only categories present in the map are emitted (omit-on-write); a
-// category present with an empty slice is emitted as an empty element, which
-// the classic endpoint treats as "clear this category".
+// map. Only categories present in the map are emitted, and a category present
+// with an empty slice is emitted as an empty element. Because the classic
+// endpoint replaces the whole grid on any sent <privileges> (see MergeGrid), an
+// absent category and an empty one both end up cleared on the server; the map
+// must therefore already be the full merged grid, not just the declared
+// categories.
 func ToAccountPrivileges(m map[string][]string) *proclassic.AccountPrivileges {
 	if len(m) == 0 {
 		return nil
@@ -121,7 +124,8 @@ func ToAccountPrivileges(m map[string][]string) *proclassic.AccountPrivileges {
 	return out
 }
 
-// ToGroupPrivileges builds an SDK group privilege grid from a wire-keyed map.
+// ToGroupPrivileges builds an SDK group privilege grid from a wire-keyed map,
+// with the same full-grid expectation as ToAccountPrivileges.
 func ToGroupPrivileges(m map[string][]string) *proclassic.GroupPrivileges {
 	if len(m) == 0 {
 		return nil

--- a/internal/resources/pro/account/crud.go
+++ b/internal/resources/pro/account/crud.go
@@ -7,11 +7,11 @@
 //   pro.UpdateAccountV1               (PUT base fields)
 //   pro.DeleteAccountV1
 //   pro.ResolveAccountV1IDByName      (data source username lookup)
-//   proclassic.GetAccountByUserID     (Custom privilege grid read)
-//   proclassic.UpdateAccountByUserID  (Custom privilege grid write — merge)
+//   proclassic.GetAccountByUserID     (Custom privilege grid read; live grid before every privilege write)
+//   proclassic.UpdateAccountByUserID  (Custom privilege grid write; a sent <privileges> replaces the whole grid — merged client-side)
 //   proclassic.ListAccounts           (privilege-catalog discovery, ModifyPlan)
 //
-// Status: current. Last reviewed 2026-06-24.
+// Status: current. Last reviewed 2026-09-06.
 
 package account
 
@@ -19,6 +19,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -28,9 +29,11 @@ import (
 )
 
 // Create creates a Jamf Pro admin account via the Pro API, then (for a Custom +
-// Full Access account) writes the privilege grid via the classic API. If the
-// classic step fails, the just-created account is deleted so no half-built
-// account is left behind. Privileges are trusted from the plan (not re-read).
+// Full Access account) writes the privilege grid via the classic API through
+// writeCustomPrivileges, which merges against whatever grid the new account
+// already carries. If the classic step fails, the just-created account is
+// deleted so no half-built account is left behind. Privileges are trusted from
+// the plan (not re-read).
 func (r *AccountResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var plan, cfg AccountResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
@@ -60,21 +63,15 @@ func (r *AccountResource) Create(ctx context.Context, req resource.CreateRequest
 	id := plan.ID.ValueString()
 
 	if custPrivApplicable(plan.PrivilegeSet, plan.AccessLevel) {
-		classicInput, d := buildClassicPrivileges(createCtx, plan)
-		resp.Diagnostics.Append(d...)
-		if resp.Diagnostics.HasError() {
+		d := r.writeCustomPrivileges(createCtx, id, plan, "Error writing Jamf Pro account privileges")
+		if d.HasError() {
+			if delErr := r.proClient.DeleteAccountV1(createCtx, id); delErr != nil {
+				tflog.Error(ctx, "failed to roll back account after privilege write failure", map[string]any{"id": id, "delete_error": delErr.Error()})
+			}
+			resp.Diagnostics.Append(d...)
 			return
 		}
-		if classicInput != nil {
-			if err := r.classicClient.UpdateAccountByUserID(createCtx, id, classicInput); err != nil {
-				// Roll back the account so we do not leave a privilege-less husk.
-				if delErr := r.proClient.DeleteAccountV1(createCtx, id); delErr != nil {
-					tflog.Error(ctx, "failed to roll back account after privilege write failure", map[string]any{"id": id, "delete_error": delErr.Error()})
-				}
-				resp.Diagnostics.AddError("Error writing Jamf Pro account privileges", err.Error())
-				return
-			}
-		}
+		resp.Diagnostics.Append(d...)
 	}
 
 	got, err := r.proClient.GetAccountV1(createCtx, id)
@@ -182,9 +179,9 @@ func (r *AccountResource) Read(ctx context.Context, req resource.ReadRequest, re
 }
 
 // Update applies base-field changes via Pro PUT and Custom privilege changes via
-// the classic API. Each side is called only when its inputs actually changed, so
-// a privilege-only edit skips the Pro PUT and a base-only edit skips the classic
-// write.
+// the classic API through writeCustomPrivileges. Each side is called only when
+// it has something to send, so a privilege-only edit skips the Pro PUT and a
+// plan with no declared privilege category skips the classic write.
 func (r *AccountResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	var plan, state, cfg AccountResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
@@ -217,16 +214,9 @@ func (r *AccountResource) Update(ctx context.Context, req resource.UpdateRequest
 	}
 
 	if custPrivApplicable(plan.PrivilegeSet, plan.AccessLevel) {
-		classicInput, d := buildClassicPrivileges(updateCtx, plan)
-		resp.Diagnostics.Append(d...)
+		resp.Diagnostics.Append(r.writeCustomPrivileges(updateCtx, id, plan, "Error updating Jamf Pro account privileges")...)
 		if resp.Diagnostics.HasError() {
 			return
-		}
-		if classicInput != nil {
-			if err := r.classicClient.UpdateAccountByUserID(updateCtx, id, classicInput); err != nil {
-				resp.Diagnostics.AddError("Error updating Jamf Pro account privileges", err.Error())
-				return
-			}
 		}
 	}
 
@@ -272,6 +262,37 @@ func (r *AccountResource) Delete(ctx context.Context, req resource.DeleteRequest
 		}
 		resp.Diagnostics.AddError("Error deleting Jamf Pro account", fmt.Sprintf("API error: %v", err))
 	}
+}
+
+// writeCustomPrivileges sends the Custom privilege grid for account id through
+// the classic API as a read-merge-write: the live grid is read first and every
+// category the plan declares replaces the server's, while undeclared categories
+// are re-sent as the server holds them. That is what makes "omit a category and
+// the server keeps it" true — the endpoint replaces the whole grid on any sent
+// <privileges> (wire-probed 2026-09-06, Jamf Pro 11.31.1, issue #385), so a
+// partial body would empty the rest. Nothing is sent, and nothing read, when the
+// plan declares no category at all; the server then keeps its grid untouched.
+// errSummary is the diagnostic summary for a failed write, so Create and Update
+// read distinctly in the output.
+func (r *AccountResource) writeCustomPrivileges(ctx context.Context, id string, plan AccountResourceModel, errSummary string) diag.Diagnostics {
+	var diags diag.Diagnostics
+	if !managesPrivileges(plan) {
+		return diags
+	}
+	live, err := r.classicClient.GetAccountByUserID(ctx, id)
+	if err != nil {
+		diags.AddError("Error reading Jamf Pro account privileges before write", err.Error())
+		return diags
+	}
+	classicInput, d := buildClassicPrivileges(ctx, plan, live)
+	diags.Append(d...)
+	if diags.HasError() || classicInput == nil {
+		return diags
+	}
+	if err := r.classicClient.UpdateAccountByUserID(ctx, id, classicInput); err != nil {
+		diags.AddError(errSummary, err.Error())
+	}
+	return diags
 }
 
 // baseFieldsChanged reports whether any Pro-owned base field differs between

--- a/internal/resources/pro/account/input_builders.go
+++ b/internal/resources/pro/account/input_builders.go
@@ -84,22 +84,38 @@ func boolOrDefault(v types.Bool, def bool) *bool {
 }
 
 // buildClassicPrivileges projects the Custom privilege grid into a ProClassic
-// Account payload carrying only <privileges>. The classic PUT merges, so other
-// account fields are intentionally omitted (they are owned by the Pro side).
+// Account payload carrying only <privileges>. The classic PUT merges at the top
+// level, so other account fields are intentionally omitted (they are owned by
+// the Pro side). Inside <privileges> it does not merge: a sent element replaces
+// the whole grid (wire-probed 2026-09-06, Jamf Pro 11.31.1, issue #385), so the
+// grid is built by accountprivileges.MergeGrid from live, the account as the
+// classic endpoint currently returns it, replacing only the declared categories
+// and carrying the rest verbatim. live may be nil when nothing has been read.
 // Returns nil when there are no privileges to send.
-func buildClassicPrivileges(ctx context.Context, plan AccountResourceModel) (*proclassic.Account, diag.Diagnostics) {
+func buildClassicPrivileges(ctx context.Context, plan AccountResourceModel, live *proclassic.Account) (*proclassic.Account, diag.Diagnostics) {
 	var diags diag.Diagnostics
-	if plan.Privileges == nil || plan.Privileges.IsEmpty() {
+	if !managesPrivileges(plan) {
 		return nil, diags
 	}
-	privMap, d := plan.Privileges.ToMap(ctx)
+	var serverGrid map[string][]string
+	if live != nil {
+		serverGrid = accountprivileges.FromAccountPrivileges(live.Privileges)
+	}
+	merged, d := accountprivileges.MergeGrid(ctx, plan.Privileges, serverGrid)
 	diags.Append(d...)
 	if diags.HasError() {
 		return nil, diags
 	}
-	grid := accountprivileges.ToAccountPrivileges(privMap)
+	grid := accountprivileges.ToAccountPrivileges(merged)
 	if grid == nil {
 		return nil, diags
 	}
 	return &proclassic.Account{Privileges: grid}, diags
+}
+
+// managesPrivileges reports whether the plan declares at least one privilege
+// category. When false no classic write is issued and the server keeps its
+// grid, which is the one retention the wire does provide.
+func managesPrivileges(plan AccountResourceModel) bool {
+	return plan.Privileges != nil && !plan.Privileges.IsEmpty()
 }

--- a/internal/resources/pro/account/resource_acceptance_test.go
+++ b/internal/resources/pro/account/resource_acceptance_test.go
@@ -367,31 +367,22 @@ func accountRetainedOnServer(t *testing.T) resource.TestCheckFunc {
 // Pro side sees no base-field change. Each step's implicit post-apply plan must
 // be empty, which is what makes the contract usable.
 //
-// Step 2 fails today, and the failure is the resource's, not the server's: it
-// builds the <privileges> element through the same accountprivileges.ToMap
-// per-category omission as jamfplatform_pro_account_group, and the server
-// treats a sent <privileges> as a whole-grid replace, so the two undeclared
-// categories are emptied while Read's null-means-unmanaged gate hides the loss
-// (issue #385). Wire-probed 2026-09-06 on Jamf Pro 11.31.1 through the SDK: a
-// PUT /accounts/userid/{id} carrying only <jss_objects> left jss_settings as
-// the server-injected "Read License Information" alone and jss_actions empty.
-// The whole-block omission in step 3 retains correctly, verified by running
-// the steps in the order full, header-only, objects-only: the header-only step
-// issued no classic PUT, the post-apply plan was empty and every step-1 value
-// survived. The test stays written as the contract the resource claims, and
-// skips until #385 is fixed, so that the fix is proven by deleting the skip
-// rather than by rewriting the assertion.
-// skipUntilPrivilegeCategoryMergeIsFixed gates the omit-retains test on issue
-// #385. Delete this function, and the call to it, when the resource either
-// emulates the category-level retention it promises or stops promising it.
-func skipUntilPrivilegeCategoryMergeIsFixed(t *testing.T) {
-	t.Helper()
-	t.Skip("jamfplatform_pro_account sends a partial <privileges> that the server treats as a full replace, wiping undeclared categories; see issue #385")
-}
-
+// Step 2 is the step the wire cannot satisfy on its own. Wire-probed 2026-09-06
+// on Jamf Pro 11.31.1 through the SDK: a PUT /accounts/userid/{id} carrying only
+// <jss_objects> left jss_settings as the server-injected "Read License
+// Information" alone and jss_actions empty — the server treats a sent
+// <privileges> as a whole-grid replace, and Read's null-means-unmanaged gate
+// hid the loss (issue #385). The resource now emulates the retention it
+// documents — every privilege write reads the live grid first and re-emits the
+// undeclared categories through accountprivileges.MergeGrid — and this step is
+// the proof: the server-side check after step 2 must still find "Read SMTP
+// Server" and the remote-lock action that only the carry-over could have sent.
+// The whole-block omission in step 3 retains on the wire itself, verified by
+// running the steps in the order full, header-only, objects-only: the
+// header-only step issued no classic PUT, the post-apply plan was empty and
+// every step-1 value survived.
 func TestAccResource_ProAccount_OmittedBlocksRetained(t *testing.T) {
 	testhelpers.AccPreCheck(t)
-	skipUntilPrivilegeCategoryMergeIsFixed(t)
 	suffix := testhelpers.RunSuffix()
 
 	resource.Test(t, resource.TestCase{

--- a/internal/resources/pro/account/resource_acceptance_test.go
+++ b/internal/resources/pro/account/resource_acceptance_test.go
@@ -13,10 +13,12 @@ package account_test
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 	"testing"
 
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/pro"
+	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/proclassic"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
@@ -201,6 +203,228 @@ func TestAccResource_ProAccount_BaseUpdate(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("jamfplatform_pro_account.test", "password_wo_version", "2"),
 					resource.TestCheckResourceAttr("jamfplatform_pro_account.test", "full_name", "TF Acc Base Renamed"),
+				),
+			},
+		},
+	})
+}
+
+const accountOmitRetainsAddr = "jamfplatform_pro_account.omit"
+
+// accountOmitRetainsConfig is the fully declared shape for the omit-retains
+// contract: three privilege categories plus the Optional+Computed site_id and
+// force_password_change, each carrying a distinctive value so a server that
+// stopped retaining an omitted element is caught on content, not presence.
+func accountOmitRetainsConfig(suffix string) string {
+	return fmt.Sprintf(`
+resource "jamfplatform_pro_account" "omit" {
+  username      = "tf-acc-acct-omit-%[1]s"
+  full_name     = "TF Acc Account Omit"
+  email_address = "tf-acc-acct-omit-%[1]s@example.invalid"
+  access_level  = "Full Access"
+  privilege_set = "Custom"
+
+  site_id               = -1
+  force_password_change = true
+
+  password            = "Pr0bePassw0rd-%[1]s"
+  password_wo_version = 1
+
+  privileges = {
+    jamf_pro_server_objects  = ["Read Buildings", "Read Departments"]
+    jamf_pro_server_settings = ["Read SMTP Server"]
+    jamf_pro_server_actions  = ["Send Computer Remote Lock Command"]
+  }
+}
+`, suffix)
+}
+
+// accountOmitRetainsObjectsOnlyConfig keeps the privileges block but declares
+// only jamf_pro_server_objects, and drops site_id and force_password_change, so
+// the classic PUT carries a <privileges> element missing two categories and the
+// Pro side is not written at all.
+func accountOmitRetainsObjectsOnlyConfig(suffix string) string {
+	return fmt.Sprintf(`
+resource "jamfplatform_pro_account" "omit" {
+  username      = "tf-acc-acct-omit-%[1]s"
+  full_name     = "TF Acc Account Omit"
+  email_address = "tf-acc-acct-omit-%[1]s@example.invalid"
+  access_level  = "Full Access"
+  privilege_set = "Custom"
+
+  password            = "Pr0bePassw0rd-%[1]s"
+  password_wo_version = 1
+
+  privileges = {
+    jamf_pro_server_objects = ["Read Buildings", "Read Departments"]
+  }
+}
+`, suffix)
+}
+
+// accountOmitRetainsHeaderOnlyConfig drops every optional block, so no classic
+// PUT is issued at all and the Pro side sees no base-field change.
+func accountOmitRetainsHeaderOnlyConfig(suffix string) string {
+	return fmt.Sprintf(`
+resource "jamfplatform_pro_account" "omit" {
+  username      = "tf-acc-acct-omit-%[1]s"
+  full_name     = "TF Acc Account Omit"
+  email_address = "tf-acc-acct-omit-%[1]s@example.invalid"
+  access_level  = "Full Access"
+  privilege_set = "Custom"
+
+  password            = "Pr0bePassw0rd-%[1]s"
+  password_wo_version = 1
+}
+`, suffix)
+}
+
+// hasPrivilege reports whether a classic privilege category carries want. The
+// server silently expands a submitted grid with dependency privileges, so the
+// retained-on-server assertion is containment, never equality.
+func hasPrivilege(category *[]string, want string) bool {
+	if category == nil {
+		return false
+	}
+	return slices.Contains(*category, want)
+}
+
+// privilegeList renders a classic privilege category for a diagnostic, so a
+// missing category reads as "absent" rather than a struct pointer.
+func privilegeList[T any](category *T, privileges func(*T) *[]string) []string {
+	if category == nil {
+		return nil
+	}
+	return testhelpers.Deref(privileges(category))
+}
+
+// liveAccount is the server's copy of an account read from both sides the
+// resource writes: the classic /accounts/userid object carries the privilege
+// grid and force_password_change, while site is reported only by Pro v1 (the
+// classic response for a Full Access account carries no <site> element,
+// wire-observed 2026-09-06 on Jamf Pro 11.31.1).
+type liveAccount struct {
+	classic *proclassic.Account
+	base    *pro.UserAccount
+}
+
+// accountRetainedOnServer asserts the server's copy still carries every
+// privilege, the forced password change and the site the omit-retains config
+// declared in its first step.
+func accountRetainedOnServer(t *testing.T) resource.TestCheckFunc {
+	sdk := testhelpers.NewAcceptanceClient(t)
+	classic := proclassic.New(sdk)
+	base := pro.New(sdk)
+	return testhelpers.CheckLiveObject(accountOmitRetainsAddr,
+		func(ctx context.Context, id string) (liveAccount, error) {
+			c, err := classic.GetAccountByUserID(ctx, id)
+			if err != nil {
+				return liveAccount{}, err
+			}
+			b, err := base.GetAccountV1(ctx, id)
+			if err != nil {
+				return liveAccount{}, err
+			}
+			return liveAccount{classic: c, base: b}, nil
+		},
+		func(got liveAccount) error {
+			a := got.classic
+			if a.Privileges == nil {
+				return fmt.Errorf("privileges: absent")
+			}
+			if a.Privileges.JssObjects == nil {
+				return fmt.Errorf("privileges.jamf_pro_server_objects: absent")
+			}
+			for _, want := range []string{"Read Buildings", "Read Departments"} {
+				if !hasPrivilege(a.Privileges.JssObjects.Privilege, want) {
+					return fmt.Errorf("privileges.jamf_pro_server_objects: want %q, got %v", want, testhelpers.Deref(a.Privileges.JssObjects.Privilege))
+				}
+			}
+			if a.Privileges.JssSettings == nil || !hasPrivilege(a.Privileges.JssSettings.Privilege, "Read SMTP Server") {
+				return fmt.Errorf("privileges.jamf_pro_server_settings: want %q, got %v", "Read SMTP Server", privilegeList(a.Privileges.JssSettings, func(c *proclassic.AccountPrivilegesJssSettings) *[]string { return c.Privilege }))
+			}
+			if a.Privileges.JssActions == nil || !hasPrivilege(a.Privileges.JssActions.Privilege, "Send Computer Remote Lock Command") {
+				return fmt.Errorf("privileges.jamf_pro_server_actions: want %q, got %v", "Send Computer Remote Lock Command", privilegeList(a.Privileges.JssActions, func(c *proclassic.AccountPrivilegesJssActions) *[]string { return c.Privilege }))
+			}
+			if err := testhelpers.RequireEqual("force_password_change", true, testhelpers.Deref(a.ForcePasswordChange)); err != nil {
+				return err
+			}
+			if got.base.SiteID == nil {
+				return fmt.Errorf("site_id: absent")
+			}
+			return testhelpers.RequireEqual("site_id", -1, *got.base.SiteID)
+		})
+}
+
+// TestAccResource_ProAccount_OmittedBlocksRetained pins the omit-retains
+// contract the plan output cannot show: dropping two privilege categories, the
+// Optional+Computed site_id and force_password_change, and finally the whole
+// privileges block from config plans them as removed, but the classic
+// /accounts/userid PUT omits the elements and the server keeps every value.
+// Step 2 keeps the privileges block with one category so the PUT carries a
+// partial <privileges>, exercising the category-level merge the resource
+// documents; step 3 drops privileges too so no classic write is issued and the
+// Pro side sees no base-field change. Each step's implicit post-apply plan must
+// be empty, which is what makes the contract usable.
+//
+// Step 2 fails today, and the failure is the resource's, not the server's: it
+// builds the <privileges> element through the same accountprivileges.ToMap
+// per-category omission as jamfplatform_pro_account_group, and the server
+// treats a sent <privileges> as a whole-grid replace, so the two undeclared
+// categories are emptied while Read's null-means-unmanaged gate hides the loss
+// (issue #385). Wire-probed 2026-09-06 on Jamf Pro 11.31.1 through the SDK: a
+// PUT /accounts/userid/{id} carrying only <jss_objects> left jss_settings as
+// the server-injected "Read License Information" alone and jss_actions empty.
+// The whole-block omission in step 3 retains correctly, verified by running
+// the steps in the order full, header-only, objects-only: the header-only step
+// issued no classic PUT, the post-apply plan was empty and every step-1 value
+// survived. The test stays written as the contract the resource claims, and
+// skips until #385 is fixed, so that the fix is proven by deleting the skip
+// rather than by rewriting the assertion.
+// skipUntilPrivilegeCategoryMergeIsFixed gates the omit-retains test on issue
+// #385. Delete this function, and the call to it, when the resource either
+// emulates the category-level retention it promises or stops promising it.
+func skipUntilPrivilegeCategoryMergeIsFixed(t *testing.T) {
+	t.Helper()
+	t.Skip("jamfplatform_pro_account sends a partial <privileges> that the server treats as a full replace, wiping undeclared categories; see issue #385")
+}
+
+func TestAccResource_ProAccount_OmittedBlocksRetained(t *testing.T) {
+	testhelpers.AccPreCheck(t)
+	skipUntilPrivilegeCategoryMergeIsFixed(t)
+	suffix := testhelpers.RunSuffix()
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testhelpers.AccTestProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckAccountDestroy(t),
+		Steps: []resource.TestStep{
+			{
+				Config: accountOmitRetainsConfig(suffix),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(accountOmitRetainsAddr, "privileges.jamf_pro_server_objects.#", "2"),
+					resource.TestCheckResourceAttr(accountOmitRetainsAddr, "privileges.jamf_pro_server_settings.#", "1"),
+					resource.TestCheckResourceAttr(accountOmitRetainsAddr, "privileges.jamf_pro_server_actions.#", "1"),
+					resource.TestCheckResourceAttr(accountOmitRetainsAddr, "force_password_change", "true"),
+					resource.TestCheckResourceAttr(accountOmitRetainsAddr, "site_id", "-1"),
+					accountRetainedOnServer(t),
+				),
+			},
+			{
+				Config: accountOmitRetainsObjectsOnlyConfig(suffix),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr(accountOmitRetainsAddr, "privileges.jamf_pro_server_settings.#"),
+					resource.TestCheckNoResourceAttr(accountOmitRetainsAddr, "privileges.jamf_pro_server_actions.#"),
+					resource.TestCheckResourceAttr(accountOmitRetainsAddr, "privileges.jamf_pro_server_objects.#", "2"),
+					resource.TestCheckResourceAttr(accountOmitRetainsAddr, "force_password_change", "true"),
+					resource.TestCheckResourceAttr(accountOmitRetainsAddr, "site_id", "-1"),
+					accountRetainedOnServer(t),
+				),
+			},
+			{
+				Config: accountOmitRetainsHeaderOnlyConfig(suffix),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr(accountOmitRetainsAddr, "privileges.jamf_pro_server_objects.#"),
+					accountRetainedOnServer(t),
 				),
 			},
 		},

--- a/internal/resources/pro/account_group/crud.go
+++ b/internal/resources/pro/account_group/crud.go
@@ -4,13 +4,13 @@
 // SDK endpoints used (Pro v1 /account-groups is read-only AND gateway-blocked,
 // so every surface — resource, data source, list — goes through ProClassic):
 //   proclassic.CreateAccountGroupByID   (POST id="0")
-//   proclassic.GetAccountGroupByID      (read; data source id lookup; list expand)
+//   proclassic.GetAccountGroupByID      (read; data source id lookup; list expand; live grid before an Update that sends <privileges>)
 //   proclassic.GetAccountGroupByName    (data source name lookup)
-//   proclassic.UpdateAccountGroupByID   (PUT, 201 empty body)
+//   proclassic.UpdateAccountGroupByID   (PUT, 201 empty body; a sent <privileges> replaces the whole grid — merged client-side)
 //   proclassic.DeleteAccountGroupByID
 //   proclassic.ListAccounts             (list-resource enumeration; privilege-catalog discovery in ModifyPlan)
 //
-// Status: current. Last reviewed 2026-06-24.
+// Status: current. Last reviewed 2026-09-06.
 
 package account_group
 
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/proclassic"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
@@ -42,7 +43,7 @@ func (r *AccountGroupResource) Create(ctx context.Context, req resource.CreateRe
 	createCtx, cancel := context.WithTimeout(ctx, createTimeout)
 	defer cancel()
 
-	input, diags := buildAccountGroupInput(createCtx, plan)
+	input, diags := buildAccountGroupInput(createCtx, plan, nil)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -161,9 +162,14 @@ func (r *AccountGroupResource) Read(ctx context.Context, req resource.ReadReques
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
-// Update updates a Jamf Pro account group. UpdateAccountGroupByID returns 201
-// with an empty body — GET to refresh server-derived base fields; privileges
-// and members are trusted from the plan.
+// Update updates a Jamf Pro account group. When the plan declares privileges
+// the live group is read first and the PUT carries the full grid merged by
+// accountprivileges.MergeGrid — the classic endpoint replaces the whole grid on
+// any sent <privileges>, so undeclared categories must be re-emitted from the
+// server to survive (issue #385). The merged grid is wire-only; state is set
+// from the plan, which keeps only the declared categories. UpdateAccountGroupByID
+// returns 201 with an empty body — GET to refresh server-derived base fields;
+// privileges and members are trusted from the plan.
 func (r *AccountGroupResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	var plan AccountGroupResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
@@ -179,7 +185,17 @@ func (r *AccountGroupResource) Update(ctx context.Context, req resource.UpdateRe
 	updateCtx, cancel := context.WithTimeout(ctx, updateTimeout)
 	defer cancel()
 
-	input, diags := buildAccountGroupInput(updateCtx, plan)
+	var live *proclassic.Group
+	if managesPrivileges(plan) {
+		current, err := r.client.GetAccountGroupByID(updateCtx, plan.ID.ValueString())
+		if err != nil {
+			resp.Diagnostics.AddError("Error reading Jamf Pro account group before update", err.Error())
+			return
+		}
+		live = current
+	}
+
+	input, diags := buildAccountGroupInput(updateCtx, plan, live)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/resources/pro/account_group/input_builders.go
+++ b/internal/resources/pro/account_group/input_builders.go
@@ -14,12 +14,17 @@ import (
 )
 
 // buildAccountGroupInput converts the Terraform plan into an SDK Group payload.
-// The classic /accounts/groupid PUT is a category-level merge: fields and
-// privilege categories that are not sent are retained, so null members /
-// null privilege categories are omitted (retained) and an explicitly empty
-// members set clears membership. Privileges are only emitted when the privilege
-// set is Custom (Jamf Pro ignores them otherwise).
-func buildAccountGroupInput(ctx context.Context, plan AccountGroupResourceModel) (*proclassic.Group, diag.Diagnostics) {
+// The classic /accounts/groupid PUT merges at the top level only: an element
+// that is not sent is retained, so null members are omitted (retained) and an
+// explicitly empty members set clears membership. Inside <privileges> there is
+// no merge — a sent element replaces the whole grid (wire-probed 2026-09-06,
+// Jamf Pro 11.31.1, issue #385) — so when the plan declares privileges the grid
+// is built by accountprivileges.MergeGrid from the live group's grid, replacing
+// only the declared categories and carrying the rest verbatim. live is the
+// group as the server currently holds it and may be nil on Create, where nothing
+// exists to carry. Privileges are only emitted when the privilege set is Custom
+// (Jamf Pro ignores them otherwise).
+func buildAccountGroupInput(ctx context.Context, plan AccountGroupResourceModel, live *proclassic.Group) (*proclassic.Group, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
 	group := &proclassic.Group{
@@ -51,15 +56,26 @@ func buildAccountGroupInput(ctx context.Context, plan AccountGroupResourceModel)
 		group.Members = &proclassic.GroupMembers{User: &users}
 	}
 
-	// Privileges: only when Custom and the block is present with content.
-	if plan.PrivilegeSet.ValueString() == proclassic.GroupPrivilegeSetCustom && plan.Privileges != nil && !plan.Privileges.IsEmpty() {
-		privMap, d := plan.Privileges.ToMap(ctx)
+	if managesPrivileges(plan) {
+		var serverGrid map[string][]string
+		if live != nil {
+			serverGrid = accountprivileges.FromGroupPrivileges(live.Privileges)
+		}
+		merged, d := accountprivileges.MergeGrid(ctx, plan.Privileges, serverGrid)
 		diags.Append(d...)
 		if diags.HasError() {
 			return nil, diags
 		}
-		group.Privileges = accountprivileges.ToGroupPrivileges(privMap)
+		group.Privileges = accountprivileges.ToGroupPrivileges(merged)
 	}
 
 	return group, diags
+}
+
+// managesPrivileges reports whether the plan will send a <privileges> element:
+// the group is Custom and the block is present with at least one declared
+// category. When false the element is omitted and the server keeps its grid,
+// which is the one retention the wire does provide.
+func managesPrivileges(plan AccountGroupResourceModel) bool {
+	return plan.PrivilegeSet.ValueString() == proclassic.GroupPrivilegeSetCustom && plan.Privileges != nil && !plan.Privileges.IsEmpty()
 }

--- a/internal/resources/pro/account_group/resource_acceptance_test.go
+++ b/internal/resources/pro/account_group/resource_acceptance_test.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -209,6 +210,230 @@ func TestAccResource_ProAccountGroup_Members(t *testing.T) {
 				Config: accountGroupMembersConfig(name, suffix, false),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("jamfplatform_pro_account_group.members", "members.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+const accountGroupOmitRetainsAddr = "jamfplatform_pro_account_group.omit"
+
+// accountGroupOmitRetainsFixture is the jamfplatform_pro_account member every
+// step of the omit-retains test carries, so the account is created once and
+// outlives the group. It mirrors the proven accountGroupMembersConfig shape.
+// The steps that stop managing members keep the fixture through depends_on,
+// which also orders the destroy (group first, account second) so a member is
+// never deleted out from under a group that still lists it.
+func accountGroupOmitRetainsFixture(suffix string) string {
+	return fmt.Sprintf(`
+resource "jamfplatform_pro_account" "omit_member" {
+  username      = "tf-acc-ag-omit-%[1]s"
+  full_name     = "TF Acc AG Omit Member"
+  email_address = "tf-acc-ag-omit-%[1]s@example.invalid"
+  access_level  = "Full Access"
+  privilege_set = "Custom"
+
+  password            = "Pr0bePassw0rd-%[1]s"
+  password_wo_version = 1
+
+  privileges = {
+    jamf_pro_server_objects = ["Read Computers"]
+  }
+}
+`, suffix)
+}
+
+// accountGroupOmitRetainsConfig is the fully declared shape for the omit-retains
+// contract: three privilege categories, a managed member and the
+// Optional+Computed site_id, each carrying a distinctive value so a server that
+// stopped retaining an omitted element is caught on content, not presence.
+func accountGroupOmitRetainsConfig(name, suffix string) string {
+	return accountGroupOmitRetainsFixture(suffix) + fmt.Sprintf(`
+resource "jamfplatform_pro_account_group" "omit" {
+  display_name  = %q
+  access_level  = "Full Access"
+  privilege_set = "Custom"
+  site_id       = -1
+  members       = [jamfplatform_pro_account.omit_member.id]
+
+  privileges = {
+    jamf_pro_server_objects  = ["Read Buildings", "Read Departments"]
+    jamf_pro_server_settings = ["Read SMTP Server"]
+    jamf_pro_server_actions  = ["Send Computer Remote Lock Command"]
+  }
+}
+`, name)
+}
+
+// accountGroupOmitRetainsObjectsOnlyConfig keeps the privileges block but
+// declares only jamf_pro_server_objects, and drops members and site_id, so the
+// PUT carries a <privileges> element missing two categories and no <members>.
+func accountGroupOmitRetainsObjectsOnlyConfig(name, suffix string) string {
+	return accountGroupOmitRetainsFixture(suffix) + fmt.Sprintf(`
+resource "jamfplatform_pro_account_group" "omit" {
+  display_name  = %q
+  access_level  = "Full Access"
+  privilege_set = "Custom"
+
+  privileges = {
+    jamf_pro_server_objects = ["Read Buildings", "Read Departments"]
+  }
+
+  depends_on = [jamfplatform_pro_account.omit_member]
+}
+`, name)
+}
+
+// accountGroupOmitRetainsHeaderOnlyConfig drops every optional attribute, so the
+// PUT carries the three required scalars alone.
+func accountGroupOmitRetainsHeaderOnlyConfig(name, suffix string) string {
+	return accountGroupOmitRetainsFixture(suffix) + fmt.Sprintf(`
+resource "jamfplatform_pro_account_group" "omit" {
+  display_name  = %q
+  access_level  = "Full Access"
+  privilege_set = "Custom"
+
+  depends_on = [jamfplatform_pro_account.omit_member]
+}
+`, name)
+}
+
+// hasPrivilege reports whether a classic privilege category carries want. The
+// server silently expands a submitted grid with dependency privileges, so the
+// retained-on-server assertion is containment, never equality.
+func hasPrivilege(category *[]string, want string) bool {
+	if category == nil {
+		return false
+	}
+	for _, p := range *category {
+		if p == want {
+			return true
+		}
+	}
+	return false
+}
+
+// privilegeList renders a classic privilege category for a diagnostic, so a
+// missing category reads as "absent" rather than a struct pointer.
+func privilegeList[T any](category *T, privileges func(*T) *[]string) []string {
+	if category == nil {
+		return nil
+	}
+	return testhelpers.Deref(privileges(category))
+}
+
+// accountGroupRetainedOnServer asserts the server's copy still carries every
+// privilege and the member the omit-retains config declared in its first step.
+// The member's id is read from the fixture's state entry because the classic
+// response identifies members by account id, not by the group.
+func accountGroupRetainedOnServer(t *testing.T) resource.TestCheckFunc {
+	c := proclassic.New(testhelpers.NewAcceptanceClient(t))
+	return func(s *terraform.State) error {
+		member, ok := s.RootModule().Resources["jamfplatform_pro_account.omit_member"]
+		if !ok {
+			return fmt.Errorf("member fixture jamfplatform_pro_account.omit_member not found in state")
+		}
+		wantMember, err := strconv.Atoi(member.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("member fixture id %q is not an integer: %w", member.Primary.ID, err)
+		}
+		return testhelpers.CheckLiveObject(accountGroupOmitRetainsAddr,
+			func(ctx context.Context, id string) (*proclassic.Group, error) {
+				return c.GetAccountGroupByID(ctx, id)
+			},
+			func(g *proclassic.Group) error {
+				if g.Privileges == nil {
+					return fmt.Errorf("privileges: absent")
+				}
+				if g.Privileges.JssObjects == nil {
+					return fmt.Errorf("privileges.jamf_pro_server_objects: absent")
+				}
+				for _, want := range []string{"Read Buildings", "Read Departments"} {
+					if !hasPrivilege(g.Privileges.JssObjects.Privilege, want) {
+						return fmt.Errorf("privileges.jamf_pro_server_objects: want %q, got %v", want, testhelpers.Deref(g.Privileges.JssObjects.Privilege))
+					}
+				}
+				if g.Privileges.JssSettings == nil || !hasPrivilege(g.Privileges.JssSettings.Privilege, "Read SMTP Server") {
+					return fmt.Errorf("privileges.jamf_pro_server_settings: want %q, got %v", "Read SMTP Server", privilegeList(g.Privileges.JssSettings, func(c *proclassic.GroupPrivilegesJssSettings) *[]string { return c.Privilege }))
+				}
+				if g.Privileges.JssActions == nil || !hasPrivilege(g.Privileges.JssActions.Privilege, "Send Computer Remote Lock Command") {
+					return fmt.Errorf("privileges.jamf_pro_server_actions: want %q, got %v", "Send Computer Remote Lock Command", privilegeList(g.Privileges.JssActions, func(c *proclassic.GroupPrivilegesJssActions) *[]string { return c.Privilege }))
+				}
+				if g.Members == nil || g.Members.User == nil || len(*g.Members.User) != 1 {
+					return fmt.Errorf("members: want exactly one member, got %+v", g.Members)
+				}
+				if err := testhelpers.RequireEqual("members[0].id", wantMember, testhelpers.Deref((*g.Members.User)[0].ID)); err != nil {
+					return err
+				}
+				if g.Site == nil {
+					return fmt.Errorf("site: absent")
+				}
+				return testhelpers.RequireEqual("site.id", -1, testhelpers.Deref(g.Site.ID))
+			})(s)
+	}
+}
+
+// TestAccResource_ProAccountGroup_OmittedBlocksRetained pins the omit-retains
+// contract the plan output cannot show: dropping members, two privilege
+// categories, and finally the whole privileges block from config plans them as
+// removed, but the classic /accounts/groupid PUT omits the elements and the
+// server keeps every value. Step 2 keeps the privileges block with one category
+// so the PUT carries a partial <privileges>, exercising the category-level
+// merge the resource documents; step 3 drops privileges too so the PUT carries
+// the header alone. Each step's implicit post-apply plan must be empty, which
+// is what makes the contract usable.
+//
+// Step 2 fails today, and the failure is the resource's, not the server's:
+// wire-probed 2026-09-06 on Jamf Pro 11.31.1, a sent <privileges> replaces the
+// whole grid, so the two undeclared categories are emptied while Read's
+// null-means-unmanaged gate hides the loss (issue #385). The whole-block
+// omission in step 3 and the members omission both retain correctly. The test
+// stays written as the contract the resource claims, and skips until #385 is
+// fixed, so that the fix is proven by deleting the skip rather than by
+// rewriting the assertion.
+// skipUntilPrivilegeCategoryMergeIsFixed gates the omit-retains test on issue
+// #385. Delete this function, and the call to it, when the resource either
+// emulates the category-level retention it promises or stops promising it.
+func skipUntilPrivilegeCategoryMergeIsFixed(t *testing.T) {
+	t.Helper()
+	t.Skip("jamfplatform_pro_account_group sends a partial <privileges> that the server treats as a full replace, wiping undeclared categories; see issue #385")
+}
+
+func TestAccResource_ProAccountGroup_OmittedBlocksRetained(t *testing.T) {
+	testhelpers.AccPreCheck(t)
+	skipUntilPrivilegeCategoryMergeIsFixed(t)
+	suffix := testhelpers.RunSuffix()
+	name := "tf-acc-account-group-omit-" + suffix
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testhelpers.AccTestProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckAccountGroupDestroy(t),
+		Steps: []resource.TestStep{
+			{
+				Config: accountGroupOmitRetainsConfig(name, suffix),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(accountGroupOmitRetainsAddr, "members.#", "1"),
+					resource.TestCheckResourceAttr(accountGroupOmitRetainsAddr, "privileges.jamf_pro_server_settings.#", "1"),
+					resource.TestCheckResourceAttr(accountGroupOmitRetainsAddr, "privileges.jamf_pro_server_actions.#", "1"),
+					accountGroupRetainedOnServer(t),
+				),
+			},
+			{
+				Config: accountGroupOmitRetainsObjectsOnlyConfig(name, suffix),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr(accountGroupOmitRetainsAddr, "members.#"),
+					resource.TestCheckNoResourceAttr(accountGroupOmitRetainsAddr, "privileges.jamf_pro_server_settings.#"),
+					resource.TestCheckNoResourceAttr(accountGroupOmitRetainsAddr, "privileges.jamf_pro_server_actions.#"),
+					resource.TestCheckResourceAttr(accountGroupOmitRetainsAddr, "privileges.jamf_pro_server_objects.#", "2"),
+					resource.TestCheckResourceAttr(accountGroupOmitRetainsAddr, "site_id", "-1"),
+					accountGroupRetainedOnServer(t),
+				),
+			},
+			{
+				Config: accountGroupOmitRetainsHeaderOnlyConfig(name, suffix),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr(accountGroupOmitRetainsAddr, "privileges.jamf_pro_server_objects.#"),
+					accountGroupRetainedOnServer(t),
 				),
 			},
 		},

--- a/internal/resources/pro/account_group/resource_acceptance_test.go
+++ b/internal/resources/pro/account_group/resource_acceptance_test.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -305,12 +306,7 @@ func hasPrivilege(category *[]string, want string) bool {
 	if category == nil {
 		return false
 	}
-	for _, p := range *category {
-		if p == want {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(*category, want)
 }
 
 // privilegeList renders a classic privilege category for a diagnostic, so a

--- a/internal/resources/pro/account_group/resource_acceptance_test.go
+++ b/internal/resources/pro/account_group/resource_acceptance_test.go
@@ -379,25 +379,17 @@ func accountGroupRetainedOnServer(t *testing.T) resource.TestCheckFunc {
 // the header alone. Each step's implicit post-apply plan must be empty, which
 // is what makes the contract usable.
 //
-// Step 2 fails today, and the failure is the resource's, not the server's:
-// wire-probed 2026-09-06 on Jamf Pro 11.31.1, a sent <privileges> replaces the
-// whole grid, so the two undeclared categories are emptied while Read's
-// null-means-unmanaged gate hides the loss (issue #385). The whole-block
-// omission in step 3 and the members omission both retain correctly. The test
-// stays written as the contract the resource claims, and skips until #385 is
-// fixed, so that the fix is proven by deleting the skip rather than by
-// rewriting the assertion.
-// skipUntilPrivilegeCategoryMergeIsFixed gates the omit-retains test on issue
-// #385. Delete this function, and the call to it, when the resource either
-// emulates the category-level retention it promises or stops promising it.
-func skipUntilPrivilegeCategoryMergeIsFixed(t *testing.T) {
-	t.Helper()
-	t.Skip("jamfplatform_pro_account_group sends a partial <privileges> that the server treats as a full replace, wiping undeclared categories; see issue #385")
-}
-
+// Step 2 is the step the wire cannot satisfy on its own: probed 2026-09-06 on
+// Jamf Pro 11.31.1, a sent <privileges> replaces the whole grid, so a partial
+// body empties the two undeclared categories while Read's null-means-unmanaged
+// gate hides the loss (issue #385). The resource now emulates the retention it
+// documents — Update reads the live grid and re-emits the undeclared categories
+// through accountprivileges.MergeGrid — and this step is the proof: the
+// server-side check after step 2 must still find "Read SMTP Server" and the
+// remote-lock action that only the carry-over could have sent. The whole-block
+// omission in step 3 and the members omission retain on the wire itself.
 func TestAccResource_ProAccountGroup_OmittedBlocksRetained(t *testing.T) {
 	testhelpers.AccPreCheck(t)
-	skipUntilPrivilegeCategoryMergeIsFixed(t)
 	suffix := testhelpers.RunSuffix()
 	name := "tf-acc-account-group-omit-" + suffix
 

--- a/internal/resources/pro/ebook/resource_acceptance_test.go
+++ b/internal/resources/pro/ebook/resource_acceptance_test.go
@@ -23,10 +23,13 @@
 package ebook_test
 
 import (
+	"context"
 	"fmt"
 	"regexp"
+	"strconv"
 	"testing"
 
+	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/proclassic"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
@@ -425,6 +428,396 @@ resource "jamfplatform_pro_ebook" "test" {
 				// ownership). Implicit post-step empty-plan enforces the round-trip.
 				Config: cfg(``),
 				Check:  resource.TestCheckResourceAttr(ebookResourceAddr, "scope.limitations.network_segment_ids.#", "0"),
+			},
+		},
+	})
+}
+
+// ebookOmitRetainsFixtures declares the tenant objects the omit-retains configs
+// reference: a department, building, static computer group and static mobile
+// device group for the targets tab, a network segment and a second department
+// and building for the exclusions tab, a network segment for the limitations
+// tab, and a category shared by general.category_id and the Self Service
+// category set. Every ID-keyed category the test covers therefore carries a
+// real, distinct member. The Platform device groups bridge to the classic
+// scope through jamf_pro_id. class_ids is not covered: there is no
+// jamfplatform_pro_class resource to mint a class id.
+func ebookOmitRetainsFixtures(suffix string) string {
+	return fmt.Sprintf(`
+		resource "jamfplatform_pro_category" "omit" {
+			name     = "tf-acc-ebook-omit-cat-%[1]s"
+			priority = 9
+		}
+
+		resource "jamfplatform_pro_department" "target" {
+			name = "tf-acc-ebook-omit-dept-target-%[1]s"
+		}
+
+		resource "jamfplatform_pro_department" "excluded" {
+			name = "tf-acc-ebook-omit-dept-excluded-%[1]s"
+		}
+
+		resource "jamfplatform_pro_building" "target" {
+			name = "tf-acc-ebook-omit-bldg-target-%[1]s"
+		}
+
+		resource "jamfplatform_pro_building" "excluded" {
+			name = "tf-acc-ebook-omit-bldg-excluded-%[1]s"
+		}
+
+		resource "jamfplatform_pro_network_segment" "limited" {
+			name             = "tf-acc-ebook-omit-seg-limited-%[1]s"
+			starting_address = "10.98.0.0"
+			ending_address   = "10.98.0.255"
+		}
+
+		resource "jamfplatform_pro_network_segment" "excluded" {
+			name             = "tf-acc-ebook-omit-seg-excluded-%[1]s"
+			starting_address = "10.98.1.0"
+			ending_address   = "10.98.1.255"
+		}
+
+		resource "jamfplatform_device_group" "computers" {
+			name        = "tf-acc-ebook-omit-computers-%[1]s"
+			description = "tf-acc omit-retains computer scope fixture"
+			group_type  = "static"
+			device_type = "computer"
+		}
+
+		resource "jamfplatform_device_group" "mobile" {
+			name        = "tf-acc-ebook-omit-mobile-%[1]s"
+			description = "tf-acc omit-retains mobile scope fixture"
+			group_type  = "static"
+			device_type = "mobile"
+		}
+	`, suffix)
+}
+
+// ebookOmitRetainsGeneral is the general block every omit-retains step shares.
+// It carries non-default Optional+Computed values (author, category_id) so the
+// wire check can tell a retained general from a defaulted one.
+func ebookOmitRetainsGeneral(name string) string {
+	return fmt.Sprintf(`
+			general = {
+				name            = %q
+				author          = "Omit Retains"
+				url             = "https://www.rd.usda.gov/sites/default/files/pdf-sample_0.pdf"
+				file_type       = "PDF"
+				version         = "1.0"
+				deployment_type = "Make Available in Self Service"
+				category_id     = jamfplatform_pro_category.omit.id
+			}
+	`, name)
+}
+
+// ebookOmitRetainsTargets is the scope.targets sub-block every omit-retains
+// step that declares a scope shares: the computer and mobile halves of the
+// dual-target union each carry a real group, plus a department and a building.
+const ebookOmitRetainsTargets = `
+				targets = {
+					department_ids          = [jamfplatform_pro_department.target.id]
+					building_ids            = [jamfplatform_pro_building.target.id]
+					computer_group_ids      = [jamfplatform_device_group.computers.jamf_pro_id]
+					mobile_device_group_ids = [jamfplatform_device_group.mobile.jamf_pro_id]
+				}
+`
+
+// ebookOmitRetainsConfig is the fully declared shape for the omit-retains
+// contract: all three scope tabs, a self_service block with every wire-echoed
+// leaf set to a distinctive value, and a Self Service category set, so a server that stopped
+// retaining an omitted element is caught on content, not on presence.
+func ebookOmitRetainsConfig(name, suffix string) string {
+	return ebookOmitRetainsFixtures(suffix) + `
+		resource "jamfplatform_pro_ebook" "test" {
+` + ebookOmitRetainsGeneral(name) + `
+			scope = {
+` + ebookOmitRetainsTargets + `
+				limitations = {
+					network_segment_ids                   = [jamfplatform_pro_network_segment.limited.id]
+					directory_service_or_local_user_names = ["tf-acc-omit-limited-user"]
+				}
+				exclusions = {
+					department_ids                        = [jamfplatform_pro_department.excluded.id]
+					building_ids                          = [jamfplatform_pro_building.excluded.id]
+					network_segment_ids                   = [jamfplatform_pro_network_segment.excluded.id]
+					directory_service_or_local_user_names = ["tf-acc-omit-excluded-user"]
+				}
+			}
+			self_service = {
+				display_name                    = "Omit-retains display name"
+				install_button_text             = "Retain me"
+				self_service_description        = "Omit-retains contract description."
+				force_users_to_view_description = true
+				feature_on_main_page            = true
+				categories = [
+					{ id = jamfplatform_pro_category.omit.id, display_in = true, feature_in = true }
+				]
+			}
+		}
+	`
+}
+
+// ebookOmitRetainsParentsOnlyConfig keeps the parents that have gated children
+// but drops the children: scope keeps targets and loses limitations and
+// exclusions, self_service loses its categories and the Optional+Computed
+// display_name. The PUT re-emits the scope from the granular merge with
+// the two dropped tabs folded in from the live object, and carries a
+// self_service element with no self_service_categories at all.
+func ebookOmitRetainsParentsOnlyConfig(name, suffix string) string {
+	return ebookOmitRetainsFixtures(suffix) + `
+		resource "jamfplatform_pro_ebook" "test" {
+` + ebookOmitRetainsGeneral(name) + `
+			scope = {
+` + ebookOmitRetainsTargets + `
+			}
+			self_service = {
+				install_button_text             = "Retain me"
+				self_service_description        = "Omit-retains contract description."
+				force_users_to_view_description = true
+				feature_on_main_page            = true
+			}
+		}
+	`
+}
+
+// ebookOmitRetainsGeneralOnlyConfig drops every optional block, so the PUT
+// carries <general> alone. The fixtures stay declared so the server's retained
+// scope and categories keep pointing at live objects, and depends_on keeps the
+// destroy order the dropped references no longer imply: the Platform
+// device-groups API refuses to delete a group the retained scope still names
+// (422 HAS_DEPENDENCIES), so the ebook must go before its groups.
+func ebookOmitRetainsGeneralOnlyConfig(name, suffix string) string {
+	return ebookOmitRetainsFixtures(suffix) + `
+		resource "jamfplatform_pro_ebook" "test" {
+			depends_on = [jamfplatform_device_group.computers, jamfplatform_device_group.mobile]
+` + ebookOmitRetainsGeneral(name) + `
+		}
+	`
+}
+
+// ebookStateAttr returns one attribute of a resource in the Terraform state, so
+// a wire assertion can compare against the id a fixture was actually allocated.
+func ebookStateAttr(s *terraform.State, addr, key string) (string, error) {
+	rs, ok := s.RootModule().Resources[addr]
+	if !ok {
+		return "", fmt.Errorf("fixture %s not found in state", addr)
+	}
+	v, ok := rs.Primary.Attributes[key]
+	if !ok || v == "" {
+		return "", fmt.Errorf("fixture %s has no %s in state", addr, key)
+	}
+	return v, nil
+}
+
+// ebookRequireSingleIDName asserts a classic id/name collection holds exactly
+// one member carrying the wanted id.
+func ebookRequireSingleIDName(field, want string, items *[]proclassic.IDName) error {
+	if items == nil || len(*items) != 1 {
+		return fmt.Errorf("%s: want exactly one member, got %+v", field, items)
+	}
+	return testhelpers.RequireEqual(field+"[0].id", want, strconv.Itoa(testhelpers.Deref((*items)[0].ID)))
+}
+
+// ebookRequireSingleID is the generic sibling of ebookRequireSingleIDName for
+// the ebook scope collections whose item type is not IDName.
+func ebookRequireSingleID[T any](field, want string, items *[]T, id func(T) *int) error {
+	if items == nil || len(*items) != 1 {
+		return fmt.Errorf("%s: want exactly one member, got %+v", field, items)
+	}
+	return testhelpers.RequireEqual(field+"[0].id", want, strconv.Itoa(testhelpers.Deref(id((*items)[0]))))
+}
+
+// ebookRetainedOnServer asserts the server's copy still carries every value the
+// omit-retains config declared in its first step. The fixture ids are read from
+// the Terraform state rather than assumed, so the check compares against what
+// the tenant allocated.
+func ebookRetainedOnServer(t *testing.T) resource.TestCheckFunc {
+	c := proclassic.New(testhelpers.NewAcceptanceClient(t))
+	return func(s *terraform.State) error {
+		ids := map[string]string{}
+		for _, f := range []struct{ key, addr, attr string }{
+			{"category", "jamfplatform_pro_category.omit", "id"},
+			{"department.target", "jamfplatform_pro_department.target", "id"},
+			{"department.excluded", "jamfplatform_pro_department.excluded", "id"},
+			{"building.target", "jamfplatform_pro_building.target", "id"},
+			{"building.excluded", "jamfplatform_pro_building.excluded", "id"},
+			{"segment.limited", "jamfplatform_pro_network_segment.limited", "id"},
+			{"segment.excluded", "jamfplatform_pro_network_segment.excluded", "id"},
+			{"group.computers", "jamfplatform_device_group.computers", "jamf_pro_id"},
+			{"group.mobile", "jamfplatform_device_group.mobile", "jamf_pro_id"},
+		} {
+			v, err := ebookStateAttr(s, f.addr, f.attr)
+			if err != nil {
+				return err
+			}
+			ids[f.key] = v
+		}
+		return testhelpers.CheckLiveObject(ebookResourceAddr,
+			func(ctx context.Context, id string) (*proclassic.Ebook, error) {
+				return c.GetEbookByID(ctx, id)
+			},
+			func(e *proclassic.Ebook) error {
+				if e.General == nil || e.General.Category == nil {
+					return fmt.Errorf("general.category: absent")
+				}
+				if err := testhelpers.RequireEqual("general.author", "Omit Retains", testhelpers.Deref(e.General.Author)); err != nil {
+					return err
+				}
+				if err := testhelpers.RequireEqual("general.category.id", ids["category"], strconv.Itoa(testhelpers.Deref(e.General.Category.ID))); err != nil {
+					return err
+				}
+				if err := ebookScopeRetained(e.Scope, ids); err != nil {
+					return err
+				}
+				return ebookSelfServiceRetained(e.SelfService, ids["category"])
+			})(s)
+	}
+}
+
+// ebookScopeRetained checks every scope category the omit-retains config
+// declared across all three tabs.
+func ebookScopeRetained(sc *proclassic.EbookScope, ids map[string]string) error {
+	if sc == nil {
+		return fmt.Errorf("scope: absent")
+	}
+	if sc.Departments == nil || sc.Buildings == nil || sc.ComputerGroups == nil || sc.MobileDeviceGroups == nil {
+		return fmt.Errorf("scope.targets: a category is absent: %+v", sc)
+	}
+	if err := ebookRequireSingleIDName("scope.targets.departments", ids["department.target"], sc.Departments.Department); err != nil {
+		return err
+	}
+	if err := ebookRequireSingleIDName("scope.targets.buildings", ids["building.target"], sc.Buildings.Building); err != nil {
+		return err
+	}
+	if err := ebookRequireSingleIDName("scope.targets.computer_groups", ids["group.computers"], sc.ComputerGroups.ComputerGroup); err != nil {
+		return err
+	}
+	if err := ebookRequireSingleIDName("scope.targets.mobile_device_groups", ids["group.mobile"], sc.MobileDeviceGroups.MobileDeviceGroup); err != nil {
+		return err
+	}
+
+	l := sc.Limitations
+	if l == nil || l.NetworkSegments == nil || l.Users == nil {
+		return fmt.Errorf("scope.limitations: a category is absent: %+v", l)
+	}
+	if err := ebookRequireSingleIDName("scope.limitations.network_segments", ids["segment.limited"], l.NetworkSegments.NetworkSegment); err != nil {
+		return err
+	}
+	if l.Users.User == nil || len(*l.Users.User) != 1 {
+		return fmt.Errorf("scope.limitations.users: want exactly one user, got %+v", l.Users)
+	}
+	if err := testhelpers.RequireEqual("scope.limitations.users[0].name", "tf-acc-omit-limited-user", testhelpers.Deref((*l.Users.User)[0].Name)); err != nil {
+		return err
+	}
+
+	x := sc.Exclusions
+	if x == nil || x.Departments == nil || x.Buildings == nil || x.NetworkSegments == nil || x.Users == nil {
+		return fmt.Errorf("scope.exclusions: a category is absent: %+v", x)
+	}
+	if err := ebookRequireSingleIDName("scope.exclusions.departments", ids["department.excluded"], x.Departments.Department); err != nil {
+		return err
+	}
+	if err := ebookRequireSingleIDName("scope.exclusions.buildings", ids["building.excluded"], x.Buildings.Building); err != nil {
+		return err
+	}
+	if err := ebookRequireSingleID("scope.exclusions.network_segments", ids["segment.excluded"], x.NetworkSegments.NetworkSegment,
+		func(i proclassic.EbookScopeExclusionsNetworkSegmentsNetworkSegmentItem) *int { return i.ID }); err != nil {
+		return err
+	}
+	if x.Users.User == nil || len(*x.Users.User) != 1 {
+		return fmt.Errorf("scope.exclusions.users: want exactly one user, got %+v", x.Users)
+	}
+	return testhelpers.RequireEqual("scope.exclusions.users[0].name", "tf-acc-omit-excluded-user", testhelpers.Deref((*x.Users.User)[0].Name))
+}
+
+// ebookSelfServiceRetained checks every self_service leaf and the category set
+// the omit-retains config declared. The notification_* leaves are deliberately
+// not declared or checked: the /ebooks GET never echoes <notification>,
+// <notification_subject> or <notification_message> (wire-observed 2026-09-06 —
+// the POST carried all three, the GET after it carried none), so their storage
+// cannot be witnessed on the wire and PreferCurrent is all that holds them in
+// state.
+func ebookSelfServiceRetained(ss *proclassic.EbookSelfService, categoryID string) error {
+	if ss == nil {
+		return fmt.Errorf("self_service: absent")
+	}
+	if err := testhelpers.RequireEqual("self_service.display_name", "Omit-retains display name", testhelpers.Deref(ss.SelfServiceDisplayName)); err != nil {
+		return err
+	}
+	if err := testhelpers.RequireEqual("self_service.install_button_text", "Retain me", testhelpers.Deref(ss.InstallButtonText)); err != nil {
+		return err
+	}
+	if err := testhelpers.RequireEqual("self_service.self_service_description", "Omit-retains contract description.", testhelpers.Deref(ss.SelfServiceDescription)); err != nil {
+		return err
+	}
+	if err := testhelpers.RequireEqual("self_service.force_users_to_view_description", true, testhelpers.Deref(ss.ForceUsersToViewDescription)); err != nil {
+		return err
+	}
+	if err := testhelpers.RequireEqual("self_service.feature_on_main_page", true, testhelpers.Deref(ss.FeatureOnMainPage)); err != nil {
+		return err
+	}
+	if ss.SelfServiceCategories == nil || ss.SelfServiceCategories.Category == nil || len(*ss.SelfServiceCategories.Category) != 1 {
+		return fmt.Errorf("self_service.categories: want exactly one category, got %+v", ss.SelfServiceCategories)
+	}
+	cat := (*ss.SelfServiceCategories.Category)[0]
+	if err := testhelpers.RequireEqual("self_service.categories[0].id", categoryID, strconv.Itoa(testhelpers.Deref(cat.ID))); err != nil {
+		return err
+	}
+	if err := testhelpers.RequireEqual("self_service.categories[0].display_in", true, testhelpers.Deref(cat.DisplayIn)); err != nil {
+		return err
+	}
+	return testhelpers.RequireEqual("self_service.categories[0].feature_in", true, testhelpers.Deref(cat.FeatureIn))
+}
+
+// TestAccResource_ProEbook_OmittedBlocksRetained pins the omit-retains contract
+// the plan output cannot show: dropping scope.limitations, scope.exclusions and
+// self_service.categories, then the whole scope and self_service, from config
+// plans them as removed, but the classic PUT omits the elements and the server
+// keeps every value. Step 2 keeps scope.targets so the scope goes through the
+// granular read-merge-write, which must fold the two live tabs back in rather
+// than emitting them empty, and keeps self_service without categories so the
+// element is sent with no self_service_categories at all. Step 3 drops both
+// blocks so the PUT carries <general> alone. Each step's implicit post-apply
+// plan must be empty, which is what makes the contract usable. If this test
+// fails on content, the endpoint no longer merges and nothing that suppresses
+// the removal plan may ship for this resource. CheckDestroy is the file's
+// documented no-op: the /ebooks delete is asynchronous and GET-sensitive.
+func TestAccResource_ProEbook_OmittedBlocksRetained(t *testing.T) {
+	testhelpers.AccPreCheck(t)
+	suffix := testhelpers.RunSuffix()
+	name := "tf-acc-ebook-omit-" + suffix
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testhelpers.AccTestProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckEbookDestroy(t),
+		Steps: []resource.TestStep{
+			{
+				Config: ebookOmitRetainsConfig(name, suffix),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(ebookResourceAddr, "self_service.categories.#", "1"),
+					resource.TestCheckResourceAttr(ebookResourceAddr, "scope.limitations.network_segment_ids.#", "1"),
+					resource.TestCheckResourceAttr(ebookResourceAddr, "scope.exclusions.department_ids.#", "1"),
+					ebookRetainedOnServer(t),
+				),
+			},
+			{
+				Config: ebookOmitRetainsParentsOnlyConfig(name, suffix),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr(ebookResourceAddr, "self_service.categories.#"),
+					resource.TestCheckNoResourceAttr(ebookResourceAddr, "scope.limitations.network_segment_ids.#"),
+					resource.TestCheckNoResourceAttr(ebookResourceAddr, "scope.exclusions.department_ids.#"),
+					resource.TestCheckResourceAttr(ebookResourceAddr, "scope.targets.department_ids.#", "1"),
+					resource.TestCheckResourceAttr(ebookResourceAddr, "self_service.display_name", "Omit-retains display name"),
+					ebookRetainedOnServer(t),
+				),
+			},
+			{
+				Config: ebookOmitRetainsGeneralOnlyConfig(name, suffix),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr(ebookResourceAddr, "scope.targets.department_ids.#"),
+					resource.TestCheckNoResourceAttr(ebookResourceAddr, "self_service.install_button_text"),
+					ebookRetainedOnServer(t),
+				),
 			},
 		},
 	})

--- a/internal/resources/pro/ldap_server/resource_acceptance_test.go
+++ b/internal/resources/pro/ldap_server/resource_acceptance_test.go
@@ -521,3 +521,167 @@ func TestAccResource_ProLdapServer_InvalidAuthType(t *testing.T) {
 		},
 	})
 }
+
+const ldapOmitRetainsConnection = `
+						connection_settings = {
+							display_name        = %q
+							directory_service   = "Active Directory"
+							hostname            = "ldap.acc-omit.example.com"
+							authentication_type = "none"
+						}`
+
+// ldapOmitRetainsConfig declares every gated mapping sub-block with a
+// distinctive value, so a server that stopped retaining an omitted element is
+// caught on content rather than presence.
+func ldapOmitRetainsConfig(name string) string {
+	return fmt.Sprintf(`
+					resource "jamfplatform_pro_ldap_server" "test" {`+ldapOmitRetainsConnection+`
+						mappings_for_users = {
+							user_mappings = {
+								object_class_limitation = "any"
+								object_classes          = "inetOrgPerson"
+								search_base             = "OU=People,DC=omit,DC=example,DC=com"
+								search_scope            = "All Subtrees"
+								username                = "uid"
+								user_id                 = "uidNumber"
+							}
+							user_group_mappings = {
+								object_class_limitation = "any"
+								object_classes          = "groupOfNames"
+								search_base             = "OU=Groups,DC=omit,DC=example,DC=com"
+								search_scope            = "All Subtrees"
+								group_name              = "cn"
+								group_id                = "gidNumber"
+							}
+							user_group_membership_mappings = {
+								membership_location     = "group object"
+								object_class_limitation = "any"
+								object_classes          = "posixGroup"
+								search_base             = "OU=Groups,DC=omit,DC=example,DC=com"
+								search_scope            = "All Subtrees"
+								username_mapping        = "uid"
+								group_id_mapping        = "gidNumber"
+							}
+						}
+					}
+				`, name)
+}
+
+// ldapOmitRetainsChildrenDroppedConfig keeps mappings_for_users but drops two
+// of its three sub-blocks and one Optional+Computed leaf, so the PUT carries a
+// partial <mappings_for_users>.
+func ldapOmitRetainsChildrenDroppedConfig(name string) string {
+	return fmt.Sprintf(`
+					resource "jamfplatform_pro_ldap_server" "test" {`+ldapOmitRetainsConnection+`
+						mappings_for_users = {
+							user_mappings = {
+								object_class_limitation = "any"
+								object_classes          = "inetOrgPerson"
+								search_base             = "OU=People,DC=omit,DC=example,DC=com"
+								search_scope            = "All Subtrees"
+								username                = "uid"
+							}
+						}
+					}
+				`, name)
+}
+
+// ldapOmitRetainsConnectionOnlyConfig drops mappings_for_users entirely.
+func ldapOmitRetainsConnectionOnlyConfig(name string) string {
+	return fmt.Sprintf(`
+					resource "jamfplatform_pro_ldap_server" "test" {`+ldapOmitRetainsConnection+`
+					}
+				`, name)
+}
+
+// ldapRetainedOnServer asserts the server's copy still carries every mapping
+// value the omit-retains config declared in its first step.
+func ldapRetainedOnServer(t *testing.T) resource.TestCheckFunc {
+	c := testhelpers.NewProClassicClient(t)
+	return testhelpers.CheckLiveObject(ldapServerResource,
+		func(ctx context.Context, id string) (*proclassic.LdapServer, error) {
+			return c.GetLDAPServerByID(ctx, id)
+		},
+		func(s *proclassic.LdapServer) error {
+			m := s.MappingsForUsers
+			if m == nil {
+				return fmt.Errorf("mappings_for_users: absent")
+			}
+			if m.UserMappings == nil {
+				return fmt.Errorf("mappings_for_users.user_mappings: absent")
+			}
+			if err := testhelpers.RequireEqual("user_mappings.username", "uid", testhelpers.Deref(m.UserMappings.MapUsername)); err != nil {
+				return err
+			}
+			if err := testhelpers.RequireEqual("user_mappings.user_id", "uidNumber", testhelpers.Deref(m.UserMappings.MapUserID)); err != nil {
+				return err
+			}
+			if err := testhelpers.RequireEqual("user_mappings.search_base", "OU=People,DC=omit,DC=example,DC=com", testhelpers.Deref(m.UserMappings.SearchBase)); err != nil {
+				return err
+			}
+			if m.UserGroupMappings == nil {
+				return fmt.Errorf("mappings_for_users.user_group_mappings: absent")
+			}
+			if err := testhelpers.RequireEqual("user_group_mappings.group_name", "cn", testhelpers.Deref(m.UserGroupMappings.MapGroupName)); err != nil {
+				return err
+			}
+			if err := testhelpers.RequireEqual("user_group_mappings.object_classes", "groupOfNames", testhelpers.Deref(m.UserGroupMappings.ObjectClasses)); err != nil {
+				return err
+			}
+			if m.UserGroupMembershipMappings == nil {
+				return fmt.Errorf("mappings_for_users.user_group_membership_mappings: absent")
+			}
+			if err := testhelpers.RequireEqual("user_group_membership_mappings.membership_location", "group object", testhelpers.Deref(m.UserGroupMembershipMappings.UserGroupMembershipStoredIn)); err != nil {
+				return err
+			}
+			if err := testhelpers.RequireEqual("user_group_membership_mappings.object_classes", "posixGroup", testhelpers.Deref(m.UserGroupMembershipMappings.ObjectClasses)); err != nil {
+				return err
+			}
+			return testhelpers.RequireEqual("user_group_membership_mappings.group_id_mapping", "gidNumber", testhelpers.Deref(m.UserGroupMembershipMappings.GroupID))
+		})
+}
+
+// TestAccResource_ProLdapServer_OmittedBlocksRetained pins the omit-retains
+// contract the plan output cannot show: dropping mapping sub-blocks, and then
+// mappings_for_users itself, plans them as removed, but the classic PUT omits
+// the elements and the server keeps every value. Step 2 keeps
+// mappings_for_users with only user_mappings, so the PUT carries a partial
+// parent; step 3 drops the block so the PUT carries <connection> alone. Each
+// step's implicit post-apply plan must be empty. If this test fails on
+// content, the endpoint no longer merges at that level and nothing that
+// suppresses the removal plan may ship for this resource.
+func TestAccResource_ProLdapServer_OmittedBlocksRetained(t *testing.T) {
+	testhelpers.AccPreCheck(t)
+	suffix := testhelpers.RunSuffix()
+	name := "tf-acc-ldap-omit-" + suffix
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testhelpers.AccTestProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckLdapServerDestroy(t),
+		Steps: []resource.TestStep{
+			{
+				Config: ldapOmitRetainsConfig(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(ldapServerResource, "mappings_for_users.user_group_mappings.group_name", "cn"),
+					ldapRetainedOnServer(t),
+				),
+			},
+			{
+				Config: ldapOmitRetainsChildrenDroppedConfig(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(ldapServerResource, "mappings_for_users.user_mappings.username", "uid"),
+					resource.TestCheckNoResourceAttr(ldapServerResource, "mappings_for_users.user_group_mappings.group_name"),
+					resource.TestCheckNoResourceAttr(ldapServerResource, "mappings_for_users.user_group_membership_mappings.membership_location"),
+					ldapRetainedOnServer(t),
+				),
+			},
+			{
+				Config: ldapOmitRetainsConnectionOnlyConfig(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr(ldapServerResource, "mappings_for_users.user_mappings.username"),
+					ldapRetainedOnServer(t),
+				),
+			},
+		},
+	})
+}

--- a/internal/resources/pro/licensed_software/resource_acceptance_test.go
+++ b/internal/resources/pro/licensed_software/resource_acceptance_test.go
@@ -649,3 +649,289 @@ func TestAccResource_ProLicensedSoftware_OptOut(t *testing.T) {
 		},
 	})
 }
+
+// licensedSoftwareOmitRetainsConfig is the fully declared shape for the
+// omit-retains contract: both opt-out lists, a purchasing block on the first
+// licence and every Optional+Computed header scalar, each carrying a
+// distinctive value so a server that stopped retaining an omitted element is
+// caught on content, not presence.
+func licensedSoftwareOmitRetainsConfig(name string) string {
+	return fmt.Sprintf(`
+		resource "jamfplatform_pro_licensed_software" "test" {
+			name                    = %q
+			publisher               = "Omit Retains Publisher"
+			notes                   = "omit-retains header notes"
+			send_email_on_violation = true
+
+			software_definitions = [
+				{ name = "Omit Retains Editor", version = "7.3", compare_type = "is" },
+				{ name = "Omit Retains Viewer", version = "2.1", compare_type = "like" },
+			]
+
+			licenses = [
+				{
+					serial_number_1   = "OMIT-RETAINS-1"
+					organization_name = "Retain Org"
+					registered_to     = "Retain Team"
+					license_type      = "Standard"
+					license_count     = 13
+					notes             = "primary omit-retains licence"
+					purchasing = {
+						license_term       = "perpetual"
+						po_number          = "PO-OMIT-RETAINS"
+						po_date            = "2026-03-15"
+						vendor             = "Retain Reseller"
+						license_expires    = "2027-03-15"
+						purchase_price     = "4242.00"
+						life_expectancy    = 4
+						purchasing_account = "Retain Finance"
+						purchasing_contact = "Retain Contact"
+					}
+				},
+				{
+					serial_number_1 = "OMIT-RETAINS-2"
+					license_type    = "Concurrent"
+					license_count   = 7
+				},
+			]
+		}
+	`, name)
+}
+
+// licensedSoftwareOmitRetainsListsOnlyConfig keeps both lists with the same
+// elements and drops only the Optional+Computed notes header, so the PUT
+// re-sends both wrappers and the header carries notes from prior state.
+//
+// The first licence deliberately keeps its purchasing block. A sent <licenses>
+// wrapper REPLACES the collection, and the classic merge does not descend into
+// a re-sent element: wire-verified 2026-09-06, a PUT whose <license> carried no
+// <purchasing> came back on GET with the server's default block (is_perpetual
+// true, every other field empty or 0), so the nested block is not a retain
+// gate and dropping it here would fail on content by design, not by defect.
+func licensedSoftwareOmitRetainsListsOnlyConfig(name string) string {
+	return fmt.Sprintf(`
+		resource "jamfplatform_pro_licensed_software" "test" {
+			name                    = %q
+			publisher               = "Omit Retains Publisher"
+			send_email_on_violation = true
+
+			software_definitions = [
+				{ name = "Omit Retains Editor", version = "7.3", compare_type = "is" },
+				{ name = "Omit Retains Viewer", version = "2.1", compare_type = "like" },
+			]
+
+			licenses = [
+				{
+					serial_number_1   = "OMIT-RETAINS-1"
+					organization_name = "Retain Org"
+					registered_to     = "Retain Team"
+					license_type      = "Standard"
+					license_count     = 13
+					notes             = "primary omit-retains licence"
+					purchasing = {
+						license_term       = "perpetual"
+						po_number          = "PO-OMIT-RETAINS"
+						po_date            = "2026-03-15"
+						vendor             = "Retain Reseller"
+						license_expires    = "2027-03-15"
+						purchase_price     = "4242.00"
+						life_expectancy    = 4
+						purchasing_account = "Retain Finance"
+						purchasing_contact = "Retain Contact"
+					}
+				},
+				{
+					serial_number_1 = "OMIT-RETAINS-2"
+					license_type    = "Concurrent"
+					license_count   = 7
+				},
+			]
+		}
+	`, name)
+}
+
+// licensedSoftwareOmitRetainsNameOnlyConfig drops every optional attribute, so
+// the PUT carries <general> alone and neither list wrapper.
+func licensedSoftwareOmitRetainsNameOnlyConfig(name string) string {
+	return fmt.Sprintf(`
+		resource "jamfplatform_pro_licensed_software" "test" {
+			name = %q
+		}
+	`, name)
+}
+
+// licensedSoftwareOmitRetainsClearDefinitionsConfig declares an explicit [] for
+// software_definitions while still omitting licenses, so one PUT carries an
+// empty <software_definitions> wrapper (clear) and no <licenses> (retain).
+func licensedSoftwareOmitRetainsClearDefinitionsConfig(name string) string {
+	return fmt.Sprintf(`
+		resource "jamfplatform_pro_licensed_software" "test" {
+			name                 = %q
+			software_definitions = []
+		}
+	`, name)
+}
+
+// licensedSoftwareRetainedOnServer asserts the server's copy still carries every
+// value the omit-retains config declared in its first step. wantDefinitions
+// false flips the software_definitions assertion to "cleared", for the step
+// that declares [] — the other half of the opt-out contract.
+func licensedSoftwareRetainedOnServer(t *testing.T, wantDefinitions bool) resource.TestCheckFunc {
+	c := proclassic.New(testhelpers.NewAcceptanceClient(t))
+	return testhelpers.CheckLiveObject(licensedSoftwareResourceAddr,
+		func(ctx context.Context, id string) (*proclassic.LicensedSoftware, error) {
+			return c.GetLicensedSoftwareByID(ctx, id)
+		},
+		func(ls *proclassic.LicensedSoftware) error {
+			if ls.General == nil {
+				return fmt.Errorf("general: absent")
+			}
+			if err := testhelpers.RequireEqual("general.publisher", "Omit Retains Publisher", testhelpers.Deref(ls.General.Publisher)); err != nil {
+				return err
+			}
+			if err := testhelpers.RequireEqual("general.notes", "omit-retains header notes", testhelpers.Deref(ls.General.Notes)); err != nil {
+				return err
+			}
+			if err := testhelpers.RequireEqual("general.send_email_on_violation", true, testhelpers.Deref(ls.General.SendEmailOnViolation)); err != nil {
+				return err
+			}
+
+			var defs []proclassic.LicensedSoftwareDefintion
+			if ls.SoftwareDefinitions != nil && ls.SoftwareDefinitions.Definition != nil {
+				defs = *ls.SoftwareDefinitions.Definition
+			}
+			if !wantDefinitions {
+				if len(defs) != 0 {
+					return fmt.Errorf("software_definitions: want cleared, got %d element(s)", len(defs))
+				}
+			} else {
+				if len(defs) != 2 {
+					return fmt.Errorf("software_definitions: want 2 elements, got %d", len(defs))
+				}
+				for i, want := range []proclassic.LicensedSoftwareDefintion{
+					{Name: new("Omit Retains Editor"), Version: new("7.3"), CompareType: new("is")},
+					{Name: new("Omit Retains Viewer"), Version: new("2.1"), CompareType: new("like")},
+				} {
+					prefix := fmt.Sprintf("software_definitions[%d]", i)
+					if err := testhelpers.RequireEqual(prefix+".name", *want.Name, testhelpers.Deref(defs[i].Name)); err != nil {
+						return err
+					}
+					if err := testhelpers.RequireEqual(prefix+".version", *want.Version, testhelpers.Deref(defs[i].Version)); err != nil {
+						return err
+					}
+					if err := testhelpers.RequireEqual(prefix+".compare_type", *want.CompareType, testhelpers.Deref(defs[i].CompareType)); err != nil {
+						return err
+					}
+				}
+			}
+
+			if ls.Licenses == nil || ls.Licenses.License == nil || len(*ls.Licenses.License) != 2 {
+				return fmt.Errorf("licenses: want 2 elements, got %+v", ls.Licenses)
+			}
+			lics := *ls.Licenses.License
+			if err := testhelpers.RequireEqual("licenses[0].serial_number_1", "OMIT-RETAINS-1", testhelpers.Deref(lics[0].SerialNumber1)); err != nil {
+				return err
+			}
+			if err := testhelpers.RequireEqual("licenses[0].organization_name", "Retain Org", testhelpers.Deref(lics[0].OrganizationName)); err != nil {
+				return err
+			}
+			if err := testhelpers.RequireEqual("licenses[0].registered_to", "Retain Team", testhelpers.Deref(lics[0].RegisteredTo)); err != nil {
+				return err
+			}
+			if err := testhelpers.RequireEqual("licenses[0].license_type", "Standard", testhelpers.Deref(lics[0].LicenseType)); err != nil {
+				return err
+			}
+			if err := testhelpers.RequireEqual("licenses[0].license_count", 13, testhelpers.Deref(lics[0].LicenseCount)); err != nil {
+				return err
+			}
+			if err := testhelpers.RequireEqual("licenses[0].notes", "primary omit-retains licence", testhelpers.Deref(lics[0].Notes)); err != nil {
+				return err
+			}
+			p := lics[0].Purchasing
+			if p == nil {
+				return fmt.Errorf("licenses[0].purchasing: absent")
+			}
+			if err := testhelpers.RequireEqual("licenses[0].purchasing.is_perpetual", true, testhelpers.Deref(p.IsPerpetual)); err != nil {
+				return err
+			}
+			if err := testhelpers.RequireEqual("licenses[0].purchasing.po_number", "PO-OMIT-RETAINS", testhelpers.Deref(p.PoNumber)); err != nil {
+				return err
+			}
+			if err := testhelpers.RequireEqual("licenses[0].purchasing.vendor", "Retain Reseller", testhelpers.Deref(p.Vendor)); err != nil {
+				return err
+			}
+			if err := testhelpers.RequireEqual("licenses[0].purchasing.life_expectancy", 4, testhelpers.Deref(p.LifeExpectancy)); err != nil {
+				return err
+			}
+			if err := testhelpers.RequireEqual("licenses[0].purchasing.purchasing_account", "Retain Finance", testhelpers.Deref(p.PurchasingAccount)); err != nil {
+				return err
+			}
+			if err := testhelpers.RequireEqual("licenses[0].purchasing.purchasing_contact", "Retain Contact", testhelpers.Deref(p.PurchasingContact)); err != nil {
+				return err
+			}
+			if err := testhelpers.RequireEqual("licenses[1].serial_number_1", "OMIT-RETAINS-2", testhelpers.Deref(lics[1].SerialNumber1)); err != nil {
+				return err
+			}
+			if err := testhelpers.RequireEqual("licenses[1].license_type", "Concurrent", testhelpers.Deref(lics[1].LicenseType)); err != nil {
+				return err
+			}
+			return testhelpers.RequireEqual("licenses[1].license_count", 7, testhelpers.Deref(lics[1].LicenseCount))
+		})
+}
+
+// TestAccResource_ProLicensedSoftware_OmittedBlocksRetained pins the opt-out
+// contract on both positional lists at once, with content the plan output
+// cannot show. Step 2 re-sends both lists and drops only the notes header;
+// step 3 drops both lists, so the PUT carries <general> alone and the server
+// must retain every element and every purchasing field; step 4 declares
+// software_definitions = [] while still
+// omitting licenses, so the same PUT must clear one collection and retain the
+// other — the half of the contract that separates "not managed" from "empty".
+// Each step's implicit post-apply plan must be empty. If a step fails on
+// content, the endpoint no longer merges at that granularity and nothing that
+// suppresses the removal plan may ship for this resource.
+func TestAccResource_ProLicensedSoftware_OmittedBlocksRetained(t *testing.T) {
+	testhelpers.AccPreCheck(t)
+	suffix := testhelpers.RunSuffix()
+	name := "tf-acc-pro-licsw-omit-" + suffix
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testhelpers.AccTestProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckLicensedSoftwareDestroy(t),
+		Steps: []resource.TestStep{
+			{
+				Config: licensedSoftwareOmitRetainsConfig(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(licensedSoftwareResourceAddr, "software_definitions.#", "2"),
+					resource.TestCheckResourceAttr(licensedSoftwareResourceAddr, "licenses.#", "2"),
+					resource.TestCheckResourceAttr(licensedSoftwareResourceAddr, "licenses.0.purchasing.po_number", "PO-OMIT-RETAINS"),
+					licensedSoftwareRetainedOnServer(t, true),
+				),
+			},
+			{
+				Config: licensedSoftwareOmitRetainsListsOnlyConfig(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(licensedSoftwareResourceAddr, "licenses.0.purchasing.po_number", "PO-OMIT-RETAINS"),
+					resource.TestCheckResourceAttr(licensedSoftwareResourceAddr, "notes", "omit-retains header notes"),
+					licensedSoftwareRetainedOnServer(t, true),
+				),
+			},
+			{
+				Config: licensedSoftwareOmitRetainsNameOnlyConfig(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr(licensedSoftwareResourceAddr, "software_definitions.#"),
+					resource.TestCheckNoResourceAttr(licensedSoftwareResourceAddr, "licenses.#"),
+					licensedSoftwareRetainedOnServer(t, true),
+				),
+			},
+			{
+				Config: licensedSoftwareOmitRetainsClearDefinitionsConfig(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(licensedSoftwareResourceAddr, "software_definitions.#", "0"),
+					resource.TestCheckNoResourceAttr(licensedSoftwareResourceAddr, "licenses.#"),
+					licensedSoftwareRetainedOnServer(t, false),
+				),
+			},
+		},
+	})
+}

--- a/internal/resources/pro/mac_app_store_app/resource_acceptance_test.go
+++ b/internal/resources/pro/mac_app_store_app/resource_acceptance_test.go
@@ -1041,3 +1041,164 @@ func TestAccResource_ProMacApp_ScopeSplitOwnership(t *testing.T) {
 		},
 	})
 }
+
+// macAppOmitRetainsConfig is the fully declared shape for the omit-retains
+// contract: every state-gated block carries a distinctive value so that a
+// server which stopped retaining an omitted element is caught on content, not
+// on presence.
+func macAppOmitRetainsConfig(name string) string {
+	return fmt.Sprintf(`
+		resource "jamfplatform_pro_mac_app_store_app" "test" {
+			general = {
+				name            = %q
+				version         = "1.0"
+				bundle_id       = "com.example.tfacc.macapp.omit"
+				url             = "https://apps.apple.com/app/id000000001"
+				deployment_type = "Install Automatically/Prompt Users to Install"
+			}
+			scope = {
+				targets = {
+					all_computers = true
+				}
+				exclusions = {
+					directory_service_or_local_user_names = ["tf-acc-omit-retains-user"]
+				}
+			}
+			self_service = {
+				install_button_text             = "Retain me"
+				self_service_description        = "Omit-retains contract description."
+				force_users_to_view_description = true
+				feature_on_main_page            = true
+			}
+			vpp = {
+				assign_vpp_device_based_licenses = false
+				vpp_admin_account_id             = "-1"
+			}
+		}
+	`, name)
+}
+
+// macAppOmitRetainsScopeOnlyConfig drops self_service, vpp and the scope
+// exclusions while still declaring scope targets, so the PUT omits two whole
+// blocks and re-emits the scope from a granular merge.
+func macAppOmitRetainsScopeOnlyConfig(name string) string {
+	return fmt.Sprintf(`
+		resource "jamfplatform_pro_mac_app_store_app" "test" {
+			general = {
+				name            = %q
+				version         = "1.0"
+				bundle_id       = "com.example.tfacc.macapp.omit"
+				url             = "https://apps.apple.com/app/id000000001"
+				deployment_type = "Install Automatically/Prompt Users to Install"
+			}
+			scope = {
+				targets = {
+					all_computers = true
+				}
+			}
+		}
+	`, name)
+}
+
+// macAppOmitRetainsGeneralOnlyConfig drops every optional block, so the PUT
+// carries <general> alone.
+func macAppOmitRetainsGeneralOnlyConfig(name string) string {
+	return fmt.Sprintf(`
+		resource "jamfplatform_pro_mac_app_store_app" "test" {
+			general = {
+				name            = %q
+				version         = "1.0"
+				bundle_id       = "com.example.tfacc.macapp.omit"
+				url             = "https://apps.apple.com/app/id000000001"
+				deployment_type = "Install Automatically/Prompt Users to Install"
+			}
+		}
+	`, name)
+}
+
+// macAppRetainedOnServer asserts the server's copy still carries every value
+// the omit-retains config declared in its first step.
+func macAppRetainedOnServer(t *testing.T) resource.TestCheckFunc {
+	c := proclassic.New(testhelpers.NewAcceptanceClient(t))
+	return testhelpers.CheckLiveObject(macAppResourceAddr,
+		func(ctx context.Context, id string) (*proclassic.MacApplication, error) {
+			return c.GetMacApplicationByID(ctx, id)
+		},
+		func(a *proclassic.MacApplication) error {
+			if a.Scope == nil {
+				return fmt.Errorf("scope: absent")
+			}
+			if err := testhelpers.RequireEqual("scope.all_computers", true, testhelpers.Deref(a.Scope.AllComputers)); err != nil {
+				return err
+			}
+			if a.Scope.Exclusions == nil || a.Scope.Exclusions.Users == nil || a.Scope.Exclusions.Users.User == nil || len(*a.Scope.Exclusions.Users.User) != 1 {
+				return fmt.Errorf("scope.exclusions.users: want exactly one user, got %+v", a.Scope.Exclusions)
+			}
+			if err := testhelpers.RequireEqual("scope.exclusions.users[0].name", "tf-acc-omit-retains-user", testhelpers.Deref((*a.Scope.Exclusions.Users.User)[0].Name)); err != nil {
+				return err
+			}
+			if a.SelfService == nil {
+				return fmt.Errorf("self_service: absent")
+			}
+			if err := testhelpers.RequireEqual("self_service.install_button_text", "Retain me", testhelpers.Deref(a.SelfService.InstallButtonText)); err != nil {
+				return err
+			}
+			if err := testhelpers.RequireEqual("self_service.self_service_description", "Omit-retains contract description.", testhelpers.Deref(a.SelfService.SelfServiceDescription)); err != nil {
+				return err
+			}
+			if err := testhelpers.RequireEqual("self_service.force_users_to_view_description", true, testhelpers.Deref(a.SelfService.ForceUsersToViewDescription)); err != nil {
+				return err
+			}
+			if err := testhelpers.RequireEqual("self_service.feature_on_main_page", true, testhelpers.Deref(a.SelfService.FeatureOnMainPage)); err != nil {
+				return err
+			}
+			if a.Vpp == nil {
+				return fmt.Errorf("vpp: absent")
+			}
+			return testhelpers.RequireEqual("vpp.vpp_admin_account_id", -1, testhelpers.Deref(a.Vpp.VppAdminAccountID))
+		})
+}
+
+// TestAccResource_ProMacApp_OmittedBlocksRetained pins the omit-retains
+// contract the plan output cannot show: dropping scope.exclusions,
+// self_service and vpp from config plans them as removed, but the classic
+// PUT omits the elements and the server keeps every value. Step 2 keeps
+// scope.targets so the scope goes through the granular merge; step 3 drops
+// scope too so the PUT carries <general> alone. Each step's implicit
+// post-apply plan must be empty, which is what makes the contract usable.
+// If this test fails on content, the endpoint no longer merges and nothing
+// that suppresses the removal plan may ship for this resource.
+func TestAccResource_ProMacApp_OmittedBlocksRetained(t *testing.T) {
+	testhelpers.AccPreCheck(t)
+	suffix := testhelpers.RunSuffix()
+	name := "tf-acc-pro-macapp-omit-" + suffix
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testhelpers.AccTestProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckMacAppDestroy(t),
+		Steps: []resource.TestStep{
+			{
+				Config: macAppOmitRetainsConfig(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(macAppResourceAddr, "self_service.install_button_text", "Retain me"),
+					macAppRetainedOnServer(t),
+				),
+			},
+			{
+				Config: macAppOmitRetainsScopeOnlyConfig(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr(macAppResourceAddr, "self_service.install_button_text"),
+					resource.TestCheckNoResourceAttr(macAppResourceAddr, "scope.exclusions.directory_service_or_local_user_names.#"),
+					macAppRetainedOnServer(t),
+				),
+			},
+			{
+				Config: macAppOmitRetainsGeneralOnlyConfig(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr(macAppResourceAddr, "scope.targets.all_computers"),
+					macAppRetainedOnServer(t),
+				),
+			},
+		},
+	})
+}

--- a/internal/resources/pro/mac_app_store_app/resource_acceptance_test.go
+++ b/internal/resources/pro/mac_app_store_app/resource_acceptance_test.go
@@ -1048,9 +1048,14 @@ func TestAccResource_ProMacApp_ScopeSplitOwnership(t *testing.T) {
 // on presence.
 func macAppOmitRetainsConfig(name string) string {
 	return fmt.Sprintf(`
+		resource "jamfplatform_pro_category" "omit" {
+			name     = "%[1]s-cat"
+			priority = 9
+		}
+
 		resource "jamfplatform_pro_mac_app_store_app" "test" {
 			general = {
-				name            = %q
+				name            = %[1]q
 				version         = "1.0"
 				bundle_id       = "com.example.tfacc.macapp.omit"
 				url             = "https://apps.apple.com/app/id000000001"
@@ -1069,6 +1074,13 @@ func macAppOmitRetainsConfig(name string) string {
 				self_service_description        = "Omit-retains contract description."
 				force_users_to_view_description = true
 				feature_on_main_page            = true
+				self_service_categories = [
+					{
+						id         = jamfplatform_pro_category.omit.id
+						display_in = true
+						feature_in = true
+					},
+				]
 			}
 			vpp = {
 				assign_vpp_device_based_licenses = false
@@ -1078,14 +1090,20 @@ func macAppOmitRetainsConfig(name string) string {
 	`, name)
 }
 
-// macAppOmitRetainsScopeOnlyConfig drops self_service, vpp and the scope
-// exclusions while still declaring scope targets, so the PUT omits two whole
-// blocks and re-emits the scope from a granular merge.
-func macAppOmitRetainsScopeOnlyConfig(name string) string {
+// macAppOmitRetainsChildrenDroppedConfig keeps every parent block but drops
+// their gated children and one Optional+Computed leaf: scope loses
+// exclusions (re-emitted from the granular merge), self_service loses its
+// categories collection and feature_on_main_page, and vpp goes entirely.
+func macAppOmitRetainsChildrenDroppedConfig(name string) string {
 	return fmt.Sprintf(`
+		resource "jamfplatform_pro_category" "omit" {
+			name     = "%[1]s-cat"
+			priority = 9
+		}
+
 		resource "jamfplatform_pro_mac_app_store_app" "test" {
 			general = {
-				name            = %q
+				name            = %[1]q
 				version         = "1.0"
 				bundle_id       = "com.example.tfacc.macapp.omit"
 				url             = "https://apps.apple.com/app/id000000001"
@@ -1096,6 +1114,11 @@ func macAppOmitRetainsScopeOnlyConfig(name string) string {
 					all_computers = true
 				}
 			}
+			self_service = {
+				install_button_text             = "Retain me"
+				self_service_description        = "Omit-retains contract description."
+				force_users_to_view_description = true
+			}
 		}
 	`, name)
 }
@@ -1104,9 +1127,14 @@ func macAppOmitRetainsScopeOnlyConfig(name string) string {
 // carries <general> alone.
 func macAppOmitRetainsGeneralOnlyConfig(name string) string {
 	return fmt.Sprintf(`
+		resource "jamfplatform_pro_category" "omit" {
+			name     = "%[1]s-cat"
+			priority = 9
+		}
+
 		resource "jamfplatform_pro_mac_app_store_app" "test" {
 			general = {
-				name            = %q
+				name            = %[1]q
 				version         = "1.0"
 				bundle_id       = "com.example.tfacc.macapp.omit"
 				url             = "https://apps.apple.com/app/id000000001"
@@ -1152,6 +1180,13 @@ func macAppRetainedOnServer(t *testing.T) resource.TestCheckFunc {
 			if err := testhelpers.RequireEqual("self_service.feature_on_main_page", true, testhelpers.Deref(a.SelfService.FeatureOnMainPage)); err != nil {
 				return err
 			}
+			if a.SelfService.SelfServiceCategories == nil || a.SelfService.SelfServiceCategories.Category == nil || len(*a.SelfService.SelfServiceCategories.Category) != 1 {
+				return fmt.Errorf("self_service.self_service_categories: want exactly one category, got %+v", a.SelfService.SelfServiceCategories)
+			}
+			cat := (*a.SelfService.SelfServiceCategories.Category)[0]
+			if err := testhelpers.RequireEqual("self_service.self_service_categories[0].feature_in", true, testhelpers.Deref(cat.FeatureIn)); err != nil {
+				return err
+			}
 			if a.Vpp == nil {
 				return fmt.Errorf("vpp: absent")
 			}
@@ -1160,11 +1195,13 @@ func macAppRetainedOnServer(t *testing.T) resource.TestCheckFunc {
 }
 
 // TestAccResource_ProMacApp_OmittedBlocksRetained pins the omit-retains
-// contract the plan output cannot show: dropping scope.exclusions,
-// self_service and vpp from config plans them as removed, but the classic
-// PUT omits the elements and the server keeps every value. Step 2 keeps
-// scope.targets so the scope goes through the granular merge; step 3 drops
-// scope too so the PUT carries <general> alone. Each step's implicit
+// contract the plan output cannot show: dropping a gated block or
+// sub-collection from config plans it as removed, but the classic PUT omits
+// the element and the server keeps every value. Step 2 keeps every parent
+// block and drops its gated children (scope exclusions through the granular
+// merge, self_service categories, one Optional+Computed leaf) plus the vpp
+// block; step 3 drops every optional block so the PUT carries <general>
+// alone. Each step's implicit
 // post-apply plan must be empty, which is what makes the contract usable.
 // If this test fails on content, the endpoint no longer merges and nothing
 // that suppresses the removal plan may ship for this resource.
@@ -1185,10 +1222,12 @@ func TestAccResource_ProMacApp_OmittedBlocksRetained(t *testing.T) {
 				),
 			},
 			{
-				Config: macAppOmitRetainsScopeOnlyConfig(name),
+				Config: macAppOmitRetainsChildrenDroppedConfig(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckNoResourceAttr(macAppResourceAddr, "self_service.install_button_text"),
+					resource.TestCheckResourceAttr(macAppResourceAddr, "self_service.install_button_text", "Retain me"),
+					resource.TestCheckNoResourceAttr(macAppResourceAddr, "self_service.self_service_categories.#"),
 					resource.TestCheckNoResourceAttr(macAppResourceAddr, "scope.exclusions.directory_service_or_local_user_names.#"),
+					resource.TestCheckNoResourceAttr(macAppResourceAddr, "vpp.vpp_admin_account_id"),
 					macAppRetainedOnServer(t),
 				),
 			},

--- a/internal/resources/pro/macos_configuration_profile/resource_acceptance_test.go
+++ b/internal/resources/pro/macos_configuration_profile/resource_acceptance_test.go
@@ -1580,3 +1580,531 @@ func injectPlistTailKey(plist string) string {
 	}
 	return plist
 }
+
+// omitRetainsFixtures carries the out-of-band (SDK-created) fixture IDs the
+// omit-retains configs reference, plus the run suffix that names the inline
+// HCL fixtures. The inline fixture IDs are only known after apply, so the
+// wire assertion resolves them from Terraform state rather than from here.
+type omitRetainsFixtures struct {
+	suffix          string
+	targetComputer  string
+	excludeComputer string
+	targetUser      string
+	excludeUser     string
+}
+
+// omitRetainsFixtureHCL declares one inline fixture per scope category and one
+// Self Service category. Targets and exclusions each get their own fixture so
+// the wire assertion can tell a retained exclusion from a leaked target.
+func omitRetainsFixtureHCL(suffix string) string {
+	return fmt.Sprintf(`
+resource "jamfplatform_pro_category" "omit" {
+  name     = "tf-acc-mcp-omit-cat-%[1]s"
+  priority = 7
+}
+
+resource "jamfplatform_pro_building" "target" {
+  name = "tf-acc-mcp-omit-bld-t-%[1]s"
+}
+
+resource "jamfplatform_pro_building" "exclude" {
+  name = "tf-acc-mcp-omit-bld-x-%[1]s"
+}
+
+resource "jamfplatform_pro_department" "target" {
+  name = "tf-acc-mcp-omit-dep-t-%[1]s"
+}
+
+resource "jamfplatform_pro_department" "exclude" {
+  name = "tf-acc-mcp-omit-dep-x-%[1]s"
+}
+
+resource "jamfplatform_device_group" "target" {
+  name        = "tf-acc-mcp-omit-grp-t-%[1]s"
+  description = "tf-acc omit-retains scope fixture"
+  group_type  = "static"
+  device_type = "computer"
+}
+
+resource "jamfplatform_device_group" "exclude" {
+  name        = "tf-acc-mcp-omit-grp-x-%[1]s"
+  description = "tf-acc omit-retains scope fixture"
+  group_type  = "static"
+  device_type = "computer"
+}
+
+resource "jamfplatform_pro_user_group" "exclude" {
+  name       = "tf-acc-mcp-omit-ug-x-%[1]s"
+  group_type = "static"
+}
+
+resource "jamfplatform_pro_network_segment" "limit" {
+  name             = "tf-acc-mcp-omit-seg-l-%[1]s"
+  starting_address = "10.94.0.0"
+  ending_address   = "10.94.0.255"
+}
+
+resource "jamfplatform_pro_network_segment" "exclude" {
+  name             = "tf-acc-mcp-omit-seg-x-%[1]s"
+  starting_address = "10.94.1.0"
+  ending_address   = "10.94.1.255"
+}
+
+resource "jamfplatform_pro_ibeacon" "limit" {
+  name                    = "tf-acc-mcp-omit-ib-l-%[1]s"
+  uuid                    = "759b0599-64e0-416a-8d31-d8e93482a4d7"
+  include_any_major_value = true
+  include_any_minor_value = true
+}
+
+resource "jamfplatform_pro_ibeacon" "exclude" {
+  name                    = "tf-acc-mcp-omit-ib-x-%[1]s"
+  uuid                    = "759b0599-64e0-416a-8d31-d8e93482a4d7"
+  major                   = 42
+  include_any_minor_value = true
+}
+`, suffix)
+}
+
+// omitRetainsConfig is the fully declared shape for the omit-retains contract:
+// every state-gated block and every scope category the resource has carries a
+// distinctive value so that a server which stopped retaining an omitted
+// element is caught on content, not on presence. Left out: the two
+// directory-service user-group categories, because the server refuses a group
+// name that does not resolve against the tenant's directory integration; and
+// scope.targets.user_group_ids, because the SDK's
+// OsXConfigurationProfileScopeJssUserGroups decodes the child as
+// <jss_user_group> while the server answers <user_group> (wire-probed
+// 2026-09-06: both spellings are accepted on write, only <user_group> is ever
+// read back), so on this resource that category never round-trips and would
+// fail the create, not the contract under test. The exclusions counterpart is
+// tagged correctly and stays covered.
+func omitRetainsConfig(name, payload string, f omitRetainsFixtures) string {
+	return omitRetainsFixtureHCL(f.suffix) + fmt.Sprintf(`
+resource "jamfplatform_pro_macos_configuration_profile" "test" {
+  general = {
+    name                = %q
+    distribution_method = "Make Available in Self Service"
+    payloads = <<EOF
+%sEOF
+  }
+  scope = {
+    targets = {
+      computer_ids       = [%q]
+      computer_group_ids = [jamfplatform_device_group.target.jamf_pro_id]
+      building_ids       = [jamfplatform_pro_building.target.id]
+      department_ids     = [jamfplatform_pro_department.target.id]
+      user_ids           = [%q]
+    }
+    limitations = {
+      network_segment_ids                   = [jamfplatform_pro_network_segment.limit.id]
+      ibeacon_ids                           = [jamfplatform_pro_ibeacon.limit.id]
+      directory_service_or_local_user_names = ["tf-acc-omit-retains-limit-user"]
+    }
+    exclusions = {
+      computer_ids                          = [%q]
+      computer_group_ids                    = [jamfplatform_device_group.exclude.jamf_pro_id]
+      building_ids                          = [jamfplatform_pro_building.exclude.id]
+      department_ids                        = [jamfplatform_pro_department.exclude.id]
+      user_ids                              = [%q]
+      user_group_ids                        = [jamfplatform_pro_user_group.exclude.id]
+      network_segment_ids                   = [jamfplatform_pro_network_segment.exclude.id]
+      ibeacon_ids                           = [jamfplatform_pro_ibeacon.exclude.id]
+      directory_service_or_local_user_names = ["tf-acc-omit-retains-exclude-user"]
+    }
+  }
+  self_service = {
+    self_service_display_name     = "Omit retains display name"
+    install_button_text           = "Retain me"
+    self_service_description      = "Omit-retains contract description."
+    ensure_users_view_description = true
+    feature_on_main_page          = true
+    display_notifications         = true
+    notification_location         = "Self Service and Notification Center"
+    notification_subject          = "Omit retains subject"
+    notification_message          = "Omit retains message"
+    removal_disallowed            = "Never"
+    categories = [
+      {
+        id         = jamfplatform_pro_category.omit.id
+        display_in = true
+        feature_in = true
+      },
+    ]
+  }
+  depends_on = [
+    jamfplatform_pro_category.omit,
+    jamfplatform_pro_building.target, jamfplatform_pro_building.exclude,
+    jamfplatform_pro_department.target, jamfplatform_pro_department.exclude,
+    jamfplatform_device_group.target, jamfplatform_device_group.exclude,
+    jamfplatform_pro_user_group.exclude,
+    jamfplatform_pro_network_segment.limit, jamfplatform_pro_network_segment.exclude,
+    jamfplatform_pro_ibeacon.limit, jamfplatform_pro_ibeacon.exclude,
+  ]
+}
+`, name, payload, f.targetComputer, f.targetUser, f.excludeComputer, f.excludeUser)
+}
+
+// omitRetainsParentsOnlyConfig keeps the scope and self_service parents but
+// drops their gated children: scope loses limitations, exclusions and the
+// user_ids target category, so the PUT re-emits the scope from the granular
+// merge; self_service loses the Optional+Computed ensure_users_view_description
+// leaf. self_service.categories stays declared, not by choice: wire-probed
+// 2026-09-06, a <self_service> sent without <self_service_categories> leaves
+// the categories in place on the server, and flattenSelfService then hydrates
+// them into a list the plan had as null, which Terraform rejects as an
+// inconsistent result. Until that read is gated on prior state, dropping the
+// categories here fails the apply rather than testing the contract.
+func omitRetainsParentsOnlyConfig(name, payload string, f omitRetainsFixtures) string {
+	return omitRetainsFixtureHCL(f.suffix) + fmt.Sprintf(`
+resource "jamfplatform_pro_macos_configuration_profile" "test" {
+  general = {
+    name                = %q
+    distribution_method = "Make Available in Self Service"
+    payloads = <<EOF
+%sEOF
+  }
+  scope = {
+    targets = {
+      computer_ids       = [%q]
+      computer_group_ids = [jamfplatform_device_group.target.jamf_pro_id]
+      building_ids       = [jamfplatform_pro_building.target.id]
+      department_ids     = [jamfplatform_pro_department.target.id]
+    }
+  }
+  self_service = {
+    self_service_display_name = "Omit retains display name"
+    install_button_text       = "Retain me"
+    self_service_description  = "Omit-retains contract description."
+    feature_on_main_page      = true
+    display_notifications     = true
+    notification_location     = "Self Service and Notification Center"
+    notification_subject      = "Omit retains subject"
+    notification_message      = "Omit retains message"
+    removal_disallowed        = "Never"
+    categories = [
+      {
+        id         = jamfplatform_pro_category.omit.id
+        display_in = true
+        feature_in = true
+      },
+    ]
+  }
+  depends_on = [
+    jamfplatform_pro_category.omit,
+    jamfplatform_pro_building.target, jamfplatform_pro_building.exclude,
+    jamfplatform_pro_department.target, jamfplatform_pro_department.exclude,
+    jamfplatform_device_group.target, jamfplatform_device_group.exclude,
+    jamfplatform_pro_user_group.exclude,
+    jamfplatform_pro_network_segment.limit, jamfplatform_pro_network_segment.exclude,
+    jamfplatform_pro_ibeacon.limit, jamfplatform_pro_ibeacon.exclude,
+  ]
+}
+`, name, payload, f.targetComputer)
+}
+
+// omitRetainsGeneralOnlyConfig drops every optional block, so the PUT carries
+// <general> alone. The fixtures stay declared so nothing the server still
+// references is destroyed underneath it, and every config lists them in
+// depends_on: once a step stops referencing a fixture from the profile, the
+// dependency edge is gone and Terraform would otherwise destroy the fixture in
+// parallel with the profile, which the server refuses while the retained scope
+// still names it.
+func omitRetainsGeneralOnlyConfig(name, payload string, f omitRetainsFixtures) string {
+	return omitRetainsFixtureHCL(f.suffix) + fmt.Sprintf(`
+resource "jamfplatform_pro_macos_configuration_profile" "test" {
+  general = {
+    name                = %q
+    distribution_method = "Make Available in Self Service"
+    payloads = <<EOF
+%sEOF
+  }
+  depends_on = [
+    jamfplatform_pro_category.omit,
+    jamfplatform_pro_building.target, jamfplatform_pro_building.exclude,
+    jamfplatform_pro_department.target, jamfplatform_pro_department.exclude,
+    jamfplatform_device_group.target, jamfplatform_device_group.exclude,
+    jamfplatform_pro_user_group.exclude,
+    jamfplatform_pro_network_segment.limit, jamfplatform_pro_network_segment.exclude,
+    jamfplatform_pro_ibeacon.limit, jamfplatform_pro_ibeacon.exclude,
+  ]
+}
+`, name, payload)
+}
+
+// requireOnlyID asserts a classic member list holds exactly one entry whose
+// id is want. Membership is checked on count as well as content so a server
+// that appended rather than retained is caught too.
+func requireOnlyID[T any](field string, items *[]T, id func(T) *int, want string) error {
+	if items == nil || len(*items) != 1 {
+		n := 0
+		if items != nil {
+			n = len(*items)
+		}
+		return fmt.Errorf("%s: want exactly one member (%s), got %d", field, want, n)
+	}
+	return testhelpers.RequireEqual(field, want, fmt.Sprint(testhelpers.Deref(id((*items)[0]))))
+}
+
+// requireOnlyIDName is requireOnlyID for the SDK's shared IDName element.
+func requireOnlyIDName(field string, items *[]proclassic.IDName, want string) error {
+	return requireOnlyID(field, items, func(i proclassic.IDName) *int { return i.ID }, want)
+}
+
+// stateID returns the primary id of a fixture resource from Terraform state,
+// which is how the wire assertion learns the ids Jamf allocated to the inline
+// fixtures.
+func stateID(s *terraform.State, addr, attr string) (string, error) {
+	rs, ok := s.RootModule().Resources[addr]
+	if !ok {
+		return "", fmt.Errorf("fixture %s not found in state", addr)
+	}
+	v, ok := rs.Primary.Attributes[attr]
+	if !ok || v == "" {
+		return "", fmt.Errorf("fixture %s has no %s in state", addr, attr)
+	}
+	return v, nil
+}
+
+// omitRetainedOnServer asserts the server's copy still carries every value the
+// omit-retains config declared in its first step. Inline fixture ids are read
+// from state because Jamf allocates them at apply. The four notification
+// attributes (display_notifications, notification_location,
+// notification_subject, notification_message) are declared but not asserted:
+// the classic GET never echoes <notification>, <notification_subject> or
+// <notification_message> for a macOS profile (wire-probed 2026-09-06 on a
+// profile created with all three set), so no read can witness whether the
+// server kept them.
+func omitRetainedOnServer(t *testing.T, f omitRetainsFixtures) resource.TestCheckFunc {
+	c := testhelpers.NewProClassicClient(t)
+	const addr = "jamfplatform_pro_macos_configuration_profile.test"
+	return func(s *terraform.State) error {
+		want := map[string]string{}
+		for _, fx := range []struct{ key, addr, attr string }{
+			{"category", "jamfplatform_pro_category.omit", "id"},
+			{"bldT", "jamfplatform_pro_building.target", "id"},
+			{"bldX", "jamfplatform_pro_building.exclude", "id"},
+			{"depT", "jamfplatform_pro_department.target", "id"},
+			{"depX", "jamfplatform_pro_department.exclude", "id"},
+			{"grpT", "jamfplatform_device_group.target", "jamf_pro_id"},
+			{"grpX", "jamfplatform_device_group.exclude", "jamf_pro_id"},
+			{"ugX", "jamfplatform_pro_user_group.exclude", "id"},
+			{"segL", "jamfplatform_pro_network_segment.limit", "id"},
+			{"segX", "jamfplatform_pro_network_segment.exclude", "id"},
+			{"ibL", "jamfplatform_pro_ibeacon.limit", "id"},
+			{"ibX", "jamfplatform_pro_ibeacon.exclude", "id"},
+		} {
+			v, err := stateID(s, fx.addr, fx.attr)
+			if err != nil {
+				return err
+			}
+			want[fx.key] = v
+		}
+		return testhelpers.CheckLiveObject(addr,
+			func(ctx context.Context, id string) (*proclassic.OsXConfigurationProfile, error) {
+				return c.GetOSXConfigurationProfileByID(ctx, id)
+			},
+			func(p *proclassic.OsXConfigurationProfile) error {
+				sc := p.Scope
+				if sc == nil {
+					return fmt.Errorf("scope: absent")
+				}
+				computerID := func(i proclassic.OsXConfigurationProfileScopeComputersComputerItem) *int { return i.ID }
+				checks := []error{
+					requireOnlyID("scope.targets.computer_ids", derefComputers(sc.Computers), computerID, f.targetComputer),
+					requireOnlyIDName("scope.targets.computer_group_ids", derefField(sc.ComputerGroups, func(g *proclassic.OsXConfigurationProfileScopeComputerGroups) *[]proclassic.IDName {
+						return g.ComputerGroup
+					}), want["grpT"]),
+					requireOnlyIDName("scope.targets.building_ids", derefField(sc.Buildings, func(b *proclassic.OsXConfigurationProfileScopeBuildings) *[]proclassic.IDName { return b.Building }), want["bldT"]),
+					requireOnlyIDName("scope.targets.department_ids", derefField(sc.Departments, func(d *proclassic.OsXConfigurationProfileScopeDepartments) *[]proclassic.IDName { return d.Department }), want["depT"]),
+					requireOnlyIDName("scope.targets.user_ids", derefField(sc.JssUsers, func(u *proclassic.OsXConfigurationProfileScopeJssUsers) *[]proclassic.IDName { return u.User }), f.targetUser),
+				}
+				for _, err := range checks {
+					if err != nil {
+						return err
+					}
+				}
+				l := sc.Limitations
+				if l == nil {
+					return fmt.Errorf("scope.limitations: absent")
+				}
+				checks = []error{
+					requireOnlyID("scope.limitations.network_segment_ids", derefField(l.NetworkSegments, func(n *proclassic.OsXConfigurationProfileScopeLimitationsNetworkSegments) *[]proclassic.OsXConfigurationProfileScopeLimitationsNetworkSegmentsNetworkSegmentItem {
+						return n.NetworkSegment
+					}), func(i proclassic.OsXConfigurationProfileScopeLimitationsNetworkSegmentsNetworkSegmentItem) *int {
+						return i.ID
+					}, want["segL"]),
+					requireOnlyIDName("scope.limitations.ibeacon_ids", derefField(l.Ibeacons, func(i *proclassic.OsXConfigurationProfileScopeLimitationsIbeacons) *[]proclassic.IDName {
+						return i.Ibeacon
+					}), want["ibL"]),
+					requireOnlyName("scope.limitations.directory_service_or_local_user_names", derefField(l.Users, func(u *proclassic.OsXConfigurationProfileScopeLimitationsUsers) *[]proclassic.IDName { return u.User }), func(i proclassic.IDName) *string { return i.Name }, "tf-acc-omit-retains-limit-user"),
+				}
+				for _, err := range checks {
+					if err != nil {
+						return err
+					}
+				}
+				e := sc.Exclusions
+				if e == nil {
+					return fmt.Errorf("scope.exclusions: absent")
+				}
+				checks = []error{
+					requireOnlyID("scope.exclusions.computer_ids", derefField(e.Computers, func(c *proclassic.OsXConfigurationProfileScopeExclusionsComputers) *[]proclassic.OsXConfigurationProfileScopeExclusionsComputersComputerItem {
+						return c.Computer
+					}), func(i proclassic.OsXConfigurationProfileScopeExclusionsComputersComputerItem) *int { return i.ID }, f.excludeComputer),
+					requireOnlyIDName("scope.exclusions.computer_group_ids", derefField(e.ComputerGroups, func(g *proclassic.OsXConfigurationProfileScopeExclusionsComputerGroups) *[]proclassic.IDName {
+						return g.ComputerGroup
+					}), want["grpX"]),
+					requireOnlyIDName("scope.exclusions.building_ids", derefField(e.Buildings, func(b *proclassic.OsXConfigurationProfileScopeExclusionsBuildings) *[]proclassic.IDName {
+						return b.Building
+					}), want["bldX"]),
+					requireOnlyIDName("scope.exclusions.department_ids", derefField(e.Departments, func(d *proclassic.OsXConfigurationProfileScopeExclusionsDepartments) *[]proclassic.IDName {
+						return d.Department
+					}), want["depX"]),
+					requireOnlyIDName("scope.exclusions.user_ids", derefField(e.JssUsers, func(u *proclassic.OsXConfigurationProfileScopeExclusionsJssUsers) *[]proclassic.IDName { return u.User }), f.excludeUser),
+					requireOnlyIDName("scope.exclusions.user_group_ids", derefField(e.JssUserGroups, func(u *proclassic.OsXConfigurationProfileScopeExclusionsJssUserGroups) *[]proclassic.IDName {
+						return u.UserGroup
+					}), want["ugX"]),
+					requireOnlyID("scope.exclusions.network_segment_ids", derefField(e.NetworkSegments, func(n *proclassic.OsXConfigurationProfileScopeExclusionsNetworkSegments) *[]proclassic.OsXConfigurationProfileScopeExclusionsNetworkSegmentsNetworkSegmentItem {
+						return n.NetworkSegment
+					}), func(i proclassic.OsXConfigurationProfileScopeExclusionsNetworkSegmentsNetworkSegmentItem) *int {
+						return i.ID
+					}, want["segX"]),
+					requireOnlyIDName("scope.exclusions.ibeacon_ids", derefField(e.Ibeacons, func(i *proclassic.OsXConfigurationProfileScopeExclusionsIbeacons) *[]proclassic.IDName {
+						return i.Ibeacon
+					}), want["ibX"]),
+					requireOnlyName("scope.exclusions.directory_service_or_local_user_names", derefField(e.Users, func(u *proclassic.OsXConfigurationProfileScopeExclusionsUsers) *[]proclassic.OsXConfigurationProfileScopeExclusionsUsersUserItem {
+						return u.User
+					}), func(i proclassic.OsXConfigurationProfileScopeExclusionsUsersUserItem) *string { return i.Name }, "tf-acc-omit-retains-exclude-user"),
+				}
+				for _, err := range checks {
+					if err != nil {
+						return err
+					}
+				}
+				ss := p.SelfService
+				if ss == nil {
+					return fmt.Errorf("self_service: absent")
+				}
+				checks = []error{
+					testhelpers.RequireEqual("self_service.self_service_display_name", "Omit retains display name", testhelpers.Deref(ss.SelfServiceDisplayName)),
+					testhelpers.RequireEqual("self_service.install_button_text", "Retain me", testhelpers.Deref(ss.InstallButtonText)),
+					testhelpers.RequireEqual("self_service.self_service_description", "Omit-retains contract description.", testhelpers.Deref(ss.SelfServiceDescription)),
+					testhelpers.RequireEqual("self_service.ensure_users_view_description", true, testhelpers.Deref(ss.ForceUsersToViewDescription)),
+					testhelpers.RequireEqual("self_service.feature_on_main_page", true, testhelpers.Deref(ss.FeatureOnMainPage)),
+				}
+				for _, err := range checks {
+					if err != nil {
+						return err
+					}
+				}
+				if ss.Security == nil {
+					return fmt.Errorf("self_service.security: absent")
+				}
+				if err := testhelpers.RequireEqual("self_service.removal_disallowed", "Never", testhelpers.Deref(ss.Security.RemovalDisallowed)); err != nil {
+					return err
+				}
+				cats := derefField(ss.SelfServiceCategories, func(c *proclassic.OsXConfigurationProfileSelfServiceSelfServiceCategories) *[]proclassic.OsXConfigurationProfileSelfServiceSelfServiceCategoriesCategoryItem {
+					return c.Category
+				})
+				if err := requireOnlyID("self_service.categories", cats, func(i proclassic.OsXConfigurationProfileSelfServiceSelfServiceCategoriesCategoryItem) *int {
+					return i.ID
+				}, want["category"]); err != nil {
+					return err
+				}
+				cat := (*cats)[0]
+				if err := testhelpers.RequireEqual("self_service.categories[0].display_in", true, testhelpers.Deref(cat.DisplayIn)); err != nil {
+					return err
+				}
+				return testhelpers.RequireEqual("self_service.categories[0].feature_in", true, testhelpers.Deref(cat.FeatureIn))
+			})(s)
+	}
+}
+
+// requireOnlyName is requireOnlyID for name-keyed classic members.
+func requireOnlyName[T any](field string, items *[]T, name func(T) *string, want string) error {
+	if items == nil || len(*items) != 1 {
+		n := 0
+		if items != nil {
+			n = len(*items)
+		}
+		return fmt.Errorf("%s: want exactly one member (%s), got %d", field, want, n)
+	}
+	return testhelpers.RequireEqual(field, want, testhelpers.Deref(name((*items)[0])))
+}
+
+// derefField reads a member slice out of an optional classic wrapper element,
+// yielding nil when the wrapper itself is absent.
+func derefField[W any, T any](w *W, get func(*W) *[]T) *[]T {
+	if w == nil {
+		return nil
+	}
+	return get(w)
+}
+
+func derefComputers(c *proclassic.OsXConfigurationProfileScopeComputers) *[]proclassic.OsXConfigurationProfileScopeComputersComputerItem {
+	return derefField(c, func(c *proclassic.OsXConfigurationProfileScopeComputers) *[]proclassic.OsXConfigurationProfileScopeComputersComputerItem {
+		return c.Computer
+	})
+}
+
+// TestAccResource_MacOSConfigurationProfile_OmittedBlocksRetained pins the
+// omit-retains contract the plan output cannot show: dropping scope
+// limitations, exclusions, target categories, self_service and its categories
+// from config plans them as removed, but the classic PUT either omits the
+// element or re-emits it from the granular scope merge, and the server keeps
+// every value. Step 2 keeps the scope and self_service parents while dropping
+// their gated children; step 3 drops every optional block so the PUT carries
+// <general> alone. Each step's implicit post-apply plan must be empty. If this
+// test fails on content, the endpoint no longer merges and nothing that
+// suppresses the removal plan may ship for this resource. The payload is never
+// touched between steps so a payload diff here is a finding of its own.
+func TestAccResource_MacOSConfigurationProfile_OmittedBlocksRetained(t *testing.T) {
+	testhelpers.AccPreCheck(t)
+	suffix := testhelpers.RunSuffix()
+	name := "tf-acc-mcp-omit-" + suffix
+	payload := readFixture(t, "1Password__notifications_profile.mobileconfig")
+	f := omitRetainsFixtures{
+		suffix:          suffix,
+		targetComputer:  createDummyComputer(t, "tf-acc-mcp-omit-comp-t-"+suffix),
+		excludeComputer: createDummyComputer(t, "tf-acc-mcp-omit-comp-x-"+suffix),
+		targetUser:      createDummyUser(t, "tf-acc-mcp-omit-user-t-"+suffix),
+		excludeUser:     createDummyUser(t, "tf-acc-mcp-omit-user-x-"+suffix),
+	}
+	const addr = "jamfplatform_pro_macos_configuration_profile.test"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testhelpers.AccTestProtoV6ProviderFactories,
+		CheckDestroy:             checkDestroy(t),
+		Steps: []resource.TestStep{
+			{
+				Config: omitRetainsConfig(name, payload, f),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(addr, "self_service.install_button_text", "Retain me"),
+					resource.TestCheckResourceAttr(addr, "self_service.categories.#", "1"),
+					resource.TestCheckResourceAttr(addr, "scope.exclusions.ibeacon_ids.#", "1"),
+					omitRetainedOnServer(t, f),
+				),
+			},
+			{
+				Config: omitRetainsParentsOnlyConfig(name, payload, f),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(addr, "self_service.categories.#", "1"),
+					resource.TestCheckResourceAttr(addr, "self_service.ensure_users_view_description", "true"),
+					resource.TestCheckNoResourceAttr(addr, "scope.limitations.network_segment_ids.#"),
+					resource.TestCheckNoResourceAttr(addr, "scope.exclusions.computer_ids.#"),
+					resource.TestCheckNoResourceAttr(addr, "scope.targets.user_ids.#"),
+					omitRetainedOnServer(t, f),
+				),
+			},
+			{
+				Config: omitRetainsGeneralOnlyConfig(name, payload, f),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr(addr, "scope.targets.computer_ids.#"),
+					resource.TestCheckNoResourceAttr(addr, "self_service.install_button_text"),
+					omitRetainedOnServer(t, f),
+				),
+			},
+		},
+	})
+}

--- a/internal/resources/pro/mobile_device_app/resource_acceptance_test.go
+++ b/internal/resources/pro/mobile_device_app/resource_acceptance_test.go
@@ -22,6 +22,8 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/proclassic"
@@ -664,6 +666,360 @@ func TestAccResource_ProMobileApp_ScopeLdapGroup(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(mobileAppResourceAddr, "id"),
 					resource.TestCheckResourceAttr(mobileAppResourceAddr, "scope.limitations.directory_service_user_group_names.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+// mobileAppOmitRetainsPreferences is the app_configuration plist the
+// omit-retains contract declares. The server stores it re-serialised inside a
+// full plist envelope (XML prolog, DOCTYPE, tab indentation — wire-observed
+// 2026-09-06), so the wire assertion looks for the distinctive value inside
+// the stored document rather than comparing the strings byte for byte.
+const (
+	mobileAppOmitRetainsPreferences      = "<dict><key>Server</key><string>https://example.com/omit-retains</string></dict>"
+	mobileAppOmitRetainsPreferencesValue = "<string>https://example.com/omit-retains</string>"
+)
+
+// mobileAppOmitRetainsFixtures returns the sibling objects every omit-retains
+// step references: two buildings (one targeted, one excluded), a department, a
+// network segment (limited and excluded) and a Self Service category.
+func mobileAppOmitRetainsFixtures(suffix string) string {
+	return fmt.Sprintf(`
+		resource "jamfplatform_pro_building" "b1" {
+			name = "tf-acc-mobileapp-omit-bldg1-%[1]s"
+		}
+
+		resource "jamfplatform_pro_building" "b2" {
+			name = "tf-acc-mobileapp-omit-bldg2-%[1]s"
+		}
+
+		resource "jamfplatform_pro_department" "d1" {
+			name = "tf-acc-mobileapp-omit-dept-%[1]s"
+		}
+
+		resource "jamfplatform_pro_network_segment" "n1" {
+			name             = "tf-acc-mobileapp-omit-ns-%[1]s"
+			starting_address = "10.213.0.1"
+			ending_address   = "10.213.0.254"
+		}
+
+		resource "jamfplatform_pro_category" "c1" {
+			name     = "tf-acc-mobileapp-omit-cat-%[1]s"
+			priority = 7
+		}
+	`, suffix)
+}
+
+// mobileAppOmitRetainsConfig is the fully declared shape for the omit-retains
+// contract: every state-gated block — scope targets / limitations /
+// exclusions, self_service with its categories, vpp and app_configuration —
+// carries a distinctive value so that a server which stopped retaining an
+// omitted element is caught on content, not on presence.
+func mobileAppOmitRetainsConfig(suffix, name string) string {
+	return mobileAppOmitRetainsFixtures(suffix) + fmt.Sprintf(`
+		resource "jamfplatform_pro_mobile_device_app" "test" {
+			general = {
+				name            = %[1]q
+				version         = "1.0"
+				bundle_id       = "com.example.tfacc.mobileapp.omit"
+				os_type         = "iOS"
+				deployment_type = "Make Available in Self Service"
+			}
+			scope = {
+				targets = {
+					building_ids   = [jamfplatform_pro_building.b1.id]
+					department_ids = [jamfplatform_pro_department.d1.id]
+				}
+				limitations = {
+					network_segment_ids                   = [jamfplatform_pro_network_segment.n1.id]
+					directory_service_or_local_user_names = ["tf-acc-omit-retains-limit-user"]
+				}
+				exclusions = {
+					building_ids                          = [jamfplatform_pro_building.b2.id]
+					network_segment_ids                   = [jamfplatform_pro_network_segment.n1.id]
+					directory_service_or_local_user_names = ["tf-acc-omit-retains-excl-user"]
+				}
+			}
+			self_service = {
+				install_button_text      = "Retain me"
+				self_service_description = "Omit-retains contract description."
+				feature_on_main_page     = true
+				self_service_categories = [
+					{
+						id         = jamfplatform_pro_category.c1.id
+						display_in = true
+					},
+				]
+			}
+			vpp = {
+				assign_vpp_device_based_licenses = false
+				vpp_admin_account_id             = "-1"
+			}
+			app_configuration = {
+				preferences = %[2]q
+			}
+		}
+	`, name, mobileAppOmitRetainsPreferences)
+}
+
+// mobileAppOmitRetainsParentsOnlyConfig keeps the two blocks that have gated
+// children but drops the children: scope keeps its targets and loses
+// limitations and exclusions (so the scope goes through the granular merge),
+// self_service loses self_service_categories and the Optional+Computed
+// feature_on_main_page leaf. vpp and app_configuration are dropped whole.
+func mobileAppOmitRetainsParentsOnlyConfig(suffix, name string) string {
+	return mobileAppOmitRetainsFixtures(suffix) + fmt.Sprintf(`
+		resource "jamfplatform_pro_mobile_device_app" "test" {
+			general = {
+				name            = %q
+				version         = "1.0"
+				bundle_id       = "com.example.tfacc.mobileapp.omit"
+				os_type         = "iOS"
+				deployment_type = "Make Available in Self Service"
+			}
+			scope = {
+				targets = {
+					building_ids   = [jamfplatform_pro_building.b1.id]
+					department_ids = [jamfplatform_pro_department.d1.id]
+				}
+			}
+			self_service = {
+				install_button_text      = "Retain me"
+				self_service_description = "Omit-retains contract description."
+			}
+		}
+	`, name)
+}
+
+// mobileAppOmitRetainsGeneralOnlyConfig drops every optional block, so the PUT
+// carries <general> alone. The fixtures stay so the server-side references
+// they back remain valid while the app still holds them.
+func mobileAppOmitRetainsGeneralOnlyConfig(suffix, name string) string {
+	return mobileAppOmitRetainsFixtures(suffix) + fmt.Sprintf(`
+		resource "jamfplatform_pro_mobile_device_app" "test" {
+			general = {
+				name            = %q
+				version         = "1.0"
+				bundle_id       = "com.example.tfacc.mobileapp.omit"
+				os_type         = "iOS"
+				deployment_type = "Make Available in Self Service"
+			}
+		}
+	`, name)
+}
+
+// mobileAppStateID reads a sibling fixture's Jamf Pro id out of Terraform state
+// so the wire assertion can compare scope members by value rather than count.
+func mobileAppStateID(s *terraform.State, addr string) (int, error) {
+	rs, ok := s.RootModule().Resources[addr]
+	if !ok {
+		return 0, fmt.Errorf("fixture %s not found in state", addr)
+	}
+	id, err := strconv.Atoi(rs.Primary.ID)
+	if err != nil {
+		return 0, fmt.Errorf("fixture %s: id %q is not an integer: %w", addr, rs.Primary.ID, err)
+	}
+	return id, nil
+}
+
+// mobileAppRetainedOnServer asserts the server's copy still carries every value
+// the omit-retains config declared in its first step. It covers only what the
+// GET echoes: self_service_after_install_button_text, notification,
+// notification_subject and notification_message are accepted on the PUT but
+// never returned for a mobile device app (wire-observed 2026-09-06), so the
+// config leaves them out rather than declare a value nothing can verify.
+func mobileAppRetainedOnServer(t *testing.T) resource.TestCheckFunc {
+	c := proclassic.New(testhelpers.NewAcceptanceClient(t))
+	return func(s *terraform.State) error {
+		b1, err := mobileAppStateID(s, "jamfplatform_pro_building.b1")
+		if err != nil {
+			return err
+		}
+		b2, err := mobileAppStateID(s, "jamfplatform_pro_building.b2")
+		if err != nil {
+			return err
+		}
+		d1, err := mobileAppStateID(s, "jamfplatform_pro_department.d1")
+		if err != nil {
+			return err
+		}
+		n1, err := mobileAppStateID(s, "jamfplatform_pro_network_segment.n1")
+		if err != nil {
+			return err
+		}
+		c1, err := mobileAppStateID(s, "jamfplatform_pro_category.c1")
+		if err != nil {
+			return err
+		}
+		return testhelpers.CheckLiveObject(mobileAppResourceAddr,
+			func(ctx context.Context, id string) (*proclassic.MobileDeviceApplication, error) {
+				return c.GetMobileDeviceApplicationByID(ctx, id)
+			},
+			func(a *proclassic.MobileDeviceApplication) error {
+				if a.Scope == nil {
+					return fmt.Errorf("scope: absent")
+				}
+				if err := requireOneIDName("scope.targets.buildings", buildingSliceOf(a.Scope.Buildings), b1); err != nil {
+					return err
+				}
+				if err := requireOneIDName("scope.targets.departments", departmentSliceOf(a.Scope.Departments), d1); err != nil {
+					return err
+				}
+				if a.Scope.Limitations == nil {
+					return fmt.Errorf("scope.limitations: absent")
+				}
+				if a.Scope.Limitations.NetworkSegments == nil {
+					return fmt.Errorf("scope.limitations.network_segments: absent")
+				}
+				if err := requireOneIDName("scope.limitations.network_segments", a.Scope.Limitations.NetworkSegments.NetworkSegment, n1); err != nil {
+					return err
+				}
+				if a.Scope.Limitations.Users == nil || a.Scope.Limitations.Users.User == nil || len(*a.Scope.Limitations.Users.User) != 1 {
+					return fmt.Errorf("scope.limitations.users: want exactly one user, got %+v", a.Scope.Limitations.Users)
+				}
+				if err := testhelpers.RequireEqual("scope.limitations.users[0].name", "tf-acc-omit-retains-limit-user", testhelpers.Deref((*a.Scope.Limitations.Users.User)[0].Name)); err != nil {
+					return err
+				}
+				if a.Scope.Exclusions == nil {
+					return fmt.Errorf("scope.exclusions: absent")
+				}
+				if a.Scope.Exclusions.Buildings == nil {
+					return fmt.Errorf("scope.exclusions.buildings: absent")
+				}
+				if err := requireOneIDName("scope.exclusions.buildings", a.Scope.Exclusions.Buildings.Building, b2); err != nil {
+					return err
+				}
+				if a.Scope.Exclusions.NetworkSegments == nil || a.Scope.Exclusions.NetworkSegments.NetworkSegment == nil || len(*a.Scope.Exclusions.NetworkSegments.NetworkSegment) != 1 {
+					return fmt.Errorf("scope.exclusions.network_segments: want exactly one segment, got %+v", a.Scope.Exclusions.NetworkSegments)
+				}
+				if err := testhelpers.RequireEqual("scope.exclusions.network_segments[0].id", n1, testhelpers.Deref((*a.Scope.Exclusions.NetworkSegments.NetworkSegment)[0].ID)); err != nil {
+					return err
+				}
+				if a.Scope.Exclusions.Users == nil || a.Scope.Exclusions.Users.User == nil || len(*a.Scope.Exclusions.Users.User) != 1 {
+					return fmt.Errorf("scope.exclusions.users: want exactly one user, got %+v", a.Scope.Exclusions.Users)
+				}
+				if err := testhelpers.RequireEqual("scope.exclusions.users[0].name", "tf-acc-omit-retains-excl-user", testhelpers.Deref((*a.Scope.Exclusions.Users.User)[0].Name)); err != nil {
+					return err
+				}
+
+				ss := a.SelfService
+				if ss == nil {
+					return fmt.Errorf("self_service: absent")
+				}
+				if err := testhelpers.RequireEqual("self_service.install_button_text", "Retain me", testhelpers.Deref(ss.SelfServiceInstallButtonText)); err != nil {
+					return err
+				}
+				if err := testhelpers.RequireEqual("self_service.self_service_description", "Omit-retains contract description.", testhelpers.Deref(ss.SelfServiceDescription)); err != nil {
+					return err
+				}
+				if err := testhelpers.RequireEqual("self_service.feature_on_main_page", true, testhelpers.Deref(ss.FeatureOnMainPage)); err != nil {
+					return err
+				}
+				if ss.SelfServiceCategories == nil || ss.SelfServiceCategories.Category == nil || len(*ss.SelfServiceCategories.Category) != 1 {
+					return fmt.Errorf("self_service.self_service_categories: want exactly one category, got %+v", ss.SelfServiceCategories)
+				}
+				cat := (*ss.SelfServiceCategories.Category)[0]
+				if err := testhelpers.RequireEqual("self_service.self_service_categories[0].id", c1, testhelpers.Deref(cat.ID)); err != nil {
+					return err
+				}
+				if err := testhelpers.RequireEqual("self_service.self_service_categories[0].display_in", true, testhelpers.Deref(cat.DisplayIn)); err != nil {
+					return err
+				}
+
+				if a.Vpp == nil {
+					return fmt.Errorf("vpp: absent")
+				}
+				if err := testhelpers.RequireEqual("vpp.assign_vpp_device_based_licenses", false, testhelpers.Deref(a.Vpp.AssignVppDeviceBasedLicenses)); err != nil {
+					return err
+				}
+				if err := testhelpers.RequireEqual("vpp.vpp_admin_account_id", -1, testhelpers.Deref(a.Vpp.VppAdminAccountID)); err != nil {
+					return err
+				}
+
+				if a.AppConfiguration == nil {
+					return fmt.Errorf("app_configuration: absent")
+				}
+				if prefs := testhelpers.Deref(a.AppConfiguration.Preferences); !strings.Contains(prefs, mobileAppOmitRetainsPreferencesValue) {
+					return fmt.Errorf("app_configuration.preferences: want a plist containing %s, got %q", mobileAppOmitRetainsPreferencesValue, prefs)
+				}
+				return nil
+			})(s)
+	}
+}
+
+// requireOneIDName asserts an id/name scope category holds exactly the one
+// member with the given id.
+func requireOneIDName(field string, items *[]proclassic.IDName, wantID int) error {
+	if items == nil || len(*items) != 1 {
+		return fmt.Errorf("%s: want exactly one member, got %+v", field, items)
+	}
+	return testhelpers.RequireEqual(field+"[0].id", wantID, testhelpers.Deref((*items)[0].ID))
+}
+
+func buildingSliceOf(b *proclassic.MobileDeviceApplicationScopeBuildings) *[]proclassic.IDName {
+	if b == nil {
+		return nil
+	}
+	return b.Building
+}
+
+func departmentSliceOf(d *proclassic.MobileDeviceApplicationScopeDepartments) *[]proclassic.IDName {
+	if d == nil {
+		return nil
+	}
+	return d.Department
+}
+
+// TestAccResource_ProMobileApp_OmittedBlocksRetained pins the omit-retains
+// contract the plan output cannot show: dropping scope limitations and
+// exclusions, self_service categories, vpp and app_configuration from config
+// plans them as removed, but the classic PUT omits the elements and the
+// server keeps every value. Step 2 keeps scope.targets and a trimmed
+// self_service so the scope goes through the granular merge and the
+// self_service PUT omits its categories; step 3 drops every optional block so
+// the PUT carries <general> alone. Each step's implicit post-apply plan must
+// be empty, which is what makes the contract usable. If this test fails on
+// content, the endpoint no longer merges and nothing that suppresses the
+// removal plan may ship for this resource.
+func TestAccResource_ProMobileApp_OmittedBlocksRetained(t *testing.T) {
+	testhelpers.AccPreCheck(t)
+	suffix := testhelpers.RunSuffix()
+	name := "tf-acc-pro-mobileapp-omit-" + suffix
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testhelpers.AccTestProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckMobileAppDestroy(t),
+		Steps: []resource.TestStep{
+			{
+				Config: mobileAppOmitRetainsConfig(suffix, name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(mobileAppResourceAddr, "self_service.install_button_text", "Retain me"),
+					resource.TestCheckResourceAttr(mobileAppResourceAddr, "self_service.self_service_categories.#", "1"),
+					resource.TestCheckResourceAttr(mobileAppResourceAddr, "scope.exclusions.building_ids.#", "1"),
+					mobileAppRetainedOnServer(t),
+				),
+			},
+			{
+				Config: mobileAppOmitRetainsParentsOnlyConfig(suffix, name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(mobileAppResourceAddr, "scope.targets.building_ids.#", "1"),
+					resource.TestCheckResourceAttr(mobileAppResourceAddr, "self_service.feature_on_main_page", "true"),
+					resource.TestCheckNoResourceAttr(mobileAppResourceAddr, "scope.limitations.network_segment_ids.#"),
+					resource.TestCheckNoResourceAttr(mobileAppResourceAddr, "scope.exclusions.building_ids.#"),
+					resource.TestCheckNoResourceAttr(mobileAppResourceAddr, "self_service.self_service_categories.#"),
+					resource.TestCheckNoResourceAttr(mobileAppResourceAddr, "vpp.vpp_admin_account_id"),
+					resource.TestCheckNoResourceAttr(mobileAppResourceAddr, "app_configuration.preferences"),
+					mobileAppRetainedOnServer(t),
+				),
+			},
+			{
+				Config: mobileAppOmitRetainsGeneralOnlyConfig(suffix, name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr(mobileAppResourceAddr, "scope.targets.building_ids.#"),
+					resource.TestCheckNoResourceAttr(mobileAppResourceAddr, "self_service.install_button_text"),
+					mobileAppRetainedOnServer(t),
 				),
 			},
 		},

--- a/internal/resources/pro/mobile_device_configuration_profile/resource_acceptance_test.go
+++ b/internal/resources/pro/mobile_device_configuration_profile/resource_acceptance_test.go
@@ -1168,3 +1168,442 @@ func injectPlistTailKey(plist string) string {
 	}
 	return plist
 }
+
+// omitRetainsFixtures carries the out-of-band (SDK-created) fixture IDs the
+// omit-retains configs reference, plus the run suffix that names the inline
+// HCL fixtures. The inline fixture IDs are only known after apply, so the
+// wire assertion resolves them from Terraform state rather than from here.
+type omitRetainsFixtures struct {
+	suffix       string
+	targetGroup  string
+	excludeGroup string
+	targetUser   string
+	excludeUser  string
+}
+
+// omitRetainsFixtureHCL declares one inline fixture per scope category. Targets
+// and exclusions each get their own fixture so the wire assertion can tell a
+// retained exclusion from a leaked target.
+func omitRetainsFixtureHCL(suffix string) string {
+	return fmt.Sprintf(`
+resource "jamfplatform_pro_building" "target" {
+  name = "tf-acc-mdcp-omit-bld-t-%[1]s"
+}
+
+resource "jamfplatform_pro_building" "exclude" {
+  name = "tf-acc-mdcp-omit-bld-x-%[1]s"
+}
+
+resource "jamfplatform_pro_department" "target" {
+  name = "tf-acc-mdcp-omit-dep-t-%[1]s"
+}
+
+resource "jamfplatform_pro_department" "exclude" {
+  name = "tf-acc-mdcp-omit-dep-x-%[1]s"
+}
+
+resource "jamfplatform_pro_user_group" "target" {
+  name       = "tf-acc-mdcp-omit-ug-t-%[1]s"
+  group_type = "static"
+}
+
+resource "jamfplatform_pro_user_group" "exclude" {
+  name       = "tf-acc-mdcp-omit-ug-x-%[1]s"
+  group_type = "static"
+}
+
+resource "jamfplatform_pro_network_segment" "limit" {
+  name             = "tf-acc-mdcp-omit-seg-l-%[1]s"
+  starting_address = "10.93.0.0"
+  ending_address   = "10.93.0.255"
+}
+
+resource "jamfplatform_pro_network_segment" "exclude" {
+  name             = "tf-acc-mdcp-omit-seg-x-%[1]s"
+  starting_address = "10.93.1.0"
+  ending_address   = "10.93.1.255"
+}
+
+resource "jamfplatform_pro_ibeacon" "limit" {
+  name                    = "tf-acc-mdcp-omit-ib-l-%[1]s"
+  uuid                    = "759b0599-64e0-416a-8d31-d8e93482a4d7"
+  include_any_major_value = true
+  include_any_minor_value = true
+}
+
+resource "jamfplatform_pro_ibeacon" "exclude" {
+  name                    = "tf-acc-mdcp-omit-ib-x-%[1]s"
+  uuid                    = "759b0599-64e0-416a-8d31-d8e93482a4d7"
+  major                   = 42
+  include_any_minor_value = true
+}
+`, suffix)
+}
+
+// omitRetainsConfig is the fully declared shape for the omit-retains contract:
+// every state-gated block and every scope category the resource has carries a
+// distinctive value so that a server which stopped retaining an omitted
+// element is caught on content, not on presence. Left out: the two
+// directory-service user-group categories (the server refuses a group name
+// that does not resolve against the tenant's directory integration), the
+// per-device categories (no enrolled mobile device fixture exists),
+// authorization_password (its removal_disallowed pairing injects a payload the
+// mask must strip, which is a separate test's concern), and
+// self_service.categories, because this endpoint never stores one: wire-probed
+// 2026-09-06, a POST or PUT carrying <self_service_categories> (id-only or
+// id+name) answers 2xx and every GET afterwards returns
+// <self_service_categories/>, so the attribute's Computed name can never
+// become known after apply on this resource.
+func omitRetainsConfig(name, payload string, f omitRetainsFixtures) string {
+	return omitRetainsFixtureHCL(f.suffix) + fmt.Sprintf(`
+resource "jamfplatform_pro_mobile_device_configuration_profile" "test" {
+  general = {
+    name                = %q
+    distribution_method = "Make Available in Self Service"
+    payloads = <<EOF
+%sEOF
+  }
+  scope = {
+    targets = {
+      mobile_device_group_ids = [%q]
+      building_ids            = [jamfplatform_pro_building.target.id]
+      department_ids          = [jamfplatform_pro_department.target.id]
+      user_ids                = [%q]
+      user_group_ids          = [jamfplatform_pro_user_group.target.id]
+    }
+    limitations = {
+      network_segment_ids                   = [jamfplatform_pro_network_segment.limit.id]
+      ibeacon_ids                           = [jamfplatform_pro_ibeacon.limit.id]
+      directory_service_or_local_user_names = ["tf-acc-omit-retains-limit-user"]
+    }
+    exclusions = {
+      mobile_device_group_ids               = [%q]
+      building_ids                          = [jamfplatform_pro_building.exclude.id]
+      department_ids                        = [jamfplatform_pro_department.exclude.id]
+      user_ids                              = [%q]
+      user_group_ids                        = [jamfplatform_pro_user_group.exclude.id]
+      network_segment_ids                   = [jamfplatform_pro_network_segment.exclude.id]
+      ibeacon_ids                           = [jamfplatform_pro_ibeacon.exclude.id]
+      directory_service_or_local_user_names = ["tf-acc-omit-retains-exclude-user"]
+    }
+  }
+  self_service = {
+    self_service_description = "Omit-retains contract description."
+    feature_on_main_page     = true
+    removal_disallowed       = "Never"
+  }
+  depends_on = [
+    jamfplatform_pro_building.target, jamfplatform_pro_building.exclude,
+    jamfplatform_pro_department.target, jamfplatform_pro_department.exclude,
+    jamfplatform_pro_user_group.target, jamfplatform_pro_user_group.exclude,
+    jamfplatform_pro_network_segment.limit, jamfplatform_pro_network_segment.exclude,
+    jamfplatform_pro_ibeacon.limit, jamfplatform_pro_ibeacon.exclude,
+  ]
+}
+`, name, payload, f.targetGroup, f.targetUser, f.excludeGroup, f.excludeUser)
+}
+
+// omitRetainsParentsOnlyConfig keeps the scope and self_service parents but
+// drops their gated children: scope loses limitations, exclusions and the two
+// user target categories, so the PUT re-emits the scope from the granular
+// merge; self_service loses the Optional+Computed feature_on_main_page leaf.
+func omitRetainsParentsOnlyConfig(name, payload string, f omitRetainsFixtures) string {
+	return omitRetainsFixtureHCL(f.suffix) + fmt.Sprintf(`
+resource "jamfplatform_pro_mobile_device_configuration_profile" "test" {
+  general = {
+    name                = %q
+    distribution_method = "Make Available in Self Service"
+    payloads = <<EOF
+%sEOF
+  }
+  scope = {
+    targets = {
+      mobile_device_group_ids = [%q]
+      building_ids            = [jamfplatform_pro_building.target.id]
+      department_ids          = [jamfplatform_pro_department.target.id]
+    }
+  }
+  self_service = {
+    self_service_description = "Omit-retains contract description."
+    removal_disallowed       = "Never"
+  }
+  depends_on = [
+    jamfplatform_pro_building.target, jamfplatform_pro_building.exclude,
+    jamfplatform_pro_department.target, jamfplatform_pro_department.exclude,
+    jamfplatform_pro_user_group.target, jamfplatform_pro_user_group.exclude,
+    jamfplatform_pro_network_segment.limit, jamfplatform_pro_network_segment.exclude,
+    jamfplatform_pro_ibeacon.limit, jamfplatform_pro_ibeacon.exclude,
+  ]
+}
+`, name, payload, f.targetGroup)
+}
+
+// omitRetainsGeneralOnlyConfig drops every optional block, so the PUT carries
+// <general> alone. The fixtures stay declared so nothing the server still
+// references is destroyed underneath it, and every config lists them in
+// depends_on: once a step stops referencing a fixture from the profile, the
+// dependency edge is gone and Terraform would otherwise destroy the fixture in
+// parallel with the profile, which the server refuses while the retained scope
+// still names it.
+func omitRetainsGeneralOnlyConfig(name, payload string, f omitRetainsFixtures) string {
+	return omitRetainsFixtureHCL(f.suffix) + fmt.Sprintf(`
+resource "jamfplatform_pro_mobile_device_configuration_profile" "test" {
+  general = {
+    name                = %q
+    distribution_method = "Make Available in Self Service"
+    payloads = <<EOF
+%sEOF
+  }
+  depends_on = [
+    jamfplatform_pro_building.target, jamfplatform_pro_building.exclude,
+    jamfplatform_pro_department.target, jamfplatform_pro_department.exclude,
+    jamfplatform_pro_user_group.target, jamfplatform_pro_user_group.exclude,
+    jamfplatform_pro_network_segment.limit, jamfplatform_pro_network_segment.exclude,
+    jamfplatform_pro_ibeacon.limit, jamfplatform_pro_ibeacon.exclude,
+  ]
+}
+`, name, payload)
+}
+
+// requireOnlyID asserts a classic member list holds exactly one entry whose
+// id is want. Membership is checked on count as well as content so a server
+// that appended rather than retained is caught too.
+func requireOnlyID[T any](field string, items *[]T, id func(T) *int, want string) error {
+	if items == nil || len(*items) != 1 {
+		n := 0
+		if items != nil {
+			n = len(*items)
+		}
+		return fmt.Errorf("%s: want exactly one member (%s), got %d", field, want, n)
+	}
+	return testhelpers.RequireEqual(field, want, fmt.Sprint(testhelpers.Deref(id((*items)[0]))))
+}
+
+// requireOnlyIDName is requireOnlyID for the SDK's shared IDName element.
+func requireOnlyIDName(field string, items *[]proclassic.IDName, want string) error {
+	return requireOnlyID(field, items, func(i proclassic.IDName) *int { return i.ID }, want)
+}
+
+// requireOnlyName is requireOnlyID for name-keyed classic members.
+func requireOnlyName[T any](field string, items *[]T, name func(T) *string, want string) error {
+	if items == nil || len(*items) != 1 {
+		n := 0
+		if items != nil {
+			n = len(*items)
+		}
+		return fmt.Errorf("%s: want exactly one member (%s), got %d", field, want, n)
+	}
+	return testhelpers.RequireEqual(field, want, testhelpers.Deref(name((*items)[0])))
+}
+
+// derefField reads a member slice out of an optional classic wrapper element,
+// yielding nil when the wrapper itself is absent.
+func derefField[W any, T any](w *W, get func(*W) *[]T) *[]T {
+	if w == nil {
+		return nil
+	}
+	return get(w)
+}
+
+// stateID returns the primary id of a fixture resource from Terraform state,
+// which is how the wire assertion learns the ids Jamf allocated to the inline
+// fixtures.
+func stateID(s *terraform.State, addr string) (string, error) {
+	rs, ok := s.RootModule().Resources[addr]
+	if !ok {
+		return "", fmt.Errorf("fixture %s not found in state", addr)
+	}
+	if rs.Primary.ID == "" {
+		return "", fmt.Errorf("fixture %s has no id in state", addr)
+	}
+	return rs.Primary.ID, nil
+}
+
+// omitRetainedOnServer asserts the server's copy still carries every value the
+// omit-retains config declared in its first step. Inline fixture ids are read
+// from state because Jamf allocates them at apply. self_service_description is
+// declared but not asserted: the classic GET returns
+// <self_service_description/> for a mobile profile whatever was written
+// (wire-probed 2026-09-06), so no read can witness whether the server kept it.
+func omitRetainedOnServer(t *testing.T, f omitRetainsFixtures) resource.TestCheckFunc {
+	c := testhelpers.NewProClassicClient(t)
+	const addr = "jamfplatform_pro_mobile_device_configuration_profile.test"
+	return func(s *terraform.State) error {
+		want := map[string]string{}
+		for _, fx := range []struct{ key, addr string }{
+			{"bldT", "jamfplatform_pro_building.target"},
+			{"bldX", "jamfplatform_pro_building.exclude"},
+			{"depT", "jamfplatform_pro_department.target"},
+			{"depX", "jamfplatform_pro_department.exclude"},
+			{"ugT", "jamfplatform_pro_user_group.target"},
+			{"ugX", "jamfplatform_pro_user_group.exclude"},
+			{"segL", "jamfplatform_pro_network_segment.limit"},
+			{"segX", "jamfplatform_pro_network_segment.exclude"},
+			{"ibL", "jamfplatform_pro_ibeacon.limit"},
+			{"ibX", "jamfplatform_pro_ibeacon.exclude"},
+		} {
+			v, err := stateID(s, fx.addr)
+			if err != nil {
+				return err
+			}
+			want[fx.key] = v
+		}
+		return testhelpers.CheckLiveObject(addr,
+			func(ctx context.Context, id string) (*proclassic.MobileDeviceConfigurationProfile, error) {
+				return c.GetMobileDeviceConfigurationProfileByID(ctx, id)
+			},
+			func(p *proclassic.MobileDeviceConfigurationProfile) error {
+				sc := p.Scope
+				if sc == nil {
+					return fmt.Errorf("scope: absent")
+				}
+				checks := []error{
+					requireOnlyIDName("scope.targets.mobile_device_group_ids", derefField(sc.MobileDeviceGroups, func(g *proclassic.MobileDeviceConfigurationProfileScopeMobileDeviceGroups) *[]proclassic.IDName {
+						return g.MobileDeviceGroup
+					}), f.targetGroup),
+					requireOnlyIDName("scope.targets.building_ids", derefField(sc.Buildings, func(b *proclassic.MobileDeviceConfigurationProfileScopeBuildings) *[]proclassic.IDName {
+						return b.Building
+					}), want["bldT"]),
+					requireOnlyIDName("scope.targets.department_ids", derefField(sc.Departments, func(d *proclassic.MobileDeviceConfigurationProfileScopeDepartments) *[]proclassic.IDName {
+						return d.Department
+					}), want["depT"]),
+					requireOnlyIDName("scope.targets.user_ids", derefField(sc.JssUsers, func(u *proclassic.MobileDeviceConfigurationProfileScopeJssUsers) *[]proclassic.IDName { return u.User }), f.targetUser),
+					requireOnlyIDName("scope.targets.user_group_ids", derefField(sc.JssUserGroups, func(u *proclassic.MobileDeviceConfigurationProfileScopeJssUserGroups) *[]proclassic.IDName {
+						return u.UserGroup
+					}), want["ugT"]),
+				}
+				for _, err := range checks {
+					if err != nil {
+						return err
+					}
+				}
+				l := sc.Limitations
+				if l == nil {
+					return fmt.Errorf("scope.limitations: absent")
+				}
+				checks = []error{
+					requireOnlyIDName("scope.limitations.network_segment_ids", derefField(l.NetworkSegments, func(n *proclassic.MobileDeviceConfigurationProfileScopeLimitationsNetworkSegments) *[]proclassic.IDName {
+						return n.NetworkSegment
+					}), want["segL"]),
+					requireOnlyIDName("scope.limitations.ibeacon_ids", derefField(l.Ibeacons, func(i *proclassic.MobileDeviceConfigurationProfileScopeLimitationsIbeacons) *[]proclassic.IDName {
+						return i.Ibeacon
+					}), want["ibL"]),
+					requireOnlyName("scope.limitations.directory_service_or_local_user_names", derefField(l.Users, func(u *proclassic.MobileDeviceConfigurationProfileScopeLimitationsUsers) *[]proclassic.IDName {
+						return u.User
+					}), func(i proclassic.IDName) *string { return i.Name }, "tf-acc-omit-retains-limit-user"),
+				}
+				for _, err := range checks {
+					if err != nil {
+						return err
+					}
+				}
+				e := sc.Exclusions
+				if e == nil {
+					return fmt.Errorf("scope.exclusions: absent")
+				}
+				checks = []error{
+					requireOnlyIDName("scope.exclusions.mobile_device_group_ids", derefField(e.MobileDeviceGroups, func(g *proclassic.MobileDeviceConfigurationProfileScopeExclusionsMobileDeviceGroups) *[]proclassic.IDName {
+						return g.MobileDeviceGroup
+					}), f.excludeGroup),
+					requireOnlyIDName("scope.exclusions.building_ids", derefField(e.Buildings, func(b *proclassic.MobileDeviceConfigurationProfileScopeExclusionsBuildings) *[]proclassic.IDName {
+						return b.Building
+					}), want["bldX"]),
+					requireOnlyIDName("scope.exclusions.department_ids", derefField(e.Departments, func(d *proclassic.MobileDeviceConfigurationProfileScopeExclusionsDepartments) *[]proclassic.IDName {
+						return d.Department
+					}), want["depX"]),
+					requireOnlyIDName("scope.exclusions.user_ids", derefField(e.JssUsers, func(u *proclassic.MobileDeviceConfigurationProfileScopeExclusionsJssUsers) *[]proclassic.IDName {
+						return u.User
+					}), f.excludeUser),
+					requireOnlyIDName("scope.exclusions.user_group_ids", derefField(e.JssUserGroups, func(u *proclassic.MobileDeviceConfigurationProfileScopeExclusionsJssUserGroups) *[]proclassic.IDName {
+						return u.UserGroup
+					}), want["ugX"]),
+					requireOnlyID("scope.exclusions.network_segment_ids", derefField(e.NetworkSegments, func(n *proclassic.MobileDeviceConfigurationProfileScopeExclusionsNetworkSegments) *[]proclassic.MobileDeviceConfigurationProfileScopeExclusionsNetworkSegmentsNetworkSegmentItem {
+						return n.NetworkSegment
+					}), func(i proclassic.MobileDeviceConfigurationProfileScopeExclusionsNetworkSegmentsNetworkSegmentItem) *int {
+						return i.ID
+					}, want["segX"]),
+					requireOnlyIDName("scope.exclusions.ibeacon_ids", derefField(e.Ibeacons, func(i *proclassic.MobileDeviceConfigurationProfileScopeExclusionsIbeacons) *[]proclassic.IDName {
+						return i.Ibeacon
+					}), want["ibX"]),
+					requireOnlyName("scope.exclusions.directory_service_or_local_user_names", derefField(e.Users, func(u *proclassic.MobileDeviceConfigurationProfileScopeExclusionsUsers) *[]proclassic.MobileDeviceConfigurationProfileScopeExclusionsUsersUserItem {
+						return u.User
+					}), func(i proclassic.MobileDeviceConfigurationProfileScopeExclusionsUsersUserItem) *string { return i.Name }, "tf-acc-omit-retains-exclude-user"),
+				}
+				for _, err := range checks {
+					if err != nil {
+						return err
+					}
+				}
+				ss := p.SelfService
+				if ss == nil {
+					return fmt.Errorf("self_service: absent")
+				}
+				if err := testhelpers.RequireEqual("self_service.feature_on_main_page", true, testhelpers.Deref(ss.FeatureOnMainPage)); err != nil {
+					return err
+				}
+				if ss.Security == nil {
+					return fmt.Errorf("self_service.security: absent")
+				}
+				return testhelpers.RequireEqual("self_service.removal_disallowed", "Never", testhelpers.Deref(ss.Security.RemovalDisallowed))
+			})(s)
+	}
+}
+
+// TestAccResource_MobileDeviceConfigurationProfile_OmittedBlocksRetained pins
+// the omit-retains contract the plan output cannot show: dropping scope
+// limitations, exclusions, target categories and self_service from config
+// plans them as removed, but the classic PUT either omits the
+// element or re-emits it from the granular scope merge, and the server keeps
+// every value. Step 2 keeps the scope and self_service parents while dropping
+// their gated children; step 3 drops every optional block so the PUT carries
+// <general> alone. Each step's implicit post-apply plan must be empty. If this
+// test fails on content, the endpoint no longer merges and nothing that
+// suppresses the removal plan may ship for this resource. The payload is never
+// touched between steps so a payload diff here is a finding of its own.
+func TestAccResource_MobileDeviceConfigurationProfile_OmittedBlocksRetained(t *testing.T) {
+	testhelpers.AccPreCheck(t)
+	suffix := testhelpers.RunSuffix()
+	name := "tf-acc-mdcp-omit-" + suffix
+	payload := freshPayload(t, "profile_44.mobileconfig")
+	f := omitRetainsFixtures{
+		suffix:       suffix,
+		targetGroup:  createDummyMobileDeviceGroup(t, "tf-acc-mdcp-omit-grp-t-"+suffix),
+		excludeGroup: createDummyMobileDeviceGroup(t, "tf-acc-mdcp-omit-grp-x-"+suffix),
+		targetUser:   createDummyUser(t, "tf-acc-mdcp-omit-user-t-"+suffix),
+		excludeUser:  createDummyUser(t, "tf-acc-mdcp-omit-user-x-"+suffix),
+	}
+	const addr = "jamfplatform_pro_mobile_device_configuration_profile.test"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testhelpers.AccTestProtoV6ProviderFactories,
+		CheckDestroy:             checkDestroy(t),
+		Steps: []resource.TestStep{
+			{
+				Config: omitRetainsConfig(name, payload, f),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(addr, "self_service.feature_on_main_page", "true"),
+					resource.TestCheckResourceAttr(addr, "scope.exclusions.ibeacon_ids.#", "1"),
+					omitRetainedOnServer(t, f),
+				),
+			},
+			{
+				Config: omitRetainsParentsOnlyConfig(name, payload, f),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(addr, "self_service.feature_on_main_page", "true"),
+					resource.TestCheckNoResourceAttr(addr, "scope.limitations.network_segment_ids.#"),
+					resource.TestCheckNoResourceAttr(addr, "scope.exclusions.mobile_device_group_ids.#"),
+					resource.TestCheckNoResourceAttr(addr, "scope.targets.user_ids.#"),
+					omitRetainedOnServer(t, f),
+				),
+			},
+			{
+				Config: omitRetainsGeneralOnlyConfig(name, payload, f),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr(addr, "scope.targets.mobile_device_group_ids.#"),
+					resource.TestCheckNoResourceAttr(addr, "self_service.self_service_description"),
+					omitRetainedOnServer(t, f),
+				),
+			},
+		},
+	})
+}

--- a/internal/resources/pro/mobile_device_enrollment_profile/resource_acceptance_test.go
+++ b/internal/resources/pro/mobile_device_enrollment_profile/resource_acceptance_test.go
@@ -229,3 +229,230 @@ data "jamfplatform_pro_mobile_device_enrollment_profile" "bad" {
 		},
 	})
 }
+
+// mdepOmitRetainsFixtures declares the site, department and building the
+// omit-retains configs reference. The department and building are real objects
+// rather than free text so the location leaves name something the tenant knows.
+func mdepOmitRetainsFixtures(name string) string {
+	return fmt.Sprintf(`
+resource "jamfplatform_pro_site" "omit" {
+  name = "%[1]s-site"
+}
+
+resource "jamfplatform_pro_department" "omit" {
+  name = "%[1]s-dept"
+}
+
+resource "jamfplatform_pro_building" "omit" {
+  name = "%[1]s-bldg"
+}
+`, name)
+}
+
+// mdepOmitRetainsConfig is the fully declared shape for the omit-retains
+// contract: both state-gated blocks (location, purchasing) carry a distinctive
+// value in every writable leaf so that a server which stopped retaining an
+// omitted element is caught on content, not on presence. is_purchased is false
+// and is_leased true because the server treats the pair as exclusive: a write
+// carrying both true is stored with is_leased reset to false (wire-observed
+// 2026-09-06), which the provider does not yet reject at plan time.
+func mdepOmitRetainsConfig(name string) string {
+	return mdepOmitRetainsFixtures(name) + fmt.Sprintf(`
+resource "jamfplatform_pro_mobile_device_enrollment_profile" "test" {
+  depends_on  = [jamfplatform_pro_site.omit, jamfplatform_pro_department.omit, jamfplatform_pro_building.omit]
+  name        = %[1]q
+  description = "Omit-retains contract profile."
+  site_id     = jamfplatform_pro_site.omit.id
+
+  location = {
+    username      = "omit.retains"
+    real_name     = "Omit Retains"
+    email_address = "omit.retains@example.com"
+    phone_number  = "+1 555 0100"
+    department    = jamfplatform_pro_department.omit.name
+    building      = jamfplatform_pro_building.omit.name
+    room          = "R-omit"
+    position      = "Retained Position"
+  }
+
+  purchasing = {
+    is_purchased       = false
+    is_leased          = true
+    po_number          = "PO-OMIT-1"
+    po_date            = "2024-02-29"
+    vendor             = "Omit Vendor"
+    warranty_expires   = "2027-03-31"
+    applecare_id       = "AC-OMIT-1"
+    lease_expires      = "2028-04-30"
+    purchase_price     = "1234.56"
+    life_expectancy    = 7
+    purchasing_account = "ACCT-OMIT"
+    purchasing_contact = "Contact Omit"
+  }
+}
+`, name)
+}
+
+// mdepOmitRetainsLeavesDroppedConfig keeps both blocks and drops two leaves
+// that the merge treats differently: life_expectancy is Optional+Computed, so
+// the builder omits it and the server retains 7; room is plain Optional, so
+// the builder emits <room></room> and the server clears it. The second is the
+// documented clear-by-omission half of this endpoint's contract, not a retain
+// case.
+func mdepOmitRetainsLeavesDroppedConfig(name string) string {
+	return mdepOmitRetainsFixtures(name) + fmt.Sprintf(`
+resource "jamfplatform_pro_mobile_device_enrollment_profile" "test" {
+  depends_on  = [jamfplatform_pro_site.omit, jamfplatform_pro_department.omit, jamfplatform_pro_building.omit]
+  name        = %[1]q
+  description = "Omit-retains contract profile."
+  site_id     = jamfplatform_pro_site.omit.id
+
+  location = {
+    username      = "omit.retains"
+    real_name     = "Omit Retains"
+    email_address = "omit.retains@example.com"
+    phone_number  = "+1 555 0100"
+    department    = jamfplatform_pro_department.omit.name
+    building      = jamfplatform_pro_building.omit.name
+    position      = "Retained Position"
+  }
+
+  purchasing = {
+    is_purchased       = false
+    is_leased          = true
+    po_number          = "PO-OMIT-1"
+    po_date            = "2024-02-29"
+    vendor             = "Omit Vendor"
+    warranty_expires   = "2027-03-31"
+    applecare_id       = "AC-OMIT-1"
+    lease_expires      = "2028-04-30"
+    purchase_price     = "1234.56"
+    purchasing_account = "ACCT-OMIT"
+    purchasing_contact = "Contact Omit"
+  }
+}
+`, name)
+}
+
+// mdepOmitRetainsGeneralOnlyConfig drops both optional blocks, so the PUT
+// carries <general> alone.
+func mdepOmitRetainsGeneralOnlyConfig(name string) string {
+	return mdepOmitRetainsFixtures(name) + fmt.Sprintf(`
+resource "jamfplatform_pro_mobile_device_enrollment_profile" "test" {
+  depends_on  = [jamfplatform_pro_site.omit, jamfplatform_pro_department.omit, jamfplatform_pro_building.omit]
+  name        = %[1]q
+  description = "Omit-retains contract profile."
+  site_id     = jamfplatform_pro_site.omit.id
+}
+`, name)
+}
+
+// mdepRetainedOnServer asserts the server's copy still carries every value the
+// omit-retains config declared in its first step. wantRoom is the one leaf the
+// contract test deliberately clears mid-run (step 2 omits it inside a kept
+// block), so the caller states what the server should hold after each step.
+func mdepRetainedOnServer(t *testing.T, name, wantRoom string) resource.TestCheckFunc {
+	c := proclassic.New(testhelpers.NewAcceptanceClient(t))
+	return testhelpers.CheckLiveObject(resAddr,
+		func(ctx context.Context, id string) (*proclassic.MobileDeviceEnrollmentProfile, error) {
+			return c.GetMobileDeviceEnrollmentProfileByID(ctx, id)
+		},
+		func(p *proclassic.MobileDeviceEnrollmentProfile) error {
+			if p.Location == nil {
+				return fmt.Errorf("location: absent")
+			}
+			l := p.Location
+			for _, f := range []struct{ field, want, got string }{
+				{"location.username", "omit.retains", testhelpers.Deref(l.Username)},
+				{"location.real_name", "Omit Retains", testhelpers.Deref(l.RealName)},
+				{"location.email_address", "omit.retains@example.com", testhelpers.Deref(l.EmailAddress)},
+				{"location.phone_number", "+1 555 0100", testhelpers.Deref(l.PhoneNumber)},
+				{"location.department", name + "-dept", testhelpers.Deref(l.Department)},
+				{"location.building", name + "-bldg", testhelpers.Deref(l.Building)},
+				{"location.room", wantRoom, testhelpers.Deref(l.Room)},
+				{"location.position", "Retained Position", testhelpers.Deref(l.Position)},
+			} {
+				if err := testhelpers.RequireEqual(f.field, f.want, f.got); err != nil {
+					return err
+				}
+			}
+			if p.Purchasing == nil {
+				return fmt.Errorf("purchasing: absent")
+			}
+			u := p.Purchasing
+			if err := testhelpers.RequireEqual("purchasing.is_purchased", false, testhelpers.Deref(u.IsPurchased)); err != nil {
+				return err
+			}
+			if err := testhelpers.RequireEqual("purchasing.is_leased", true, testhelpers.Deref(u.IsLeased)); err != nil {
+				return err
+			}
+			if err := testhelpers.RequireEqual("purchasing.life_expectancy", 7, testhelpers.Deref(u.LifeExpectancy)); err != nil {
+				return err
+			}
+			for _, f := range []struct{ field, want, got string }{
+				{"purchasing.po_number", "PO-OMIT-1", testhelpers.Deref(u.PoNumber)},
+				{"purchasing.po_date", "2024-02-29", testhelpers.Deref(u.PoDate)},
+				{"purchasing.vendor", "Omit Vendor", testhelpers.Deref(u.Vendor)},
+				{"purchasing.warranty_expires", "2027-03-31", testhelpers.Deref(u.WarrantyExpires)},
+				{"purchasing.applecare_id", "AC-OMIT-1", testhelpers.Deref(u.ApplecareID)},
+				{"purchasing.lease_expires", "2028-04-30", testhelpers.Deref(u.LeaseExpires)},
+				{"purchasing.purchase_price", "1234.56", testhelpers.Deref(u.PurchasePrice)},
+				{"purchasing.purchasing_account", "ACCT-OMIT", testhelpers.Deref(u.PurchasingAccount)},
+				{"purchasing.purchasing_contact", "Contact Omit", testhelpers.Deref(u.PurchasingContact)},
+			} {
+				if err := testhelpers.RequireEqual(f.field, f.want, f.got); err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+}
+
+// TestAccResource_ProMobileDeviceEnrollmentProfile_OmittedBlocksRetained pins
+// the omit-retains contract the plan output cannot show: dropping a gated
+// block from config plans it as removed, but the classic merge PUT omits the
+// element and the server keeps every value. This endpoint's merge has a second
+// half — an element that is present but empty clears — and the builder relies
+// on it by always emitting every plain-Optional leaf inside a declared block.
+// Step 2 keeps both blocks and drops one leaf of each kind: the
+// Optional+Computed life_expectancy (omitted, so retained) and the
+// plain-Optional room (emitted empty, so cleared); step 3 drops both blocks so
+// the PUT carries <general> alone and every step-1 value must survive. Each
+// step's implicit post-apply plan must be empty. If this test fails on content
+// the endpoint no longer merges and nothing that suppresses the removal plan
+// may ship for this resource.
+func TestAccResource_ProMobileDeviceEnrollmentProfile_OmittedBlocksRetained(t *testing.T) {
+	testhelpers.AccPreCheck(t)
+	name := "tf-acc-mdep-omit-" + testhelpers.RunSuffix()
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testhelpers.AccTestProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckEnrollmentProfileDestroy(t),
+		Steps: []resource.TestStep{
+			{
+				Config: mdepOmitRetainsConfig(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resAddr, "location.room", "R-omit"),
+					resource.TestCheckResourceAttr(resAddr, "purchasing.life_expectancy", "7"),
+					mdepRetainedOnServer(t, name, "R-omit"),
+				),
+			},
+			{
+				Config: mdepOmitRetainsLeavesDroppedConfig(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr(resAddr, "location.room"),
+					resource.TestCheckResourceAttr(resAddr, "purchasing.life_expectancy", "7"),
+					mdepRetainedOnServer(t, name, ""),
+				),
+			},
+			{
+				Config: mdepOmitRetainsGeneralOnlyConfig(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr(resAddr, "location.username"),
+					resource.TestCheckNoResourceAttr(resAddr, "purchasing.vendor"),
+					mdepRetainedOnServer(t, name, ""),
+				),
+			},
+		},
+	})
+}

--- a/internal/resources/pro/patch_policy/resource_acceptance_test.go
+++ b/internal/resources/pro/patch_policy/resource_acceptance_test.go
@@ -26,6 +26,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"strconv"
 	"testing"
 
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/proclassic"
@@ -429,6 +430,357 @@ func TestAccListResource_ProPatchPolicy_Basic(t *testing.T) {
 						},
 					),
 				},
+			},
+		},
+	})
+}
+
+// patchPolicyOmitRetainsFixtures returns the title chain plus every sibling
+// object the omit-retains steps reference: a smart computer group and a
+// building for the targets, a second building and a department for the
+// exclusions, and a network segment and an iBeacon that are both limited and
+// excluded.
+func patchPolicyOmitRetainsFixtures(suffix string) string {
+	return fixtureTitle(suffix) + fmt.Sprintf(`
+		resource "jamfplatform_device_group" "grp" {
+			name        = "tf-acc-pp-omit-grp-%[1]s"
+			group_type  = "smart"
+			device_type = "computer"
+			description = "Patch policy omit-retains fixture"
+			criteria = [
+				{ criteria = "Operating System Version", operator = "greater than or equal", value = "10.0" },
+			]
+		}
+
+		resource "jamfplatform_pro_building" "b1" {
+			name = "tf-acc-pp-omit-bldg1-%[1]s"
+		}
+
+		resource "jamfplatform_pro_building" "b2" {
+			name = "tf-acc-pp-omit-bldg2-%[1]s"
+		}
+
+		resource "jamfplatform_pro_department" "d1" {
+			name = "tf-acc-pp-omit-dept-%[1]s"
+		}
+
+		resource "jamfplatform_pro_network_segment" "n1" {
+			name             = "tf-acc-pp-omit-ns-%[1]s"
+			starting_address = "10.214.0.1"
+			ending_address   = "10.214.0.254"
+		}
+
+		resource "jamfplatform_pro_ibeacon" "i1" {
+			name  = "tf-acc-pp-omit-ibeacon-%[1]s"
+			uuid  = "5a3f7a1e-6c2d-4b8e-9f10-2d3c4b5a6e7f"
+			major = 7
+			minor = 11
+		}
+	`, suffix)
+}
+
+// patchPolicyOmitRetainsConfig is the fully declared shape for the omit-retains
+// contract: every state-gated block the wire can show — scope targets /
+// limitations / exclusions and user_interaction with its deadlines and
+// grace_period — carries a value distinct from the server default so that a
+// server which stopped retaining an omitted element is caught on content, not
+// on presence. user_interaction.notifications (and its nested reminders) is
+// deliberately absent: the classic GET never returns a <notifications>
+// element, neither after a create that carried one nor after a PUT that did
+// (wire-observed 2026-09-06 on this tenant, both distribution methods), so
+// no value declared there can be verified against the server and the block
+// stays out rather than pretend the test covers it.
+func patchPolicyOmitRetainsConfig(suffix, name string) string {
+	return patchPolicyOmitRetainsFixtures(suffix) + fmt.Sprintf(`
+		resource "jamfplatform_pro_patch_policy" "test" {
+			software_title_configuration_id = jamfplatform_pro_patch_software_title.title.id
+			name                            = %[1]q
+			target_version                  = %[2]q
+			enabled                         = false
+			distribution_method             = "selfservice"
+
+			scope = {
+				targets = {
+					computer_group_ids = [jamfplatform_device_group.grp.jamf_pro_id]
+					building_ids       = [jamfplatform_pro_building.b1.id]
+				}
+				limitations = {
+					network_segment_ids = [jamfplatform_pro_network_segment.n1.id]
+					ibeacon_ids         = [jamfplatform_pro_ibeacon.i1.id]
+				}
+				exclusions = {
+					building_ids        = [jamfplatform_pro_building.b2.id]
+					department_ids      = [jamfplatform_pro_department.d1.id]
+					network_segment_ids = [jamfplatform_pro_network_segment.n1.id]
+					ibeacon_ids         = [jamfplatform_pro_ibeacon.i1.id]
+				}
+			}
+
+			user_interaction = {
+				install_button_text      = "Retain me"
+				self_service_description = "Omit-retains contract description."
+
+				deadlines = {
+					enabled = true
+					period  = 5
+				}
+
+				grace_period = {
+					duration                    = 45
+					notification_center_subject = "Retained grace subject"
+					message                     = "Retained grace message"
+				}
+			}
+		}
+	`, name, accTitleVersion)
+}
+
+// patchPolicyOmitRetainsParentsOnlyConfig keeps the two blocks that have gated
+// children but drops the children: scope keeps its targets and loses
+// limitations and exclusions (so the scope goes through the granular merge),
+// user_interaction keeps install_button_text and loses deadlines,
+// grace_period and the Optional+Computed self_service_description leaf.
+func patchPolicyOmitRetainsParentsOnlyConfig(suffix, name string) string {
+	return patchPolicyOmitRetainsFixtures(suffix) + fmt.Sprintf(`
+		resource "jamfplatform_pro_patch_policy" "test" {
+			software_title_configuration_id = jamfplatform_pro_patch_software_title.title.id
+			name                            = %[1]q
+			target_version                  = %[2]q
+			enabled                         = false
+			distribution_method             = "selfservice"
+
+			scope = {
+				targets = {
+					computer_group_ids = [jamfplatform_device_group.grp.jamf_pro_id]
+					building_ids       = [jamfplatform_pro_building.b1.id]
+				}
+			}
+
+			user_interaction = {
+				install_button_text = "Retain me"
+			}
+		}
+	`, name, accTitleVersion)
+}
+
+// patchPolicyOmitRetainsGeneralOnlyConfig drops every optional block, so the
+// PUT carries <general> alone. The fixtures stay so the server-side references
+// they back remain valid while the policy still holds them.
+func patchPolicyOmitRetainsGeneralOnlyConfig(suffix, name string) string {
+	return patchPolicyOmitRetainsFixtures(suffix) + fmt.Sprintf(`
+		resource "jamfplatform_pro_patch_policy" "test" {
+			software_title_configuration_id = jamfplatform_pro_patch_software_title.title.id
+			name                            = %[1]q
+			target_version                  = %[2]q
+			enabled                         = false
+			distribution_method             = "selfservice"
+		}
+	`, name, accTitleVersion)
+}
+
+// patchPolicyStateInt reads an integer attribute of a sibling fixture out of
+// Terraform state so the wire assertion can compare scope members by value
+// rather than count.
+func patchPolicyStateInt(s *terraform.State, addr, attr string) (int, error) {
+	rs, ok := s.RootModule().Resources[addr]
+	if !ok {
+		return 0, fmt.Errorf("fixture %s not found in state", addr)
+	}
+	raw, ok := rs.Primary.Attributes[attr]
+	if !ok {
+		return 0, fmt.Errorf("fixture %s: attribute %s not in state", addr, attr)
+	}
+	id, err := strconv.Atoi(raw)
+	if err != nil {
+		return 0, fmt.Errorf("fixture %s: %s %q is not an integer: %w", addr, attr, raw, err)
+	}
+	return id, nil
+}
+
+// requireOneIDName asserts an id/name scope category holds exactly the one
+// member with the given id.
+func requireOneIDName(field string, items *[]proclassic.IDName, wantID int) error {
+	if items == nil || len(*items) != 1 {
+		return fmt.Errorf("%s: want exactly one member, got %+v", field, items)
+	}
+	return testhelpers.RequireEqual(field+"[0].id", wantID, testhelpers.Deref((*items)[0].ID))
+}
+
+// patchPolicyRetainedOnServer asserts the server's copy still carries every
+// value the omit-retains config declared in its first step.
+func patchPolicyRetainedOnServer(t *testing.T) resource.TestCheckFunc {
+	c := proclassic.New(testhelpers.NewAcceptanceClient(t))
+	return func(s *terraform.State) error {
+		grp, err := patchPolicyStateInt(s, "jamfplatform_device_group.grp", "jamf_pro_id")
+		if err != nil {
+			return err
+		}
+		b1, err := patchPolicyStateInt(s, "jamfplatform_pro_building.b1", "id")
+		if err != nil {
+			return err
+		}
+		b2, err := patchPolicyStateInt(s, "jamfplatform_pro_building.b2", "id")
+		if err != nil {
+			return err
+		}
+		d1, err := patchPolicyStateInt(s, "jamfplatform_pro_department.d1", "id")
+		if err != nil {
+			return err
+		}
+		n1, err := patchPolicyStateInt(s, "jamfplatform_pro_network_segment.n1", "id")
+		if err != nil {
+			return err
+		}
+		i1, err := patchPolicyStateInt(s, "jamfplatform_pro_ibeacon.i1", "id")
+		if err != nil {
+			return err
+		}
+		return testhelpers.CheckLiveObject(patchPolicyType+".test",
+			func(ctx context.Context, id string) (*proclassic.PatchPolicy, error) {
+				return c.GetPatchPolicyByID(ctx, id)
+			},
+			func(p *proclassic.PatchPolicy) error {
+				sc := p.Scope
+				if sc == nil {
+					return fmt.Errorf("scope: absent")
+				}
+				if sc.ComputerGroups == nil {
+					return fmt.Errorf("scope.targets.computer_groups: absent")
+				}
+				if err := requireOneIDName("scope.targets.computer_groups", sc.ComputerGroups.ComputerGroup, grp); err != nil {
+					return err
+				}
+				if sc.Buildings == nil {
+					return fmt.Errorf("scope.targets.buildings: absent")
+				}
+				if err := requireOneIDName("scope.targets.buildings", sc.Buildings.Building, b1); err != nil {
+					return err
+				}
+				if sc.Limitations == nil {
+					return fmt.Errorf("scope.limitations: absent")
+				}
+				if sc.Limitations.NetworkSegments == nil {
+					return fmt.Errorf("scope.limitations.network_segments: absent")
+				}
+				if err := requireOneIDName("scope.limitations.network_segments", sc.Limitations.NetworkSegments.NetworkSegment, n1); err != nil {
+					return err
+				}
+				if sc.Limitations.Ibeacons == nil {
+					return fmt.Errorf("scope.limitations.ibeacons: absent")
+				}
+				if err := requireOneIDName("scope.limitations.ibeacons", sc.Limitations.Ibeacons.Ibeacon, i1); err != nil {
+					return err
+				}
+				if sc.Exclusions == nil {
+					return fmt.Errorf("scope.exclusions: absent")
+				}
+				if sc.Exclusions.Buildings == nil {
+					return fmt.Errorf("scope.exclusions.buildings: absent")
+				}
+				if err := requireOneIDName("scope.exclusions.buildings", sc.Exclusions.Buildings.Building, b2); err != nil {
+					return err
+				}
+				if sc.Exclusions.Departments == nil {
+					return fmt.Errorf("scope.exclusions.departments: absent")
+				}
+				if err := requireOneIDName("scope.exclusions.departments", sc.Exclusions.Departments.Department, d1); err != nil {
+					return err
+				}
+				if sc.Exclusions.NetworkSegments == nil {
+					return fmt.Errorf("scope.exclusions.network_segments: absent")
+				}
+				if err := requireOneIDName("scope.exclusions.network_segments", sc.Exclusions.NetworkSegments.NetworkSegment, n1); err != nil {
+					return err
+				}
+				if sc.Exclusions.Ibeacons == nil {
+					return fmt.Errorf("scope.exclusions.ibeacons: absent")
+				}
+				if err := requireOneIDName("scope.exclusions.ibeacons", sc.Exclusions.Ibeacons.Ibeacon, i1); err != nil {
+					return err
+				}
+
+				ui := p.UserInteraction
+				if ui == nil {
+					return fmt.Errorf("user_interaction: absent")
+				}
+				if err := testhelpers.RequireEqual("user_interaction.install_button_text", "Retain me", testhelpers.Deref(ui.InstallButtonText)); err != nil {
+					return err
+				}
+				if err := testhelpers.RequireEqual("user_interaction.self_service_description", "Omit-retains contract description.", testhelpers.Deref(ui.SelfServiceDescription)); err != nil {
+					return err
+				}
+				if ui.Deadlines == nil {
+					return fmt.Errorf("user_interaction.deadlines: absent")
+				}
+				if err := testhelpers.RequireEqual("user_interaction.deadlines.enabled", true, testhelpers.Deref(ui.Deadlines.DeadlineEnabled)); err != nil {
+					return err
+				}
+				if err := testhelpers.RequireEqual("user_interaction.deadlines.period", 5, testhelpers.Deref(ui.Deadlines.DeadlinePeriod)); err != nil {
+					return err
+				}
+				if ui.GracePeriod == nil {
+					return fmt.Errorf("user_interaction.grace_period: absent")
+				}
+				if err := testhelpers.RequireEqual("user_interaction.grace_period.duration", 45, testhelpers.Deref(ui.GracePeriod.GracePeriodDuration)); err != nil {
+					return err
+				}
+				if err := testhelpers.RequireEqual("user_interaction.grace_period.notification_center_subject", "Retained grace subject", testhelpers.Deref(ui.GracePeriod.NotificationCenterSubject)); err != nil {
+					return err
+				}
+				return testhelpers.RequireEqual("user_interaction.grace_period.message", "Retained grace message", testhelpers.Deref(ui.GracePeriod.Message))
+			})(s)
+	}
+}
+
+// TestAccResource_ProPatchPolicy_OmittedBlocksRetained pins the omit-retains
+// contract the plan output cannot show: dropping scope limitations and
+// exclusions, and the user_interaction deadlines / grace_period sub-blocks,
+// from config plans them as removed, but the classic
+// PUT omits the elements and the server keeps every value. Step 2 keeps
+// scope.targets and a one-field user_interaction so the scope goes through
+// the granular merge and the user_interaction PUT omits its children; step 3
+// drops both blocks so the PUT carries <general> alone. Each step's implicit
+// post-apply plan must be empty, which is what makes the contract usable. If
+// this test fails on content, the endpoint no longer merges and nothing that
+// suppresses the removal plan may ship for this resource.
+func TestAccResource_ProPatchPolicy_OmittedBlocksRetained(t *testing.T) {
+	testhelpers.AccPreCheck(t)
+	suffix := testhelpers.RunSuffix()
+	name := "tf-acc-pp-omit-" + suffix
+	addr := patchPolicyType + ".test"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testhelpers.AccTestProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckPatchPolicyDestroy(t),
+		Steps: []resource.TestStep{
+			{
+				Config: patchPolicyOmitRetainsConfig(suffix, name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(addr, "user_interaction.install_button_text", "Retain me"),
+					resource.TestCheckResourceAttr(addr, "user_interaction.grace_period.duration", "45"),
+					resource.TestCheckResourceAttr(addr, "scope.exclusions.ibeacon_ids.#", "1"),
+					patchPolicyRetainedOnServer(t),
+				),
+			},
+			{
+				Config: patchPolicyOmitRetainsParentsOnlyConfig(suffix, name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(addr, "scope.targets.building_ids.#", "1"),
+					resource.TestCheckNoResourceAttr(addr, "scope.limitations.ibeacon_ids.#"),
+					resource.TestCheckNoResourceAttr(addr, "scope.exclusions.building_ids.#"),
+					resource.TestCheckResourceAttr(addr, "user_interaction.install_button_text", "Retain me"),
+					resource.TestCheckNoResourceAttr(addr, "user_interaction.deadlines.period"),
+					resource.TestCheckNoResourceAttr(addr, "user_interaction.grace_period.duration"),
+					patchPolicyRetainedOnServer(t),
+				),
+			},
+			{
+				Config: patchPolicyOmitRetainsGeneralOnlyConfig(suffix, name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr(addr, "scope.targets.building_ids.#"),
+					resource.TestCheckNoResourceAttr(addr, "user_interaction.install_button_text"),
+					patchPolicyRetainedOnServer(t),
+				),
 			},
 		},
 	})

--- a/internal/resources/pro/policy/resource_acceptance_test.go
+++ b/internal/resources/pro/policy/resource_acceptance_test.go
@@ -2483,3 +2483,790 @@ resource "jamfplatform_pro_policy" "test" {
 		},
 	})
 }
+
+// policyOmitRetainsResourceAddr is the policy under test in the omit-retains
+// contract test; the disk-encryption fixture's address is needed too because
+// the wire echoes only its numeric id.
+const (
+	policyOmitRetainsResourceAddr = "jamfplatform_pro_policy.test"
+	policyOmitRetainsDecAddr      = "jamfplatform_pro_disk_encryption_configuration.fixture"
+)
+
+// policyOmitRetainsNames derives every fixture name from the run-unique base
+// name, so the wire assertion can match referenced objects by the name Jamf
+// echoes rather than by server-assigned ids the config helper cannot know.
+type policyOmitRetainsNames struct {
+	Policy, Category, Building, Department, DeviceGroup, SegmentLimitation, SegmentExclusion, Ibeacon, Script, Printer, DockItem, Dec, DirectoryBinding string
+}
+
+func newPolicyOmitRetainsNames(base string) policyOmitRetainsNames {
+	return policyOmitRetainsNames{
+		Policy:            base,
+		Category:          base + "-cat",
+		Building:          base + "-bld",
+		Department:        base + "-dept",
+		DeviceGroup:       base + "-grp",
+		SegmentLimitation: base + "-seg-lim",
+		SegmentExclusion:  base + "-seg-excl",
+		Ibeacon:           base + "-ibeacon",
+		Script:            base + "-script",
+		Printer:           base + "-printer",
+		DockItem:          base + "-dock",
+		Dec:               base + "-dec",
+		DirectoryBinding:  base + "-db",
+	}
+}
+
+// policyOmitRetainsFixtures declares every sibling object the fully declared
+// policy references. It is shared by all three steps so a fixture is never
+// destroyed while the policy still points at it; only the policy body shrinks.
+func policyOmitRetainsFixtures(n policyOmitRetainsNames) string {
+	return fmt.Sprintf(`
+resource "jamfplatform_pro_category" "fixture" {
+  name     = %q
+  priority = 9
+}
+
+resource "jamfplatform_pro_building" "fixture" {
+  name = %q
+}
+
+resource "jamfplatform_pro_department" "fixture" {
+  name = %q
+}
+
+resource "jamfplatform_device_group" "fixture" {
+  name        = %q
+  description = "tf-acc omit-retains fixture"
+  group_type  = "static"
+  device_type = "computer"
+}
+
+resource "jamfplatform_pro_network_segment" "limitation" {
+  name             = %q
+  starting_address = "10.77.0.0"
+  ending_address   = "10.77.0.255"
+}
+
+resource "jamfplatform_pro_network_segment" "exclusion" {
+  name             = %q
+  starting_address = "10.76.0.0"
+  ending_address   = "10.76.0.255"
+}
+
+resource "jamfplatform_pro_ibeacon" "fixture" {
+  name                    = %q
+  uuid                    = "759b0599-64e0-416a-8d31-d8e93482a4d7"
+  include_any_major_value = true
+  include_any_minor_value = true
+}
+
+resource "jamfplatform_pro_script" "fixture" {
+  name            = %q
+  priority        = "AFTER"
+  info            = "tf-acc omit-retains script fixture"
+  script_contents = <<-EOT
+    #!/bin/sh
+    echo "tf-acc-omit-retains"
+  EOT
+}
+
+resource "jamfplatform_pro_printer" "fixture" {
+  name = %q
+  uri  = "ipp://10.1.20.121/"
+}
+
+resource "jamfplatform_pro_dock_item" "fixture" {
+  name = %q
+  type = "App"
+  path = "/Applications/Calculator.app"
+}
+
+resource "jamfplatform_pro_disk_encryption_configuration" "fixture" {
+  name                     = %q
+  key_type                 = "Individual"
+  file_vault_enabled_users = "Current or Next User"
+}
+
+resource "jamfplatform_pro_directory_binding" "fixture" {
+  name     = %q
+  priority = 1
+  type     = "Open Directory"
+  domain   = "ldap.tf-acc.example.com"
+  username = "cn=joiner,dc=tf-acc,dc=example,dc=com"
+  password = "Sup3rS3cret!"
+
+  open_directory = {
+    encrypt_using_ssl      = false
+    perform_secure_bind    = false
+    use_for_authentication = true
+    use_for_contacts       = false
+  }
+}
+`, n.Category, n.Building, n.Department, n.DeviceGroup, n.SegmentLimitation, n.SegmentExclusion, n.Ibeacon, n.Script, n.Printer, n.DockItem, n.Dec, n.DirectoryBinding)
+}
+
+// policyOmitRetainsDependsOn pins the policy after every fixture in all three
+// steps. Once a step stops declaring a reference the server still holds it,
+// which is the very contract under test, so without this edge Terraform's
+// destroy would try to remove the device group and disk encryption
+// configuration while the live policy still points at them and both deletes
+// are refused as HAS_DEPENDENCIES.
+const policyOmitRetainsDependsOn = `
+  depends_on = [
+    jamfplatform_pro_category.fixture,
+    jamfplatform_pro_building.fixture,
+    jamfplatform_pro_department.fixture,
+    jamfplatform_device_group.fixture,
+    jamfplatform_pro_network_segment.limitation,
+    jamfplatform_pro_network_segment.exclusion,
+    jamfplatform_pro_ibeacon.fixture,
+    jamfplatform_pro_script.fixture,
+    jamfplatform_pro_printer.fixture,
+    jamfplatform_pro_dock_item.fixture,
+    jamfplatform_pro_disk_encryption_configuration.fixture,
+    jamfplatform_pro_directory_binding.fixture,
+  ]
+`
+
+// policyOmitRetainsGeneralScalars is the general block every step keeps.
+// frequency=Ongoing forbids retry configuration, so the retry pair is pinned
+// to its cleared form and category/site to NONE, making the block independent
+// of tenant inventory and stable across the three steps.
+const policyOmitRetainsGeneralScalars = `
+    enabled        = true
+    frequency      = "Ongoing"
+    retry_event    = "none"
+    retry_attempts = -1
+    category_id    = "-1"
+    site_id        = "-1"
+`
+
+// policyOmitRetainsConfig is the fully declared shape for the omit-retains
+// contract: every state-gated block, sub-block and collection carries a
+// distinctive non-default value so a server that stopped retaining an
+// omitted element is caught on content, not on presence. packages and
+// self_service.self_service_icon are the two gated sections left out —
+// both need an out-of-band upload (JCDS, icon bytes) this test cannot supply.
+// Four general leaves are left undeclared because wire probes on 2026-09-06
+// showed the server ignores them on both POST and PUT and echoes its own
+// value, which would fail step 1 on content rather than on retention:
+// date_time_limitations.no_execute_start / no_execute_end always echo
+// empty, network_limitations.minimum_network_connection always echoes
+// "No Minimum", and override_default_settings.force_afp_smb always echoes
+// false. network_limitations.network_segment_ids and any_ip_address are
+// server-derived mirrors of scope.limitations.network_segment_ids, and a
+// <network_limitations> element naming only one of any_ip_address /
+// minimum_network_connection is refused 409 "Problem with general", so the
+// block declares both with the values the server will echo. The four
+// self_service notification leaves are declared but not asserted: the
+// classic GET on this tenant echoes no <notification>, <notification_type>,
+// <notification_subject> or <notification_message> element at all, so the
+// wire cannot witness them either way. printers.leave_existing_default is
+// declared false because the server echoes false whatever is sent while a
+// printer in the same block carries make_default = true.
+func policyOmitRetainsConfig(n policyOmitRetainsNames) string {
+	return policyOmitRetainsFixtures(n) + fmt.Sprintf(`
+resource "jamfplatform_pro_policy" "test" {
+  general = {
+    name = %q
+%s
+    date_time_limitations = {
+      activation_date = "2026-02-03 04:05:06"
+      expiration_date = "2027-02-03 04:05:06"
+      no_execute_on   = ["Tue", "Thu"]
+    }
+    network_limitations = {
+      minimum_network_connection = "No Minimum"
+      any_ip_address             = false
+    }
+    override_default_settings = {
+      target_drive       = "/"
+      distribution_point = "default"
+      force_afp_smb      = false
+      sus                = "default"
+    }
+  }
+  scope = {
+    targets = {
+      computer_group_ids = [jamfplatform_device_group.fixture.jamf_pro_id]
+      building_ids       = [jamfplatform_pro_building.fixture.id]
+    }
+    limitations = {
+      network_segment_ids = [jamfplatform_pro_network_segment.limitation.id]
+      ibeacon_ids         = [jamfplatform_pro_ibeacon.fixture.id]
+    }
+    exclusions = {
+      department_ids      = [jamfplatform_pro_department.fixture.id]
+      network_segment_ids = [jamfplatform_pro_network_segment.exclusion.id]
+    }
+  }
+  self_service = {
+    use_for_self_service          = true
+    self_service_display_name     = "Omit-retains display name"
+    install_button_text           = "Retain me"
+    reinstall_button_text         = "Retain me again"
+    self_service_description      = "Omit-retains contract description."
+    ensure_users_view_description = true
+    include_in_featured_category  = true
+    display_notifications         = true
+    notification_location         = "Self Service and Notification Center"
+    notification_subject          = "Omit-retains subject"
+    notification_message          = "Omit-retains message"
+    categories = [
+      {
+        id         = jamfplatform_pro_category.fixture.id
+        display_in = true
+        feature_in = true
+      },
+    ]
+  }
+  scripts = {
+    scripts = [
+      {
+        id           = jamfplatform_pro_script.fixture.id
+        priority     = "Before"
+        parameter_4  = "omit-retains-p4"
+        parameter_5  = "omit-retains-p5"
+        parameter_11 = "omit-retains-p11"
+      },
+    ]
+  }
+  printers = {
+    leave_existing_default = false
+    printers = [
+      {
+        id           = jamfplatform_pro_printer.fixture.id
+        action       = "Map"
+        make_default = true
+      },
+    ]
+  }
+  dock_items = {
+    dock_items = [
+      {
+        id     = jamfplatform_pro_dock_item.fixture.id
+        action = "Add To Beginning"
+      },
+    ]
+  }
+  local_accounts = [
+    {
+      action               = "Create"
+      username             = "tf-acc-omit"
+      realname             = "Omit Retains"
+      password             = "Sup3rS3cret!"
+      password_wo_version  = 1
+      home                 = "/Users/tf-acc-omit"
+      hint                 = "omit-retains hint"
+      admin                = true
+      filevault_enabled    = false
+      secure_token_allowed = true
+    },
+  ]
+  directory_bindings = [
+    {
+      id = jamfplatform_pro_directory_binding.fixture.id
+    },
+  ]
+  management_account = {
+    action                      = "rotate"
+    managed_password            = "Sup3rS3cret!"
+    managed_password_wo_version = 1
+  }
+  efi_password = {
+    of_mode                = "command"
+    of_password            = "OF-omit-retains-1!"
+    of_password_wo_version = 1
+  }
+  restart_options = {
+    message                        = "Omit-retains reboot message"
+    startup_disk                   = "Current Startup Disk"
+    specify_startup                = "Standard Restart"
+    no_user_logged_in              = "Restart immediately"
+    user_logged_in                 = "Restart if a package or update requires it"
+    delay_minutes                  = 7
+    start_reboot_timer_immediately = true
+    file_vault_2_reboot            = true
+  }
+  maintenance = {
+    update_inventory        = false
+    reset_computer_names    = true
+    install_cached_packages = true
+    fix_disk_permissions    = false
+    fix_byhost_files        = true
+    flush_system_caches     = false
+    flush_user_caches       = true
+    verify_startup_disk     = true
+  }
+  files_and_processes = {
+    search_by_path         = "/tmp/omit-retains"
+    delete_file_if_found   = true
+    search_by_filename     = "omit-retains.txt"
+    update_locate_database = true
+    search_by_spotlight    = "omit-retains-spotlight"
+    search_for_process     = "omitretainsd"
+    kill_process_if_found  = true
+    execute_command        = "echo omit-retains"
+  }
+  user_interaction = {
+    start_message    = "Omit-retains start message"
+    deferral_type    = "duration"
+    deferral_days    = 3
+    complete_message = "Omit-retains complete message"
+  }
+  disk_encryption = {
+    action                           = "apply"
+    disk_encryption_configuration_id = tonumber(jamfplatform_pro_disk_encryption_configuration.fixture.id)
+    auth_restart                     = true
+  }
+%s}
+`, n.Policy, policyOmitRetainsGeneralScalars, policyOmitRetainsDependsOn)
+}
+
+// policyOmitRetainsParentsOnlyConfig keeps every parent that has a state-gated
+// child and drops the child: general without its three sub-blocks, scope with
+// targets but no limitations or exclusions, self_service without categories,
+// and management_account as the sole survivor of the four account-maintenance
+// peers so the PUT carries an <account_maintenance> element that names only
+// <management_account>. It also drops the Optional+Computed leaf
+// self_service.install_button_text. Every other optional block is omitted.
+func policyOmitRetainsParentsOnlyConfig(n policyOmitRetainsNames) string {
+	return policyOmitRetainsFixtures(n) + fmt.Sprintf(`
+resource "jamfplatform_pro_policy" "test" {
+  general = {
+    name = %q
+%s
+  }
+  scope = {
+    targets = {
+      computer_group_ids = [jamfplatform_device_group.fixture.jamf_pro_id]
+      building_ids       = [jamfplatform_pro_building.fixture.id]
+    }
+  }
+  self_service = {
+    use_for_self_service          = true
+    self_service_display_name     = "Omit-retains display name"
+    reinstall_button_text         = "Retain me again"
+    self_service_description      = "Omit-retains contract description."
+    ensure_users_view_description = true
+    include_in_featured_category  = true
+    display_notifications         = true
+    notification_location         = "Self Service and Notification Center"
+    notification_subject          = "Omit-retains subject"
+    notification_message          = "Omit-retains message"
+  }
+  management_account = {
+    action                      = "rotate"
+    managed_password_wo_version = 1
+  }
+%s}
+`, n.Policy, policyOmitRetainsGeneralScalars, policyOmitRetainsDependsOn)
+}
+
+// policyOmitRetainsGeneralOnlyConfig drops every optional block, so the PUT
+// carries <general> alone.
+func policyOmitRetainsGeneralOnlyConfig(n policyOmitRetainsNames) string {
+	return policyOmitRetainsFixtures(n) + fmt.Sprintf(`
+resource "jamfplatform_pro_policy" "test" {
+  general = {
+    name = %q
+%s
+  }
+%s}
+`, n.Policy, policyOmitRetainsGeneralScalars, policyOmitRetainsDependsOn)
+}
+
+// requireSingleNamed asserts a wire collection holds exactly one element and
+// that its name is the fixture the step-1 config referenced. Names are used
+// because Jamf echoes them for every referenced object and the config helper
+// cannot know server-assigned ids.
+func requireSingleNamed[T any](field string, items *[]T, name func(T) *string, want string) error {
+	if items == nil || len(*items) != 1 {
+		return fmt.Errorf("%s: want exactly one element named %q, got %+v", field, want, items)
+	}
+	return testhelpers.RequireEqual(field+"[0].name", want, testhelpers.Deref(name((*items)[0])))
+}
+
+func idNameName(i proclassic.IDName) *string { return i.Name }
+
+// policyRetainedOnServer asserts the server's copy still carries every value
+// the omit-retains config declared in its first step. The disk-encryption
+// configuration id is read from the fixture's Terraform state because that is
+// the one reference the wire echoes as a bare id.
+func policyRetainedOnServer(t *testing.T, n policyOmitRetainsNames) resource.TestCheckFunc {
+	c := proclassic.New(testhelpers.NewAcceptanceClient(t))
+	return func(s *terraform.State) error {
+		dec, ok := s.RootModule().Resources[policyOmitRetainsDecAddr]
+		if !ok {
+			return fmt.Errorf("resource %s not found in state", policyOmitRetainsDecAddr)
+		}
+		wantDecID := dec.Primary.ID
+		return testhelpers.CheckLiveObject(policyOmitRetainsResourceAddr,
+			func(ctx context.Context, id string) (*proclassic.Policy, error) {
+				return c.GetPolicyByID(ctx, id)
+			},
+			func(p *proclassic.Policy) error {
+				if err := policyGeneralRetained(p.General); err != nil {
+					return err
+				}
+				if err := policyScopeRetained(p.Scope, n); err != nil {
+					return err
+				}
+				if err := policySelfServiceRetained(p.SelfService, n); err != nil {
+					return err
+				}
+				if err := policyLinkedObjectsRetained(p, n); err != nil {
+					return err
+				}
+				if err := policyAccountMaintenanceRetained(p.AccountMaintenance, n); err != nil {
+					return err
+				}
+				return policyOptionsRetained(p, wantDecID)
+			})(s)
+	}
+}
+
+func policyGeneralRetained(g *proclassic.PolicyGeneral) error {
+	if g == nil {
+		return fmt.Errorf("general: absent")
+	}
+	dtl := g.DateTimeLimitations
+	if dtl == nil {
+		return fmt.Errorf("general.date_time_limitations: absent")
+	}
+	if err := testhelpers.RequireEqual("general.date_time_limitations.activation_date", "2026-02-03 04:05:06", testhelpers.Deref(dtl.ActivationDate)); err != nil {
+		return err
+	}
+	if err := testhelpers.RequireEqual("general.date_time_limitations.expiration_date", "2027-02-03 04:05:06", testhelpers.Deref(dtl.ExpirationDate)); err != nil {
+		return err
+	}
+	if dtl.NoExecuteOn == nil || dtl.NoExecuteOn.Day == nil || len(*dtl.NoExecuteOn.Day) != 2 {
+		return fmt.Errorf("general.date_time_limitations.no_execute_on: want [Tue Thu], got %+v", dtl.NoExecuteOn)
+	}
+	days := strings.Join(*dtl.NoExecuteOn.Day, ",")
+	if days != "Tue,Thu" && days != "Thu,Tue" {
+		return fmt.Errorf("general.date_time_limitations.no_execute_on: want [Tue Thu], got %q", days)
+	}
+	nl := g.NetworkLimitations
+	if nl == nil {
+		return fmt.Errorf("general.network_limitations: absent")
+	}
+	if err := testhelpers.RequireEqual("general.network_limitations.minimum_network_connection", "No Minimum", testhelpers.Deref(nl.MinimumNetworkConnection)); err != nil {
+		return err
+	}
+	if err := testhelpers.RequireEqual("general.network_limitations.any_ip_address", false, testhelpers.Deref(nl.AnyIPAddress)); err != nil {
+		return err
+	}
+	ods := g.OverrideDefaultSettings
+	if ods == nil {
+		return fmt.Errorf("general.override_default_settings: absent")
+	}
+	checks := []error{
+		testhelpers.RequireEqual("general.override_default_settings.target_drive", "/", testhelpers.Deref(ods.TargetDrive)),
+		testhelpers.RequireEqual("general.override_default_settings.distribution_point", "default", testhelpers.Deref(ods.DistributionPoint)),
+		testhelpers.RequireEqual("general.override_default_settings.force_afp_smb", false, testhelpers.Deref(ods.ForceAfpSmb)),
+		testhelpers.RequireEqual("general.override_default_settings.sus", "default", testhelpers.Deref(ods.Sus)),
+	}
+	for _, err := range checks {
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func policyScopeRetained(s *proclassic.PolicyScope, n policyOmitRetainsNames) error {
+	if s == nil {
+		return fmt.Errorf("scope: absent")
+	}
+	if s.ComputerGroups == nil || s.Buildings == nil {
+		return fmt.Errorf("scope.targets: computer_groups or buildings absent")
+	}
+	if err := requireSingleNamed("scope.computer_groups", s.ComputerGroups.ComputerGroup, idNameName, n.DeviceGroup); err != nil {
+		return err
+	}
+	if err := requireSingleNamed("scope.buildings", s.Buildings.Building, idNameName, n.Building); err != nil {
+		return err
+	}
+	if s.Limitations == nil || s.Limitations.NetworkSegments == nil || s.Limitations.Ibeacons == nil {
+		return fmt.Errorf("scope.limitations: want network_segments and ibeacons, got %+v", s.Limitations)
+	}
+	if err := requireSingleNamed("scope.limitations.network_segments", s.Limitations.NetworkSegments.NetworkSegment, idNameName, n.SegmentLimitation); err != nil {
+		return err
+	}
+	if err := requireSingleNamed("scope.limitations.ibeacons", s.Limitations.Ibeacons.Ibeacon, idNameName, n.Ibeacon); err != nil {
+		return err
+	}
+	if s.Exclusions == nil || s.Exclusions.Departments == nil || s.Exclusions.NetworkSegments == nil {
+		return fmt.Errorf("scope.exclusions: want departments and network_segments, got %+v", s.Exclusions)
+	}
+	if err := requireSingleNamed("scope.exclusions.departments", s.Exclusions.Departments.Department, idNameName, n.Department); err != nil {
+		return err
+	}
+	return requireSingleNamed("scope.exclusions.network_segments", s.Exclusions.NetworkSegments.NetworkSegment,
+		func(i proclassic.PolicyScopeExclusionsNetworkSegmentsNetworkSegmentItem) *string { return i.Name }, n.SegmentExclusion)
+}
+
+func policySelfServiceRetained(ss *proclassic.PolicySelfService, n policyOmitRetainsNames) error {
+	if ss == nil {
+		return fmt.Errorf("self_service: absent")
+	}
+	checks := []error{
+		testhelpers.RequireEqual("self_service.use_for_self_service", true, testhelpers.Deref(ss.UseForSelfService)),
+		testhelpers.RequireEqual("self_service.self_service_display_name", "Omit-retains display name", testhelpers.Deref(ss.SelfServiceDisplayName)),
+		testhelpers.RequireEqual("self_service.install_button_text", "Retain me", testhelpers.Deref(ss.InstallButtonText)),
+		testhelpers.RequireEqual("self_service.reinstall_button_text", "Retain me again", testhelpers.Deref(ss.ReinstallButtonText)),
+		testhelpers.RequireEqual("self_service.self_service_description", "Omit-retains contract description.", testhelpers.Deref(ss.SelfServiceDescription)),
+		testhelpers.RequireEqual("self_service.force_users_to_view_description", true, testhelpers.Deref(ss.ForceUsersToViewDescription)),
+		testhelpers.RequireEqual("self_service.feature_on_main_page", true, testhelpers.Deref(ss.FeatureOnMainPage)),
+	}
+	for _, err := range checks {
+		if err != nil {
+			return err
+		}
+	}
+	if ss.SelfServiceCategories == nil {
+		return fmt.Errorf("self_service.self_service_categories: absent")
+	}
+	if err := requireSingleNamed("self_service.self_service_categories", ss.SelfServiceCategories.Category,
+		func(c proclassic.PolicySelfServiceSelfServiceCategoriesCategoryItem) *string { return c.Name }, n.Category); err != nil {
+		return err
+	}
+	cat := (*ss.SelfServiceCategories.Category)[0]
+	if err := testhelpers.RequireEqual("self_service.self_service_categories[0].display_in", true, testhelpers.Deref(cat.DisplayIn)); err != nil {
+		return err
+	}
+	return testhelpers.RequireEqual("self_service.self_service_categories[0].feature_in", true, testhelpers.Deref(cat.FeatureIn))
+}
+
+func policyLinkedObjectsRetained(p *proclassic.Policy, n policyOmitRetainsNames) error {
+	if p.Scripts == nil {
+		return fmt.Errorf("scripts: absent")
+	}
+	if err := requireSingleNamed("scripts", p.Scripts.Script, func(s proclassic.PolicyScriptsScriptItem) *string { return s.Name }, n.Script); err != nil {
+		return err
+	}
+	sc := (*p.Scripts.Script)[0]
+	checks := []error{
+		testhelpers.RequireEqual("scripts[0].priority", "Before", testhelpers.Deref(sc.Priority)),
+		testhelpers.RequireEqual("scripts[0].parameter4", "omit-retains-p4", testhelpers.Deref(sc.Parameter4)),
+		testhelpers.RequireEqual("scripts[0].parameter5", "omit-retains-p5", testhelpers.Deref(sc.Parameter5)),
+		testhelpers.RequireEqual("scripts[0].parameter11", "omit-retains-p11", testhelpers.Deref(sc.Parameter11)),
+	}
+	for _, err := range checks {
+		if err != nil {
+			return err
+		}
+	}
+	if p.Printers == nil {
+		return fmt.Errorf("printers: absent")
+	}
+	if err := testhelpers.RequireEqual("printers.leave_existing_default", false, testhelpers.Deref(p.Printers.LeaveExistingDefault)); err != nil {
+		return err
+	}
+	if err := requireSingleNamed("printers", p.Printers.Printer, func(pr proclassic.PolicyPrintersPrinterItem) *string { return pr.Name }, n.Printer); err != nil {
+		return err
+	}
+	pr := (*p.Printers.Printer)[0]
+	if err := testhelpers.RequireEqual("printers[0].action", proclassic.PolicyPrintersPrinterItemActionInstall, testhelpers.Deref(pr.Action)); err != nil {
+		return err
+	}
+	if err := testhelpers.RequireEqual("printers[0].make_default", true, testhelpers.Deref(pr.MakeDefault)); err != nil {
+		return err
+	}
+	if p.DockItems == nil {
+		return fmt.Errorf("dock_items: absent")
+	}
+	if err := requireSingleNamed("dock_items", p.DockItems.DockItem, func(d proclassic.PolicyDockItemsDockItemItem) *string { return d.Name }, n.DockItem); err != nil {
+		return err
+	}
+	return testhelpers.RequireEqual("dock_items[0].action", "Add To Beginning", testhelpers.Deref((*p.DockItems.DockItem)[0].Action))
+}
+
+func policyAccountMaintenanceRetained(am *proclassic.PolicyAccountMaintenance, n policyOmitRetainsNames) error {
+	if am == nil {
+		return fmt.Errorf("account_maintenance: absent")
+	}
+	if am.Accounts == nil {
+		return fmt.Errorf("account_maintenance.accounts: absent")
+	}
+	if err := requireSingleNamed("account_maintenance.accounts", am.Accounts.Account,
+		func(a proclassic.PolicyAccountMaintenanceAccountsAccountItem) *string { return a.Username }, "tf-acc-omit"); err != nil {
+		return err
+	}
+	acct := (*am.Accounts.Account)[0]
+	checks := []error{
+		testhelpers.RequireEqual("account_maintenance.accounts[0].action", "Create", testhelpers.Deref(acct.Action)),
+		testhelpers.RequireEqual("account_maintenance.accounts[0].realname", "Omit Retains", testhelpers.Deref(acct.Realname)),
+		testhelpers.RequireEqual("account_maintenance.accounts[0].home", "/Users/tf-acc-omit", testhelpers.Deref(acct.Home)),
+		testhelpers.RequireEqual("account_maintenance.accounts[0].hint", "omit-retains hint", testhelpers.Deref(acct.Hint)),
+		testhelpers.RequireEqual("account_maintenance.accounts[0].admin", true, testhelpers.Deref(acct.Admin)),
+		testhelpers.RequireEqual("account_maintenance.accounts[0].secure_token_allowed", true, testhelpers.Deref(acct.SecureTokenAllowed)),
+	}
+	for _, err := range checks {
+		if err != nil {
+			return err
+		}
+	}
+	if am.DirectoryBindings == nil {
+		return fmt.Errorf("account_maintenance.directory_bindings: absent")
+	}
+	if err := requireSingleNamed("account_maintenance.directory_bindings", am.DirectoryBindings.Binding, idNameName, n.DirectoryBinding); err != nil {
+		return err
+	}
+	if am.ManagementAccount == nil {
+		return fmt.Errorf("account_maintenance.management_account: absent")
+	}
+	if err := testhelpers.RequireEqual("account_maintenance.management_account.action", proclassic.PolicyAccountMaintenanceManagementAccountActionRotate, testhelpers.Deref(am.ManagementAccount.Action)); err != nil {
+		return err
+	}
+	if am.OpenFirmwareEfiPassword == nil {
+		return fmt.Errorf("account_maintenance.open_firmware_efi_password: absent")
+	}
+	return testhelpers.RequireEqual("account_maintenance.open_firmware_efi_password.of_mode", proclassic.PolicyAccountMaintenanceOpenFirmwareEfiPasswordOfModeCommand, testhelpers.Deref(am.OpenFirmwareEfiPassword.OfMode))
+}
+
+func policyOptionsRetained(p *proclassic.Policy, wantDecID string) error {
+	r := p.Reboot
+	if r == nil {
+		return fmt.Errorf("reboot: absent")
+	}
+	checks := []error{
+		testhelpers.RequireEqual("reboot.message", "Omit-retains reboot message", testhelpers.Deref(r.Message)),
+		testhelpers.RequireEqual("reboot.startup_disk", "Current Startup Disk", testhelpers.Deref(r.StartupDisk)),
+		testhelpers.RequireEqual("reboot.specify_startup", "Standard Restart", testhelpers.Deref(r.SpecifyStartup)),
+		testhelpers.RequireEqual("reboot.no_user_logged_in", "Restart immediately", testhelpers.Deref(r.NoUserLoggedIn)),
+		testhelpers.RequireEqual("reboot.user_logged_in", "Restart if a package or update requires it", testhelpers.Deref(r.UserLoggedIn)),
+		testhelpers.RequireEqual("reboot.minutes_until_reboot", 7, testhelpers.Deref(r.MinutesUntilReboot)),
+		testhelpers.RequireEqual("reboot.start_reboot_timer_immediately", true, testhelpers.Deref(r.StartRebootTimerImmediately)),
+		testhelpers.RequireEqual("reboot.file_vault_2_reboot", true, testhelpers.Deref(r.FileVault2Reboot)),
+	}
+	for _, err := range checks {
+		if err != nil {
+			return err
+		}
+	}
+	m := p.Maintenance
+	if m == nil {
+		return fmt.Errorf("maintenance: absent")
+	}
+	checks = []error{
+		testhelpers.RequireEqual("maintenance.recon", false, testhelpers.Deref(m.Recon)),
+		testhelpers.RequireEqual("maintenance.reset_name", true, testhelpers.Deref(m.ResetName)),
+		testhelpers.RequireEqual("maintenance.install_all_cached_packages", true, testhelpers.Deref(m.InstallAllCachedPackages)),
+		testhelpers.RequireEqual("maintenance.permissions", false, testhelpers.Deref(m.Permissions)),
+		testhelpers.RequireEqual("maintenance.byhost", true, testhelpers.Deref(m.Byhost)),
+		testhelpers.RequireEqual("maintenance.system_cache", false, testhelpers.Deref(m.SystemCache)),
+		testhelpers.RequireEqual("maintenance.user_cache", true, testhelpers.Deref(m.UserCache)),
+		testhelpers.RequireEqual("maintenance.verify", true, testhelpers.Deref(m.Verify)),
+	}
+	for _, err := range checks {
+		if err != nil {
+			return err
+		}
+	}
+	fp := p.FilesProcesses
+	if fp == nil {
+		return fmt.Errorf("files_processes: absent")
+	}
+	checks = []error{
+		testhelpers.RequireEqual("files_processes.search_by_path", "/tmp/omit-retains", testhelpers.Deref(fp.SearchByPath)),
+		testhelpers.RequireEqual("files_processes.delete_file", true, testhelpers.Deref(fp.DeleteFile)),
+		testhelpers.RequireEqual("files_processes.locate_file", "omit-retains.txt", testhelpers.Deref(fp.LocateFile)),
+		testhelpers.RequireEqual("files_processes.update_locate_database", true, testhelpers.Deref(fp.UpdateLocateDatabase)),
+		testhelpers.RequireEqual("files_processes.spotlight_search", "omit-retains-spotlight", testhelpers.Deref(fp.SpotlightSearch)),
+		testhelpers.RequireEqual("files_processes.search_for_process", "omitretainsd", testhelpers.Deref(fp.SearchForProcess)),
+		testhelpers.RequireEqual("files_processes.kill_process", true, testhelpers.Deref(fp.KillProcess)),
+		testhelpers.RequireEqual("files_processes.run_command", "echo omit-retains", testhelpers.Deref(fp.RunCommand)),
+	}
+	for _, err := range checks {
+		if err != nil {
+			return err
+		}
+	}
+	ui := p.UserInteraction
+	if ui == nil {
+		return fmt.Errorf("user_interaction: absent")
+	}
+	checks = []error{
+		testhelpers.RequireEqual("user_interaction.message_start", "Omit-retains start message", testhelpers.Deref(ui.MessageStart)),
+		testhelpers.RequireEqual("user_interaction.message_finish", "Omit-retains complete message", testhelpers.Deref(ui.MessageFinish)),
+		testhelpers.RequireEqual("user_interaction.allow_users_to_defer", true, testhelpers.Deref(ui.AllowUsersToDefer)),
+		testhelpers.RequireEqual("user_interaction.allow_deferral_minutes", 3*1440, testhelpers.Deref(ui.AllowDeferralMinutes)),
+	}
+	for _, err := range checks {
+		if err != nil {
+			return err
+		}
+	}
+	de := p.DiskEncryption
+	if de == nil {
+		return fmt.Errorf("disk_encryption: absent")
+	}
+	if err := testhelpers.RequireEqual("disk_encryption.action", "apply", testhelpers.Deref(de.Action)); err != nil {
+		return err
+	}
+	if err := testhelpers.RequireEqual("disk_encryption.disk_encryption_configuration_id", wantDecID, fmt.Sprintf("%d", testhelpers.Deref(de.DiskEncryptionConfigurationID))); err != nil {
+		return err
+	}
+	return testhelpers.RequireEqual("disk_encryption.auth_restart", true, testhelpers.Deref(de.AuthRestart))
+}
+
+// TestAccResource_ProPolicy_OmittedBlocksRetained pins the omit-retains
+// contract the plan output cannot show. Dropping any state-gated block from
+// config plans it as removed, the classic PUT omits the element, and the
+// server is expected to keep every value; Terraform state cannot witness
+// that, so the assertion is made against the wire object after every step.
+// Step 1 declares every gated section this test can build without an upload
+// (packages needs JCDS, self_service_icon needs icon bytes). Step 2 keeps
+// the parents that have gated children and drops the children — so the scope
+// travels through the granular merge, self_service goes out without
+// categories, and <account_maintenance> names only <management_account>.
+// Step 3 drops every optional block so the PUT carries <general> alone. Each
+// step's implicit post-apply plan must be empty. If this test fails on
+// content, the endpoint no longer merges for that element and nothing that
+// suppresses the removal plan may ship for this resource.
+func TestAccResource_ProPolicy_OmittedBlocksRetained(t *testing.T) {
+	testhelpers.AccPreCheck(t)
+	suffix := testhelpers.RunSuffix()
+	n := newPolicyOmitRetainsNames("tf-acc-policy-omit-" + suffix)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testhelpers.AccTestProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckPolicyDestroy(t),
+		Steps: []resource.TestStep{
+			{
+				Config: policyOmitRetainsConfig(n),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(policyOmitRetainsResourceAddr, "self_service.install_button_text", "Retain me"),
+					resource.TestCheckResourceAttr(policyOmitRetainsResourceAddr, "self_service.categories.#", "1"),
+					resource.TestCheckResourceAttr(policyOmitRetainsResourceAddr, "scope.exclusions.department_ids.#", "1"),
+					policyRetainedOnServer(t, n),
+				),
+			},
+			{
+				Config: policyOmitRetainsParentsOnlyConfig(n),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(policyOmitRetainsResourceAddr, "self_service.install_button_text", "Retain me"),
+					resource.TestCheckNoResourceAttr(policyOmitRetainsResourceAddr, "self_service.categories.#"),
+					resource.TestCheckNoResourceAttr(policyOmitRetainsResourceAddr, "scope.exclusions.department_ids.#"),
+					resource.TestCheckNoResourceAttr(policyOmitRetainsResourceAddr, "scope.limitations.ibeacon_ids.#"),
+					resource.TestCheckNoResourceAttr(policyOmitRetainsResourceAddr, "general.date_time_limitations.activation_date"),
+					resource.TestCheckNoResourceAttr(policyOmitRetainsResourceAddr, "local_accounts.#"),
+					resource.TestCheckNoResourceAttr(policyOmitRetainsResourceAddr, "scripts.scripts.#"),
+					policyRetainedOnServer(t, n),
+				),
+			},
+			{
+				Config: policyOmitRetainsGeneralOnlyConfig(n),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr(policyOmitRetainsResourceAddr, "scope.targets.building_ids.#"),
+					resource.TestCheckNoResourceAttr(policyOmitRetainsResourceAddr, "self_service.use_for_self_service"),
+					resource.TestCheckNoResourceAttr(policyOmitRetainsResourceAddr, "management_account.action"),
+					policyRetainedOnServer(t, n),
+				),
+			},
+		},
+	})
+}

--- a/internal/resources/pro/restricted_software/resource_acceptance_test.go
+++ b/internal/resources/pro/restricted_software/resource_acceptance_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"strconv"
 	"testing"
 
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/proclassic"
@@ -333,6 +334,266 @@ resource "jamfplatform_pro_restricted_software" "test" {
 				// ownership). Implicit post-step empty-plan enforces the round-trip.
 				Config: cfg(``),
 				Check:  resource.TestCheckResourceAttr(restrictedSoftwareResourceAddr, "scope.exclusions.directory_service_or_local_user_names.#", "0"),
+			},
+		},
+	})
+}
+
+// restrictedSoftwareOmitRetainsFixtures declares the tenant objects the
+// omit-retains configs scope against: one department, building and static
+// computer group for the targets tab and a second of each for the exclusions
+// tab, so every ID-keyed category on both tabs carries a real, distinct member.
+// The Platform device groups bridge to the classic scope through jamf_pro_id.
+func restrictedSoftwareOmitRetainsFixtures(suffix string) string {
+	return fmt.Sprintf(`
+		resource "jamfplatform_pro_department" "target" {
+			name = "tf-acc-rs-omit-dept-target-%[1]s"
+		}
+
+		resource "jamfplatform_pro_department" "excluded" {
+			name = "tf-acc-rs-omit-dept-excluded-%[1]s"
+		}
+
+		resource "jamfplatform_pro_building" "target" {
+			name = "tf-acc-rs-omit-bldg-target-%[1]s"
+		}
+
+		resource "jamfplatform_pro_building" "excluded" {
+			name = "tf-acc-rs-omit-bldg-excluded-%[1]s"
+		}
+
+		resource "jamfplatform_device_group" "target" {
+			name        = "tf-acc-rs-omit-group-target-%[1]s"
+			description = "tf-acc omit-retains scope target fixture"
+			group_type  = "static"
+			device_type = "computer"
+		}
+
+		resource "jamfplatform_device_group" "excluded" {
+			name        = "tf-acc-rs-omit-group-excluded-%[1]s"
+			description = "tf-acc omit-retains scope exclusion fixture"
+			group_type  = "static"
+			device_type = "computer"
+		}
+	`, suffix)
+}
+
+// restrictedSoftwareOmitRetainsConfig is the fully declared shape for the
+// omit-retains contract: both scope tabs carry a member in every ID-keyed
+// category plus a free-text excluded user, and general carries non-default
+// values, so a server that stopped retaining an omitted element is caught on
+// content, not on presence. Restricted software has no limitations tab.
+func restrictedSoftwareOmitRetainsConfig(name, suffix string) string {
+	return restrictedSoftwareOmitRetainsFixtures(suffix) + fmt.Sprintf(`
+		resource "jamfplatform_pro_restricted_software" "test" {
+			general = {
+				name            = %q
+				process_name    = "Chess.app"
+				kill_process    = true
+				display_message = "Omit-retains contract message."
+			}
+			scope = {
+				targets = {
+					department_ids     = [jamfplatform_pro_department.target.id]
+					building_ids       = [jamfplatform_pro_building.target.id]
+					computer_group_ids = [jamfplatform_device_group.target.jamf_pro_id]
+				}
+				exclusions = {
+					department_ids                        = [jamfplatform_pro_department.excluded.id]
+					building_ids                          = [jamfplatform_pro_building.excluded.id]
+					computer_group_ids                    = [jamfplatform_device_group.excluded.jamf_pro_id]
+					directory_service_or_local_user_names = ["tf-acc-omit-retains-user"]
+				}
+			}
+		}
+	`, name)
+}
+
+// restrictedSoftwareOmitRetainsTargetsOnlyConfig keeps scope.targets but drops
+// scope.exclusions and the Optional+Computed general.display_message, so the
+// PUT re-emits the scope from the granular merge with the exclusions folded in
+// from the live object rather than from config.
+func restrictedSoftwareOmitRetainsTargetsOnlyConfig(name, suffix string) string {
+	return restrictedSoftwareOmitRetainsFixtures(suffix) + fmt.Sprintf(`
+		resource "jamfplatform_pro_restricted_software" "test" {
+			general = {
+				name         = %q
+				process_name = "Chess.app"
+				kill_process = true
+			}
+			scope = {
+				targets = {
+					department_ids     = [jamfplatform_pro_department.target.id]
+					building_ids       = [jamfplatform_pro_building.target.id]
+					computer_group_ids = [jamfplatform_device_group.target.jamf_pro_id]
+				}
+			}
+		}
+	`, name)
+}
+
+// restrictedSoftwareOmitRetainsGeneralOnlyConfig drops the scope block, so the
+// PUT carries <general> alone. The fixtures stay declared so the server's
+// retained scope keeps pointing at live objects, and depends_on keeps the
+// destroy order the dropped references no longer imply: the Platform
+// device-groups API refuses to delete a group the retained scope still names
+// (422 HAS_DEPENDENCIES), so the record must go before its groups.
+func restrictedSoftwareOmitRetainsGeneralOnlyConfig(name, suffix string) string {
+	return restrictedSoftwareOmitRetainsFixtures(suffix) + fmt.Sprintf(`
+		resource "jamfplatform_pro_restricted_software" "test" {
+			depends_on = [jamfplatform_device_group.target, jamfplatform_device_group.excluded]
+
+			general = {
+				name         = %q
+				process_name = "Chess.app"
+				kill_process = true
+			}
+		}
+	`, name)
+}
+
+// stateAttr returns one attribute of a resource in the Terraform state, so a
+// wire assertion can compare against the id a fixture was actually allocated.
+func stateAttr(s *terraform.State, addr, key string) (string, error) {
+	rs, ok := s.RootModule().Resources[addr]
+	if !ok {
+		return "", fmt.Errorf("fixture %s not found in state", addr)
+	}
+	v, ok := rs.Primary.Attributes[key]
+	if !ok || v == "" {
+		return "", fmt.Errorf("fixture %s has no %s in state", addr, key)
+	}
+	return v, nil
+}
+
+// requireSingleID asserts a classic id/name collection holds exactly one member
+// carrying the wanted id.
+func requireSingleID(field, want string, items *[]proclassic.IDName) error {
+	if items == nil || len(*items) != 1 {
+		return fmt.Errorf("%s: want exactly one member, got %+v", field, items)
+	}
+	return testhelpers.RequireEqual(field+"[0].id", want, strconv.Itoa(testhelpers.Deref((*items)[0].ID)))
+}
+
+// restrictedSoftwareRetainedOnServer asserts the server's copy still carries
+// every value the omit-retains config declared in its first step. The fixture
+// ids are read from the Terraform state rather than assumed, so the check
+// compares against what the tenant allocated.
+func restrictedSoftwareRetainedOnServer(t *testing.T) resource.TestCheckFunc {
+	c := proclassic.New(testhelpers.NewAcceptanceClient(t))
+	return func(s *terraform.State) error {
+		ids := map[string]string{}
+		for _, f := range []struct{ key, addr, attr string }{
+			{"department.target", "jamfplatform_pro_department.target", "id"},
+			{"department.excluded", "jamfplatform_pro_department.excluded", "id"},
+			{"building.target", "jamfplatform_pro_building.target", "id"},
+			{"building.excluded", "jamfplatform_pro_building.excluded", "id"},
+			{"group.target", "jamfplatform_device_group.target", "jamf_pro_id"},
+			{"group.excluded", "jamfplatform_device_group.excluded", "jamf_pro_id"},
+		} {
+			v, err := stateAttr(s, f.addr, f.attr)
+			if err != nil {
+				return err
+			}
+			ids[f.key] = v
+		}
+		return testhelpers.CheckLiveObject(restrictedSoftwareResourceAddr,
+			func(ctx context.Context, id string) (*proclassic.RestrictedSoftware, error) {
+				return c.GetRestrictedSoftwareByID(ctx, id)
+			},
+			func(rs *proclassic.RestrictedSoftware) error {
+				if rs.General == nil {
+					return fmt.Errorf("general: absent")
+				}
+				if err := testhelpers.RequireEqual("general.kill_process", true, testhelpers.Deref(rs.General.KillProcess)); err != nil {
+					return err
+				}
+				if err := testhelpers.RequireEqual("general.display_message", "Omit-retains contract message.", testhelpers.Deref(rs.General.DisplayMessage)); err != nil {
+					return err
+				}
+				if rs.Scope == nil {
+					return fmt.Errorf("scope: absent")
+				}
+				sc := rs.Scope
+				if err := testhelpers.RequireEqual("scope.all_computers", false, testhelpers.Deref(sc.AllComputers)); err != nil {
+					return err
+				}
+				if sc.Departments == nil || sc.Buildings == nil || sc.ComputerGroups == nil {
+					return fmt.Errorf("scope.targets: a category is absent: %+v", sc)
+				}
+				if err := requireSingleID("scope.targets.departments", ids["department.target"], sc.Departments.Department); err != nil {
+					return err
+				}
+				if err := requireSingleID("scope.targets.buildings", ids["building.target"], sc.Buildings.Building); err != nil {
+					return err
+				}
+				if err := requireSingleID("scope.targets.computer_groups", ids["group.target"], sc.ComputerGroups.ComputerGroup); err != nil {
+					return err
+				}
+				x := sc.Exclusions
+				if x == nil || x.Departments == nil || x.Buildings == nil || x.ComputerGroups == nil || x.Users == nil {
+					return fmt.Errorf("scope.exclusions: a category is absent: %+v", x)
+				}
+				if err := requireSingleID("scope.exclusions.departments", ids["department.excluded"], x.Departments.Department); err != nil {
+					return err
+				}
+				if err := requireSingleID("scope.exclusions.buildings", ids["building.excluded"], x.Buildings.Building); err != nil {
+					return err
+				}
+				if err := requireSingleID("scope.exclusions.computer_groups", ids["group.excluded"], x.ComputerGroups.ComputerGroup); err != nil {
+					return err
+				}
+				if x.Users.User == nil || len(*x.Users.User) != 1 {
+					return fmt.Errorf("scope.exclusions.users: want exactly one user, got %+v", x.Users)
+				}
+				return testhelpers.RequireEqual("scope.exclusions.users[0].name", "tf-acc-omit-retains-user", testhelpers.Deref((*x.Users.User)[0].Name))
+			})(s)
+	}
+}
+
+// TestAccResource_ProRestrictedSoftware_OmittedBlocksRetained pins the
+// omit-retains contract the plan output cannot show: dropping scope.exclusions,
+// then the whole scope, from config plans them as removed, but the classic PUT
+// omits the elements and the server keeps every value. Step 2 keeps
+// scope.targets so the scope goes through the granular read-merge-write, which
+// must fold the live exclusions back in rather than emitting them empty; it
+// also drops the Optional+Computed general.display_message. Step 3 drops scope
+// too so the PUT carries <general> alone. Each step's implicit post-apply plan
+// must be empty, which is what makes the contract usable. If this test fails
+// on content, the endpoint no longer merges and nothing that suppresses the
+// removal plan may ship for this resource.
+func TestAccResource_ProRestrictedSoftware_OmittedBlocksRetained(t *testing.T) {
+	testhelpers.AccPreCheck(t)
+	suffix := testhelpers.RunSuffix()
+	name := "tf-acc-rs-omit-" + suffix
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testhelpers.AccTestProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckRestrictedSoftwareDestroy(t),
+		Steps: []resource.TestStep{
+			{
+				Config: restrictedSoftwareOmitRetainsConfig(name, suffix),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(restrictedSoftwareResourceAddr, "scope.exclusions.directory_service_or_local_user_names.#", "1"),
+					resource.TestCheckResourceAttr(restrictedSoftwareResourceAddr, "general.display_message", "Omit-retains contract message."),
+					restrictedSoftwareRetainedOnServer(t),
+				),
+			},
+			{
+				Config: restrictedSoftwareOmitRetainsTargetsOnlyConfig(name, suffix),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr(restrictedSoftwareResourceAddr, "scope.exclusions.directory_service_or_local_user_names.#"),
+					resource.TestCheckResourceAttr(restrictedSoftwareResourceAddr, "scope.targets.department_ids.#", "1"),
+					resource.TestCheckResourceAttr(restrictedSoftwareResourceAddr, "general.display_message", "Omit-retains contract message."),
+					restrictedSoftwareRetainedOnServer(t),
+				),
+			},
+			{
+				Config: restrictedSoftwareOmitRetainsGeneralOnlyConfig(name, suffix),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr(restrictedSoftwareResourceAddr, "scope.targets.department_ids.#"),
+					restrictedSoftwareRetainedOnServer(t),
+				),
 			},
 		},
 	})

--- a/internal/resources/pro/user_group/resource_acceptance_test.go
+++ b/internal/resources/pro/user_group/resource_acceptance_test.go
@@ -13,6 +13,7 @@ package user_group_test
 import (
 	"context"
 	"fmt"
+	"slices"
 	"testing"
 
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/proclassic"
@@ -547,6 +548,150 @@ func TestAccResource_ProUserGroup_Static_MembersNullVsEmpty(t *testing.T) {
 					resource.TestCheckResourceAttr("jamfplatform_pro_user_group.test", "members.#", "1"),
 					resource.TestCheckResourceAttr("jamfplatform_pro_user_group.test", "member_count", "1"),
 					resource.TestCheckTypeSetElemAttr("jamfplatform_pro_user_group.test", "members.*", u1ID),
+				),
+			},
+		},
+	})
+}
+
+const userGroupResourceAddr = "jamfplatform_pro_user_group.test"
+
+// userGroupOmitRetainsConfig is the fully declared shape for the omit-retains
+// contract on a static group: members is the one Read-gated attribute this
+// resource has (refreshed only when prior state holds it), and it carries a
+// real user id rather than an empty set so a server that stopped retaining an
+// omitted <users> element is caught on content, not on presence. The
+// notify flag is a non-default Optional+Computed leaf kept alongside it.
+func userGroupOmitRetainsConfig(name, memberID string) string {
+	return fmt.Sprintf(`
+		resource "jamfplatform_pro_user_group" "test" {
+			name                        = %q
+			group_type                  = "static"
+			notify_on_membership_change = true
+			members                     = [%q]
+		}
+	`, name, memberID)
+}
+
+// userGroupOmitRetainsMembersDroppedConfig drops members from config, so the
+// plan removes it from state and buildUsersWrapper omits <users> from the PUT.
+func userGroupOmitRetainsMembersDroppedConfig(name string) string {
+	return fmt.Sprintf(`
+		resource "jamfplatform_pro_user_group" "test" {
+			name                        = %q
+			group_type                  = "static"
+			notify_on_membership_change = true
+		}
+	`, name)
+}
+
+// userGroupOmitRetainsMembersClearedConfig is the documented clear path: an
+// explicit empty set sends an empty <users/> wrapper, which the server
+// applies. members is Optional-only, so `[]` is the only way to clear it.
+func userGroupOmitRetainsMembersClearedConfig(name string) string {
+	return fmt.Sprintf(`
+		resource "jamfplatform_pro_user_group" "test" {
+			name                        = %q
+			group_type                  = "static"
+			notify_on_membership_change = true
+			members                     = []
+		}
+	`, name)
+}
+
+// userGroupMembersOnServer asserts the server's copy of the group lists
+// exactly wantIDs as members and still carries the step-1 notify flag.
+func userGroupMembersOnServer(t *testing.T, wantIDs ...int) resource.TestCheckFunc {
+	c := proclassic.New(testhelpers.NewAcceptanceClient(t))
+	return testhelpers.CheckLiveObject(userGroupResourceAddr,
+		func(ctx context.Context, id string) (*proclassic.UserGroup, error) {
+			return c.GetUserGroupByID(ctx, id)
+		},
+		func(ug *proclassic.UserGroup) error {
+			if err := testhelpers.RequireEqual("is_notify_on_change", true, testhelpers.Deref(ug.IsNotifyOnChange)); err != nil {
+				return err
+			}
+			var gotIDs []int
+			if ug.Users != nil && ug.Users.User != nil {
+				for _, u := range *ug.Users.User {
+					gotIDs = append(gotIDs, testhelpers.Deref(u.ID))
+				}
+			}
+			if err := testhelpers.RequireEqual("users.size", len(wantIDs), len(gotIDs)); err != nil {
+				return err
+			}
+			for _, want := range wantIDs {
+				if !slices.Contains(gotIDs, want) {
+					return fmt.Errorf("users: want member %d, got %v", want, gotIDs)
+				}
+			}
+			return nil
+		})
+}
+
+// TestAccResource_ProUserGroup_OmittedBlocksRetained pins the omit-retains
+// contract on the one Read-gated attribute a static user group has: dropping
+// members from config plans it as removed, the classic PUT omits <users>, and
+// the server keeps the membership. Terraform state cannot witness that, so the
+// assertion runs against the wire object after every step. Step 3 then
+// asserts the documented clear path — an explicit `members = []` — really does
+// empty the group, so the two shapes are pinned side by side. Each step's
+// implicit post-apply plan must be empty. If step 2 fails on content, the
+// endpoint no longer merges and nothing that suppresses the removal plan may
+// ship for this resource.
+//
+// The member fixture is a classic user created through the SDK, as
+// TestAccResource_ProUserGroup_Static_MembersNullVsEmpty does: there is no
+// jamfplatform_pro_user resource. t.Cleanup runs after the framework's destroy,
+// so the group is gone before the user is deleted.
+func TestAccResource_ProUserGroup_OmittedBlocksRetained(t *testing.T) {
+	testhelpers.AccPreCheck(t)
+	suffix := testhelpers.RunSuffix()
+	groupName := "tf-acc-pro-ug-omit-" + suffix
+	userName := "tf-acc-pro-ug-omit-member-" + suffix
+
+	ctx := context.Background()
+	client := proclassic.New(testhelpers.NewAcceptanceClient(t))
+
+	member, err := client.CreateUserByID(ctx, "0", &proclassic.UserPost{Name: new(userName)})
+	if err != nil {
+		t.Fatalf("create fixture user: %v", err)
+	}
+	if member == nil || member.ID == nil {
+		t.Fatal("create fixture user: response carried no id")
+	}
+	t.Cleanup(func() {
+		_ = client.DeleteUserByID(context.Background(), fmt.Sprintf("%d", *member.ID))
+	})
+	memberID := fmt.Sprintf("%d", *member.ID)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testhelpers.AccTestProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckUserGroupDestroy(t),
+		Steps: []resource.TestStep{
+			{
+				Config: userGroupOmitRetainsConfig(groupName, memberID),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(userGroupResourceAddr, "members.#", "1"),
+					resource.TestCheckTypeSetElemAttr(userGroupResourceAddr, "members.*", memberID),
+					resource.TestCheckResourceAttr(userGroupResourceAddr, "member_count", "1"),
+					userGroupMembersOnServer(t, *member.ID),
+				),
+			},
+			{
+				Config: userGroupOmitRetainsMembersDroppedConfig(groupName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr(userGroupResourceAddr, "members"),
+					resource.TestCheckResourceAttr(userGroupResourceAddr, "member_count", "1"),
+					userGroupMembersOnServer(t, *member.ID),
+				),
+			},
+			{
+				Config: userGroupOmitRetainsMembersClearedConfig(groupName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(userGroupResourceAddr, "members.#", "0"),
+					resource.TestCheckResourceAttr(userGroupResourceAddr, "member_count", "0"),
+					userGroupMembersOnServer(t),
 				),
 			},
 		},

--- a/internal/resources/pro/vpp_assignment/resource_acceptance_test.go
+++ b/internal/resources/pro/vpp_assignment/resource_acceptance_test.go
@@ -39,6 +39,9 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"slices"
+	"sort"
+	"strconv"
 	"testing"
 
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/proclassic"
@@ -406,6 +409,326 @@ resource "jamfplatform_pro_vpp_assignment" "test" {
 }
 `, name),
 				Check: resource.TestCheckResourceAttrSet(resAddr, "id"),
+			},
+		},
+	})
+}
+
+// vppaOmitRetainsConfig is the fully declared shape for the omit-retains
+// contract: every state-gated collection carries a distinctive value so that a
+// server which stopped retaining an omitted element is caught on content, not
+// on presence. The three content sets are the first owned iOS app (required —
+// the fixture token owns at least one), and the first owned Mac app and book
+// if the account has any (a `slice` of at most one, so an account owning none
+// declares `[]` and the contract is still exercised on the cleared shape).
+// The scope carries a target group and an exclusion group; the
+// directory-service limitation category is not declared because it needs a
+// real LDAP group and leaving one scoped through destroy orphans the
+// scope->LDAP association (see TestAccResource_ProVPPAssignment_DSGroupScope).
+// The group fixtures are carried by every step so the server never sees a
+// scoped group disappear underneath the assignment.
+func vppaOmitRetainsConfig(token, suffix, name string) string {
+	return vppaOmitRetainsFixtures(token, suffix, name) + fmt.Sprintf(`
+resource "jamfplatform_pro_vpp_assignment" "test" {
+  name                 = %[1]q
+  vpp_admin_account_id = jamfplatform_pro_volume_purchasing_location.vpp.id
+
+  ios_app_adam_ids = [
+    [for c in jamfplatform_pro_volume_purchasing_location.vpp.content :
+      c.adam_id if c.content_type == "IOS_APP"
+    ][0],
+  ]
+  mac_app_adam_ids = slice(
+    [for c in jamfplatform_pro_volume_purchasing_location.vpp.content :
+      c.adam_id if c.content_type == "MAC_APP"
+    ], 0, min(1, length([for c in jamfplatform_pro_volume_purchasing_location.vpp.content :
+      c.adam_id if c.content_type == "MAC_APP"
+    ])))
+  ebook_adam_ids = slice(
+    [for c in jamfplatform_pro_volume_purchasing_location.vpp.content :
+      c.adam_id if c.content_type == "BOOK"
+    ], 0, min(1, length([for c in jamfplatform_pro_volume_purchasing_location.vpp.content :
+      c.adam_id if c.content_type == "BOOK"
+    ])))
+
+  scope = {
+    targets = {
+      jss_user_group_ids = [jamfplatform_pro_user_group.a.id]
+    }
+    exclusions = {
+      jss_user_group_ids = [jamfplatform_pro_user_group.b.id]
+    }
+  }
+}
+`, name)
+}
+
+// vppaOmitRetainsChildrenDroppedConfig keeps the scope block but drops its
+// exclusions (re-emitted from the granular merge), keeps the iOS content set
+// and drops the Mac and book sets (omitted, so retained by the merge).
+func vppaOmitRetainsChildrenDroppedConfig(token, suffix, name string) string {
+	return vppaOmitRetainsFixtures(token, suffix, name) + fmt.Sprintf(`
+resource "jamfplatform_pro_vpp_assignment" "test" {
+  name                 = %[1]q
+  vpp_admin_account_id = jamfplatform_pro_volume_purchasing_location.vpp.id
+
+  ios_app_adam_ids = [
+    [for c in jamfplatform_pro_volume_purchasing_location.vpp.content :
+      c.adam_id if c.content_type == "IOS_APP"
+    ][0],
+  ]
+
+  scope = {
+    targets = {
+      jss_user_group_ids = [jamfplatform_pro_user_group.a.id]
+    }
+  }
+}
+`, name)
+}
+
+// vppaOmitRetainsGeneralOnlyConfig drops every optional collection and the
+// scope, so the PUT carries <general> alone.
+func vppaOmitRetainsGeneralOnlyConfig(token, suffix, name string) string {
+	return vppaOmitRetainsFixtures(token, suffix, name) + fmt.Sprintf(`
+resource "jamfplatform_pro_vpp_assignment" "test" {
+  name                 = %[1]q
+  vpp_admin_account_id = jamfplatform_pro_volume_purchasing_location.vpp.id
+}
+`, name)
+}
+
+// vppaOmitRetainsFixtures is the location + two static user groups every
+// omit-retains step shares.
+func vppaOmitRetainsFixtures(token, suffix, name string) string {
+	return vppLocationFixture(token, suffix) + fmt.Sprintf(`
+resource "jamfplatform_pro_user_group" "a" {
+  name       = "%[1]s-grp-a"
+  group_type = "static"
+}
+
+resource "jamfplatform_pro_user_group" "b" {
+  name       = "%[1]s-grp-b"
+  group_type = "static"
+}
+`, name)
+}
+
+// vppaOmitRetainsWant is what step 1 wrote, captured from Terraform state
+// rather than hand-set: the adam_ids come from whatever the fixture account
+// owns, and the group ids are minted by the tenant.
+type vppaOmitRetainsWant struct {
+	ios, mac, ebook   []int
+	targetGroup, excl int
+}
+
+// vppaOmitRetainsCapture records the step-1 values the later steps must find
+// on the wire. Runs before vppaRetainedOnServer in the same composed check.
+func vppaOmitRetainsCapture(want *vppaOmitRetainsWant) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		var err error
+		if want.ios, err = vppaStateIntSet(s, resAddr, "ios_app_adam_ids"); err != nil {
+			return err
+		}
+		if want.mac, err = vppaStateIntSet(s, resAddr, "mac_app_adam_ids"); err != nil {
+			return err
+		}
+		if want.ebook, err = vppaStateIntSet(s, resAddr, "ebook_adam_ids"); err != nil {
+			return err
+		}
+		if want.targetGroup, err = vppaStateInt(s, "jamfplatform_pro_user_group.a", "id"); err != nil {
+			return err
+		}
+		if want.excl, err = vppaStateInt(s, "jamfplatform_pro_user_group.b", "id"); err != nil {
+			return err
+		}
+		if len(want.ios) != 1 {
+			return fmt.Errorf("ios_app_adam_ids: want exactly one assigned app, got %v", want.ios)
+		}
+		return nil
+	}
+}
+
+func vppaStateInt(s *terraform.State, addr, key string) (int, error) {
+	rs, ok := s.RootModule().Resources[addr]
+	if !ok {
+		return 0, fmt.Errorf("resource %s not found in state", addr)
+	}
+	raw, ok := rs.Primary.Attributes[key]
+	if !ok {
+		return 0, fmt.Errorf("%s: attribute %s not in state", addr, key)
+	}
+	return strconv.Atoi(raw)
+}
+
+func vppaStateIntSet(s *terraform.State, addr, key string) ([]int, error) {
+	n, err := vppaStateInt(s, addr, key+".#")
+	if err != nil {
+		return nil, err
+	}
+	out := make([]int, 0, n)
+	for i := range n {
+		v, err := vppaStateInt(s, addr, fmt.Sprintf("%s.%d", key, i))
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, v)
+	}
+	sort.Ints(out)
+	return out, nil
+}
+
+// vppaRequireIDs compares a wire id list against the ids step 1 wrote,
+// order-insensitively. A nil wire wrapper is an empty list.
+func vppaRequireIDs(field string, want []int, got []*int) error {
+	ids := make([]int, 0, len(got))
+	for _, p := range got {
+		if p != nil {
+			ids = append(ids, *p)
+		}
+	}
+	sort.Ints(ids)
+	if !slices.Equal(want, ids) {
+		return fmt.Errorf("%s: want %v, got %v", field, want, ids)
+	}
+	return nil
+}
+
+func vppaIDNameIDs(items *[]proclassic.IDName) []*int {
+	if items == nil {
+		return nil
+	}
+	out := make([]*int, 0, len(*items))
+	for _, it := range *items {
+		out = append(out, it.ID)
+	}
+	return out
+}
+
+// vppaRetainedOnServer asserts the server's copy still carries every value the
+// omit-retains config declared in its first step.
+func vppaRetainedOnServer(t *testing.T, want *vppaOmitRetainsWant) resource.TestCheckFunc {
+	c := proclassic.New(testhelpers.NewAcceptanceClient(t))
+	return testhelpers.CheckLiveObject(resAddr,
+		func(ctx context.Context, id string) (*proclassic.VppAssignment, error) {
+			return c.GetVPPAssignmentByID(ctx, id)
+		},
+		func(a *proclassic.VppAssignment) error {
+			if err := vppaRequireIDs("ios_apps", want.ios, iosAdamIDs(a.IosApps)); err != nil {
+				return err
+			}
+			if err := vppaRequireIDs("mac_apps", want.mac, macAdamIDs(a.MacApps)); err != nil {
+				return err
+			}
+			if err := vppaRequireIDs("ebooks", want.ebook, ebookAdamIDs(a.Ebooks)); err != nil {
+				return err
+			}
+			if a.Scope == nil {
+				return fmt.Errorf("scope: absent")
+			}
+			if err := testhelpers.RequireEqual("scope.all_jss_users", false, testhelpers.Deref(a.Scope.AllJssUsers)); err != nil {
+				return err
+			}
+			var targetGroups *[]proclassic.IDName
+			if a.Scope.JssUserGroups != nil {
+				targetGroups = a.Scope.JssUserGroups.UserGroup
+			}
+			if err := vppaRequireIDs("scope.jss_user_groups", []int{want.targetGroup}, vppaIDNameIDs(targetGroups)); err != nil {
+				return err
+			}
+			if a.Scope.Exclusions == nil {
+				return fmt.Errorf("scope.exclusions: absent")
+			}
+			var exclGroups *[]proclassic.IDName
+			if a.Scope.Exclusions.JssUserGroups != nil {
+				exclGroups = a.Scope.Exclusions.JssUserGroups.UserGroup
+			}
+			return vppaRequireIDs("scope.exclusions.jss_user_groups", []int{want.excl}, vppaIDNameIDs(exclGroups))
+		})
+}
+
+func iosAdamIDs(a *proclassic.VppAssignmentIosApps) []*int {
+	if a == nil || a.IosApp == nil {
+		return nil
+	}
+	out := make([]*int, 0, len(*a.IosApp))
+	for _, it := range *a.IosApp {
+		out = append(out, it.AdamID)
+	}
+	return out
+}
+
+func macAdamIDs(a *proclassic.VppAssignmentMacApps) []*int {
+	if a == nil || a.MacApp == nil {
+		return nil
+	}
+	out := make([]*int, 0, len(*a.MacApp))
+	for _, it := range *a.MacApp {
+		out = append(out, it.AdamID)
+	}
+	return out
+}
+
+func ebookAdamIDs(a *proclassic.VppAssignmentEbooks) []*int {
+	if a == nil || a.Ebook == nil {
+		return nil
+	}
+	out := make([]*int, 0, len(*a.Ebook))
+	for _, it := range *a.Ebook {
+		out = append(out, it.AdamID)
+	}
+	return out
+}
+
+// TestAccResource_ProVPPAssignment_OmittedBlocksRetained pins the omit-retains
+// contract the plan output cannot show: dropping a gated collection or scope
+// block from config plans it as removed, but the classic PUT omits the element
+// and the server keeps every value. Step 2 keeps the scope and the iOS set
+// and drops the scope exclusions (through the granular merge) plus the Mac and
+// book sets; step 3 drops every optional element so the PUT carries <general>
+// alone. Each step's implicit post-apply plan must be empty, which is what
+// makes the contract usable. If this test fails on content, the endpoint no
+// longer merges and nothing that suppresses the removal plan may ship for this
+// resource. Gated on JAMFPLATFORM_ACC_PRO_VPP_TOKEN like every apply test here.
+func TestAccResource_ProVPPAssignment_OmittedBlocksRetained(t *testing.T) {
+	token := vppToken(t)
+	testhelpers.AccPreCheck(t)
+	suffix := testhelpers.RunSuffix()
+	name := "tf-acc-vppa-omit-" + suffix
+	var want vppaOmitRetainsWant
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testhelpers.AccTestProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckVPPAssignmentDestroy(t),
+		Steps: []resource.TestStep{
+			{
+				Config: vppaOmitRetainsConfig(token, suffix, name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resAddr, "ios_app_adam_ids.#", "1"),
+					resource.TestCheckResourceAttr(resAddr, "scope.targets.jss_user_group_ids.#", "1"),
+					resource.TestCheckResourceAttr(resAddr, "scope.exclusions.jss_user_group_ids.#", "1"),
+					vppaOmitRetainsCapture(&want),
+					vppaRetainedOnServer(t, &want),
+				),
+			},
+			{
+				Config: vppaOmitRetainsChildrenDroppedConfig(token, suffix, name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resAddr, "ios_app_adam_ids.#", "1"),
+					resource.TestCheckNoResourceAttr(resAddr, "mac_app_adam_ids.#"),
+					resource.TestCheckNoResourceAttr(resAddr, "ebook_adam_ids.#"),
+					resource.TestCheckResourceAttr(resAddr, "scope.targets.jss_user_group_ids.#", "1"),
+					resource.TestCheckNoResourceAttr(resAddr, "scope.exclusions.jss_user_group_ids.#"),
+					vppaRetainedOnServer(t, &want),
+				),
+			},
+			{
+				Config: vppaOmitRetainsGeneralOnlyConfig(token, suffix, name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr(resAddr, "ios_app_adam_ids.#"),
+					resource.TestCheckNoResourceAttr(resAddr, "scope.targets.jss_user_group_ids.#"),
+					vppaRetainedOnServer(t, &want),
+				),
 			},
 		},
 	})

--- a/internal/resources/pro/vpp_invitation/resource_acceptance_test.go
+++ b/internal/resources/pro/vpp_invitation/resource_acceptance_test.go
@@ -37,6 +37,9 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"slices"
+	"sort"
+	"strconv"
 	"testing"
 
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/proclassic"
@@ -415,6 +418,215 @@ resource "jamfplatform_pro_vpp_invitation" "test" {
 }
 `, name),
 				Check: resource.TestCheckResourceAttrSet(resAddr, "id"),
+			},
+		},
+	})
+}
+
+// vppiOmitRetainsConfig is the fully declared shape for the omit-retains
+// contract: the one state-gated block this resource has is scope, so it
+// carries a target group and an exclusion group, each a distinctive tenant id
+// so that a server which stopped retaining an omitted element is caught on
+// content, not on presence. The directory-service limitation category is not
+// declared because it needs a real LDAP group and leaving one scoped through
+// destroy orphans the scope->LDAP association (see
+// TestAccResource_ProVPPInvitation_DSGroupScope). The group fixtures are
+// carried by every step so the server never sees a scoped group disappear
+// underneath the invitation.
+func vppiOmitRetainsConfig(token, suffix, name string) string {
+	return vppiOmitRetainsFixtures(token, suffix, name) + fmt.Sprintf(`
+resource "jamfplatform_pro_vpp_invitation" "test" {
+  name                        = %[1]q
+  vpp_account_id              = jamfplatform_pro_volume_purchasing_location.vpp.id
+  distribution_method         = "Prompt users to accept/make available in Self Service"
+  auto_register_managed_users = true
+
+  scope = {
+    targets = {
+      jss_user_group_ids = [jamfplatform_pro_user_group.a.id]
+    }
+    exclusions = {
+      jss_user_group_ids = [jamfplatform_pro_user_group.b.id]
+    }
+  }
+}
+`, name)
+}
+
+// vppiOmitRetainsChildrenDroppedConfig keeps the scope block but drops its
+// exclusions, which the granular merge re-emits from the server's copy.
+func vppiOmitRetainsChildrenDroppedConfig(token, suffix, name string) string {
+	return vppiOmitRetainsFixtures(token, suffix, name) + fmt.Sprintf(`
+resource "jamfplatform_pro_vpp_invitation" "test" {
+  name                        = %[1]q
+  vpp_account_id              = jamfplatform_pro_volume_purchasing_location.vpp.id
+  distribution_method         = "Prompt users to accept/make available in Self Service"
+  auto_register_managed_users = true
+
+  scope = {
+    targets = {
+      jss_user_group_ids = [jamfplatform_pro_user_group.a.id]
+    }
+  }
+}
+`, name)
+}
+
+// vppiOmitRetainsGeneralOnlyConfig drops the scope, so the PUT carries
+// <general> alone.
+func vppiOmitRetainsGeneralOnlyConfig(token, suffix, name string) string {
+	return vppiOmitRetainsFixtures(token, suffix, name) + fmt.Sprintf(`
+resource "jamfplatform_pro_vpp_invitation" "test" {
+  name                        = %[1]q
+  vpp_account_id              = jamfplatform_pro_volume_purchasing_location.vpp.id
+  distribution_method         = "Prompt users to accept/make available in Self Service"
+  auto_register_managed_users = true
+}
+`, name)
+}
+
+// vppiOmitRetainsFixtures is the location + two static user groups every
+// omit-retains step shares.
+func vppiOmitRetainsFixtures(token, suffix, name string) string {
+	return vppLocationFixture(token, suffix) + fmt.Sprintf(`
+resource "jamfplatform_pro_user_group" "a" {
+  name       = "%[1]s-grp-a"
+  group_type = "static"
+}
+
+resource "jamfplatform_pro_user_group" "b" {
+  name       = "%[1]s-grp-b"
+  group_type = "static"
+}
+`, name)
+}
+
+// vppiOmitRetainsWant holds the tenant-minted group ids step 1 scoped, read
+// from Terraform state so the wire assertion compares real ids.
+type vppiOmitRetainsWant struct {
+	targetGroup, excl int
+}
+
+// vppiOmitRetainsCapture records the step-1 group ids the later steps must
+// find on the wire. Runs before vppiRetainedOnServer in the same composed check.
+func vppiOmitRetainsCapture(want *vppiOmitRetainsWant) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		var err error
+		if want.targetGroup, err = vppiStateInt(s, "jamfplatform_pro_user_group.a", "id"); err != nil {
+			return err
+		}
+		want.excl, err = vppiStateInt(s, "jamfplatform_pro_user_group.b", "id")
+		return err
+	}
+}
+
+func vppiStateInt(s *terraform.State, addr, key string) (int, error) {
+	rs, ok := s.RootModule().Resources[addr]
+	if !ok {
+		return 0, fmt.Errorf("resource %s not found in state", addr)
+	}
+	raw, ok := rs.Primary.Attributes[key]
+	if !ok {
+		return 0, fmt.Errorf("%s: attribute %s not in state", addr, key)
+	}
+	return strconv.Atoi(raw)
+}
+
+// vppiRequireIDs compares a wire IDName list against the ids step 1 wrote,
+// order-insensitively. A nil wrapper is an empty list.
+func vppiRequireIDs(field string, want []int, got *[]proclassic.IDName) error {
+	ids := make([]int, 0)
+	if got != nil {
+		for _, it := range *got {
+			if it.ID != nil {
+				ids = append(ids, *it.ID)
+			}
+		}
+	}
+	sort.Ints(ids)
+	if !slices.Equal(want, ids) {
+		return fmt.Errorf("%s: want %v, got %v", field, want, ids)
+	}
+	return nil
+}
+
+// vppiRetainedOnServer asserts the server's copy still carries every scope
+// value the omit-retains config declared in its first step.
+func vppiRetainedOnServer(t *testing.T, want *vppiOmitRetainsWant) resource.TestCheckFunc {
+	c := proclassic.New(testhelpers.NewAcceptanceClient(t))
+	return testhelpers.CheckLiveObject(resAddr,
+		func(ctx context.Context, id string) (*proclassic.VppInvitation, error) {
+			return c.GetVPPInvitationByID(ctx, id)
+		},
+		func(inv *proclassic.VppInvitation) error {
+			if inv.Scope == nil {
+				return fmt.Errorf("scope: absent")
+			}
+			if err := testhelpers.RequireEqual("scope.all_jss_users", false, testhelpers.Deref(inv.Scope.AllJssUsers)); err != nil {
+				return err
+			}
+			var targetGroups *[]proclassic.IDName
+			if inv.Scope.JssUserGroups != nil {
+				targetGroups = inv.Scope.JssUserGroups.UserGroup
+			}
+			if err := vppiRequireIDs("scope.jss_user_groups", []int{want.targetGroup}, targetGroups); err != nil {
+				return err
+			}
+			if inv.Scope.Exclusions == nil {
+				return fmt.Errorf("scope.exclusions: absent")
+			}
+			var exclGroups *[]proclassic.IDName
+			if inv.Scope.Exclusions.JssUserGroups != nil {
+				exclGroups = inv.Scope.Exclusions.JssUserGroups.UserGroup
+			}
+			return vppiRequireIDs("scope.exclusions.jss_user_groups", []int{want.excl}, exclGroups)
+		})
+}
+
+// TestAccResource_ProVPPInvitation_OmittedBlocksRetained pins the omit-retains
+// contract the plan output cannot show: dropping the gated scope block from
+// config plans it as removed, but the classic PUT omits the element and the
+// server keeps every value. Step 2 keeps the scope and drops its exclusions
+// (through the granular merge); step 3 drops the scope so the PUT carries
+// <general> alone. Each step's implicit post-apply plan must be empty, which
+// is what makes the contract usable. If this test fails on content, the
+// endpoint no longer merges and nothing that suppresses the removal plan may
+// ship for this resource. Gated on JAMFPLATFORM_ACC_PRO_VPP_TOKEN like every
+// apply test here.
+func TestAccResource_ProVPPInvitation_OmittedBlocksRetained(t *testing.T) {
+	token := vppToken(t)
+	testhelpers.AccPreCheck(t)
+	suffix := testhelpers.RunSuffix()
+	name := "tf-acc-vpp-omit-" + suffix
+	var want vppiOmitRetainsWant
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testhelpers.AccTestProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckVPPInvitationDestroy(t),
+		Steps: []resource.TestStep{
+			{
+				Config: vppiOmitRetainsConfig(token, suffix, name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resAddr, "scope.targets.jss_user_group_ids.#", "1"),
+					resource.TestCheckResourceAttr(resAddr, "scope.exclusions.jss_user_group_ids.#", "1"),
+					vppiOmitRetainsCapture(&want),
+					vppiRetainedOnServer(t, &want),
+				),
+			},
+			{
+				Config: vppiOmitRetainsChildrenDroppedConfig(token, suffix, name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resAddr, "scope.targets.jss_user_group_ids.#", "1"),
+					resource.TestCheckNoResourceAttr(resAddr, "scope.exclusions.jss_user_group_ids.#"),
+					vppiRetainedOnServer(t, &want),
+				),
+			},
+			{
+				Config: vppiOmitRetainsGeneralOnlyConfig(token, suffix, name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr(resAddr, "scope.targets.jss_user_group_ids.#"),
+					vppiRetainedOnServer(t, &want),
+				),
 			},
 		},
 	})

--- a/internal/testhelpers/acceptance_omit_retains.go
+++ b/internal/testhelpers/acceptance_omit_retains.go
@@ -1,0 +1,63 @@
+// Copyright Jamf Software LLC 2026
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build acceptance
+
+package testhelpers
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+// CheckLiveObject returns a TestCheckFunc that fetches the server's copy of the
+// resource at addr and hands it to assert.
+//
+// It exists for the omit-retains contract tests on the classic resources whose
+// Read gates an optional block on prior state: a config that drops such a block
+// plans it as removed, the PUT omits the element, and the classic merge is
+// expected to leave the server's copy untouched. Terraform state cannot witness
+// that — the block is gone from state by design — so the assertion has to be
+// made against the wire object. If Jamf ever changes an endpoint so that an
+// omitted element clears, this is the test that turns red, and it must turn
+// red before any plan suppression built on the same assumption ships.
+//
+// get receives the Terraform resource's id; assert receives whatever get
+// returned and reports the first block that no longer matches.
+func CheckLiveObject[T any](addr string, get func(ctx context.Context, id string) (T, error), assert func(T) error) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[addr]
+		if !ok {
+			return fmt.Errorf("resource %s not found in state", addr)
+		}
+		got, err := get(context.Background(), rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("reading live object for %s (id %s): %w", addr, rs.Primary.ID, err)
+		}
+		if err := assert(got); err != nil {
+			return fmt.Errorf("%s (id %s): omitted block was not retained on the server: %w", addr, rs.Primary.ID, err)
+		}
+		return nil
+	}
+}
+
+// RequireEqual reports a retained-value mismatch for one field.
+func RequireEqual[V comparable](field string, want, got V) error {
+	if want != got {
+		return fmt.Errorf("%s: want %v, got %v", field, want, got)
+	}
+	return nil
+}
+
+// Deref returns the pointee or the zero value, so a nil pointer in a classic
+// response compares as "absent" rather than panicking.
+func Deref[V any](p *V) V {
+	var zero V
+	if p == nil {
+		return zero
+	}
+	return *p
+}


### PR DESCRIPTION
## What

One acceptance test per block-gated classic resource (16 of them: the 12 from the #279 sweep, plus `ldap_server`, `account`, `mobile_device_enrollment_profile` and `user_group`, found by reading every classic Read path rather than grepping for a gate spelling) pinning the **omit-retains contract**: dropping a state-gated block, sub-block or collection from config plans it as removed, the classic PUT omits the element, and the server must keep every value. Terraform state cannot witness that (the block leaves state by design), so each test asserts against the wire object through the SDK GET after every step, via a shared `testhelpers.CheckLiveObject`.

Three steps per resource: fully declared → parents kept with their gated children dropped (plus one Optional+Computed leaf) → required attributes only. The framework's implicit post-apply plan must be empty at each step.

## Why

The provider's stated contract is that **an undeclared block or field is not managed by Terraform, and the server keeps whatever it holds**. That is the whole basis of co-managing an object between Terraform and the Jamf Pro UI, and it is the answer given to #383. Until now it was a promise with no test behind it — one that depends on Jamf Pro's classic merge-PUT behaviour and would therefore rot silently at some future release. These tests are what make the sentence safe to write in the documentation, and they pin it per resource, per nesting level, against a named Jamf Pro version.

Originally opened as "phase 1" of suppressing the misleading `-> null` plan in #383. That framing is withdrawn — see below — but the tests stand on their own and are not gated on it.

## Resources

| Resource | Result | Notes |
|---|---|---|
| mac_app_store_app | PASS | reference implementation |
| policy | PASS | every section except packages (JCDS) and Self Service icon (upload) |
| restricted_software | PASS | |
| ebook | PASS | both halves of the dual-target scope |
| mobile_device_app | PASS | incl. vpp and app_configuration |
| patch_policy | PASS | incl. iBeacon limitations, deadlines, grace period |
| macos_configuration_profile | PASS | |
| mobile_device_configuration_profile | PASS | |
| licensed_software | PASS | 4 steps; asserts the `[]`-clears half of the opt-out contract too |
| ldap_server | PASS | 13th gated resource, missed by the #279 sweep (gate spelled `state.Connection != nil`); partial `<mappings_for_users>` retains omitted sub-blocks |
| vpp_assignment, vpp_invitation | SKIP | same VPP token gate as the rest of their files |
| account_group | SKIP | written to the promised contract, gated on #385 |
| account | SKIP | same defect through the shared `accountprivileges.ToMap`; #385 widened; whole-block omission issues no classic PUT and retains |
| mobile_device_enrollment_profile | PASS | whole-block omission retains; inside a kept block an always-emit leaf clears and an Optional+Computed leaf retains, both pinned |
| user_group | PASS | static `members`: omitted `<users>` retained, `[]` clears |

Full serial run against the EU test tenant on 2026-09-06, **Jamf Pro 11.31.1**: 12 PASS, 4 SKIP. Tenant swept clean afterwards. The version is recorded in each test file, not just here — the contract is version-scoped and a Pro upgrade is the trigger to rerun.

## Contract result

**An absent element is retained on every classic endpoint tested**, at every level: top-level blocks, `general` sub-blocks, scope through the granular merge, self_service categories, account_maintenance children. No server-side counterexample.

The one failure is the provider's, not the server's, and it sharpens the rule rather than breaking it. The contract is about **absent elements**, not about absent Terraform blocks: a **present** parent element replaces its subtree. `account_group` sends a partial `<privileges>` and the server wipes every undeclared category while Read hides the loss → #385. Any documentation of this contract has to state it in those terms.

## Follow-up work this run defined

The two defects below have to be fixed for the contract the tests assert to be true of the provider as well as of the server. Both are the same class: the provider sends a partial parent, or omits a leaf whose Read then asserts a value against a null plan.

- **#385 `account_group` / `account`** — partial `privileges` wipes undeclared categories. Fix is a GET-merge-PUT in `accountprivileges` once, for both resources: take the server's grid for a category the config does not declare, full-replace a category it does. Note the server injects dependency privileges into a declared category, so a declared category can never shrink below its injected set; that needs its own probe and a documentation line.
- **#384 (widened to the class)** — six classic resources with Optional-only scalars the builder omits and Read then echoes: `printer`, `network_segment`, `directory_binding`, `webhook`, `patch_external_source`, `account_group.ldap_server_id`. Fixing these by making the fields Required, or by always emitting them empty, would both contradict the contract this PR pins: the first removes the ability not to manage them, the second makes an omitted leaf *clear* while an omitted block *retains*, which is a level-dependent rule no documentation can state cleanly. The fix is to make omission mean retention here too — Optional+Computed, builder emits when non-null, Read prefers prior state — with an **explicit empty string to clear**, which is the same `omit = retain, explicit empty = clear` shape the collections already use. Probe per endpoint that an empty element does clear.

## `-> null` plan suppression: withdrawn

The proposed phase 2 (carry prior state for a null-in-config gated block, so the plan stays quiet) is not being pursued, for reasons this run produced:

- The rule is per nesting path, not per block, because a present parent replaces its subtree (#385). An allowlist would have to be wire-probed per path and re-probed per Jamf Pro release.
- Several attributes are held in state only by a prefer-prior-state read and are never echoed by the GET. Suppressing the plan turns an already-unverifiable state entry into a permanent unauditable claim of management.
- Four `policy` writes do not persist on 11.31.1. Suppression would hide the discrepancy rather than surface it.
- Failure mode if the documentation is wrong: a confused operator files an issue. Failure mode if suppression is wrong: silent data loss with no plan line.

#383 is being answered with documentation — a guide covering the co-management model and the per-family PUT mechanics, plus per-field notes only where a field departs from its family default — together with the two fixes above, and one narrowing of import hydration:

- **Do not adopt an empty section or collection on first hydration.** Most of the alarming plan in #383 is hydration writing nine empty `exclusions` lists, three empty `limitations` lists and six empty `targets` lists into state for a server object that has nothing in them. Declining to adopt a wire section with no content removes that noise without hiding anything, and the rule is already established in this repo for `device_group.members`. `vpp.remaining/total/used_vpp_licenses` are server counters in a managed block and should be Computed-only per the server-derived-echo rule.

Full hydration itself stays: #278 is the same reporter and the same resource asking for the opposite, state after import is supposed to describe the object, and `plan -generate-config-out` — which jamformer depends on, see #379 — can only emit a block that Read hydrated.

## Other findings recorded

- #384 `printer`: unset Optional strings can never converge (found while reproducing #383); since widened to the six-resource class above.
- **SDK**: `OsXConfigurationProfileScopeJssUserGroups.JssUserGroup` is tagged `xml:"jss_user_group"`; the server reads back `<user_group>`, so the category never decodes and the Update merge base sees zero target user groups and clears admin-owned ones. Fixed in jamfplatform-go-sdk#68 (one `propertyRenames` line); the provider is pinned at SDK v0.22.0 and picks it up on the next bump.
- **Never-echoed attributes held in state only by prefer-prior-state reads** (drift and non-persistence undetectable) — the general class is now #387 / PR #388; the mobile profile's two are #393: ebook, mobile_device_app, policy and both profiles' Self Service `notification_*`; mobile app `after_install_button_text`; patch_policy `user_interaction.notifications`; mobile profile `self_service_description` and `self_service.categories` (the latter can never work: every GET returns empty).
- **Policy writes that do not persist** (11.31.1) — filed as #394: `date_time_limitations.no_execute_start/end`, `network_limitations.minimum_network_connection=Ethernet`, `override_default_settings.force_afp_smb`, `printers.leave_existing_default`; and `network_limitations.network_segment_ids` is a server mirror of `scope.limitations.network_segment_ids`, not an independent field.
- macOS profile `flattenSelfService` hydrates categories ungated, so dropping `categories` while keeping `self_service` fails the consistency check even though the server retains them — filed as #392.

## Import shape differs per resource

`mobile_device_enrollment_profile` and `user_group` do **not** hydrate their gated blocks on a classic import (the `Raw.IsNull()` check is dead on the passthrough path), so they show the #278 shape after import (declared block planned as an add) rather than the #383 shape. Filed as #391 — the provider currently does both things depending on which resource you picked, and the documentation cannot describe import until that is one shape. (`account` turned out to be fine: it already carries an `importHydration` gate.) `is_purchased` and `is_leased` on the enrollment profile are mutually exclusive server-side with no plan-time validator.

## Test-design law learned

A fixture referenced only in step 1 loses its dependency edge in later steps, Terraform destroys it in parallel with the parent, and the server refuses (`422 HAS_DEPENDENCIES`) because it still holds the retained reference. Every test carries `depends_on` to its fixtures in all steps. That failure mode is itself proof of retention.

## Gates

`make fix fmt lint test` green. `golangci-lint --build-tags acceptance` on the touched packages: one pre-existing staticcheck hit in licensed_software (line 255, not from this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
