### PR TITLE
fix: emulate per-category privilege retention on account and account_group (#385)

### DIFF
--- a/internal/common/accountprivileges/accountprivileges.go
+++ b/internal/common/accountprivileges/accountprivileges.go
@@ -7,16 +7,21 @@
 // Jamf Pro administrator accounts and account groups carry a privilege grid
 // split into seven wire categories (jss_objects, jss_settings, jss_actions,
 // casper_admin, casper_remote, casper_imaging, recon), each a list of
-// free-text privilege strings. Two server behaviours make this grid awkward to
-// manage declaratively (both wire-probed 2026-06-12):
+// free-text privilege strings. Three server behaviours make this grid awkward
+// to manage declaratively (the first two wire-probed 2026-06-12, the third
+// 2026-09-06 on Jamf Pro 11.31.1):
 //
 //   - The server SILENTLY EXPANDS a submitted set, adding dependency
 //     privileges the caller did not request — sometimes in a different
-//     category (e.g. submitting jss_objects=["Update Buildings"] yields a
-//     stored jss_settings=["Read Activation Code"]). Re-submitting the same
-//     subset reproduces the same superset, stably.
+//     category (e.g. submitting jss_objects=["Read Buildings"] yields a stored
+//     jss_settings=["Read License Information"]). Re-submitting the same subset
+//     reproduces the same superset, stably.
 //   - The server SILENTLY DROPS an unrecognised privilege string, returning
 //     201/200 with the bad value simply absent — no error.
+//   - A sent <privileges> element REPLACES THE WHOLE GRID on both
+//     /accounts/groupid and /accounts/userid: every category absent from the
+//     body is emptied, while omitting the element leaves the grid untouched.
+//     There is no per-category merge on the wire (issue #385).
 //
 // To keep a correct configuration free of perpetual diffs we use
 // INTERSECT-ON-READ: refresh-Read stores, per category, only the intersection
@@ -29,6 +34,13 @@
 // after apply" abort. The plan-time Validator (discovering the tenant's catalog
 // from an Administrator account/group) is what keeps invalid privileges from
 // reaching apply in the first place.
+//
+// The user-facing contract for a category is the one the scope helper uses:
+// declared (including []) means Terraform owns it, omitted means it is left as
+// configured outside Terraform. Because the wire replaces the whole grid, the
+// second half is emulated with a read-merge-write: a write GETs the live grid,
+// overlays the declared categories via MergeGrid and sends every merged
+// category, so an undeclared category survives exactly as the server held it.
 package accountprivileges
 
 // Category describes one of the seven privilege buckets: its Jamf classic wire

--- a/internal/common/accountprivileges/accountprivileges_test.go
+++ b/internal/common/accountprivileges/accountprivileges_test.go
@@ -221,6 +221,91 @@ func TestModelToMap_OmitsNullCategories(t *testing.T) {
 	}
 }
 
+// TestMergeGrid_DeclaredReplacesUndeclaredCarried is the write-side contract
+// behind issue #385: a declared category wins over the live value, and a
+// category the configuration does not declare is carried from the live grid,
+// server-injected dependency privileges included, so the full-replace PUT cannot
+// empty it.
+func TestMergeGrid_DeclaredReplacesUndeclaredCarried(t *testing.T) {
+	declared := &Model{JamfProServerObjects: mustSet(t, "Read Buildings", "Read Departments")}
+	server := map[string][]string{
+		"jss_objects":  {"Read Computers"},
+		"jss_settings": {"Read License Information", "Read SMTP Server"},
+		"jss_actions":  {"Send Computer Remote Lock Command"},
+	}
+	got, diags := MergeGrid(context.Background(), declared, server)
+	if diags.HasError() {
+		t.Fatalf("diags: %v", diags)
+	}
+	want := map[string][]string{
+		"jss_objects":  {"Read Buildings", "Read Departments"},
+		"jss_settings": {"Read License Information", "Read SMTP Server"},
+		"jss_actions":  {"Send Computer Remote Lock Command"},
+	}
+	for k, w := range want {
+		g := got[k]
+		sort.Strings(g)
+		if !reflect.DeepEqual(g, w) {
+			t.Errorf("category %s: got %v want %v", k, g, w)
+		}
+	}
+	if len(got) != len(want) {
+		t.Errorf("merged grid has %d categories, want %d: %v", len(got), len(want), got)
+	}
+	if !reflect.DeepEqual(server["jss_objects"], []string{"Read Computers"}) {
+		t.Errorf("server grid mutated: %v", server["jss_objects"])
+	}
+}
+
+// TestMergeGrid_DeclaredEmptyClears keeps a declared [] as a present key with an
+// empty slice, so ToGroupPrivileges emits an empty element and the category is
+// cleared rather than carried from the live grid.
+func TestMergeGrid_DeclaredEmptyClears(t *testing.T) {
+	declared := &Model{JamfProServerActions: mustSet(t)}
+	server := map[string][]string{"jss_actions": {"Send Computer Remote Lock Command"}}
+	got, diags := MergeGrid(context.Background(), declared, server)
+	if diags.HasError() {
+		t.Fatalf("diags: %v", diags)
+	}
+	v, ok := got["jss_actions"]
+	if !ok {
+		t.Fatalf("declared empty category dropped from merged grid: %v", got)
+	}
+	if v == nil || len(v) != 0 {
+		t.Errorf("declared empty category should be a non-nil empty slice, got %#v", v)
+	}
+	if grid := ToGroupPrivileges(got); grid == nil || grid.JssActions == nil {
+		t.Errorf("empty category should still be emitted as an element: %+v", grid)
+	}
+}
+
+// TestMergeGrid_NilServer covers Create, where nothing exists yet: the merged
+// grid is exactly the declared categories.
+func TestMergeGrid_NilServer(t *testing.T) {
+	declared := &Model{Recon: mustSet(t, "Use Recon")}
+	got, diags := MergeGrid(context.Background(), declared, nil)
+	if diags.HasError() {
+		t.Fatalf("diags: %v", diags)
+	}
+	if !reflect.DeepEqual(got, map[string][]string{"recon": {"Use Recon"}}) {
+		t.Errorf("got %v", got)
+	}
+}
+
+// TestMergeGrid_NilDeclared returns a copy of the live grid when nothing is
+// declared, so a caller that does reach it with no configuration re-sends the
+// server's own grid rather than an empty one.
+func TestMergeGrid_NilDeclared(t *testing.T) {
+	server := map[string][]string{"casper_admin": {"Use Casper Admin"}}
+	got, diags := MergeGrid(context.Background(), nil, server)
+	if diags.HasError() {
+		t.Fatalf("diags: %v", diags)
+	}
+	if !reflect.DeepEqual(got, server) {
+		t.Errorf("got %v want %v", got, server)
+	}
+}
+
 // fakeDiscoverer serves a fixed account/group topology for Discover tests.
 type fakeDiscoverer struct {
 	groups map[int]*proclassic.Group

--- a/internal/common/accountprivileges/model.go
+++ b/internal/common/accountprivileges/model.go
@@ -14,8 +14,10 @@ import (
 
 // Model is the Terraform model for the privileges single-nested block. Each
 // field is a Set of privilege strings for one category. A nil/null Set means
-// the category is unmanaged by the configuration (omit-on-write, stays null on
-// read).
+// the category is unmanaged by the configuration: it stays null on read
+// (IntersectIntoState) and on write it is carried from the live server grid
+// rather than omitted (MergeGrid), because the classic endpoints replace the
+// whole grid on any sent <privileges> element.
 type Model struct {
 	JamfProServerObjects  types.Set `tfsdk:"jamf_pro_server_objects"`
 	JamfProServerSettings types.Set `tfsdk:"jamf_pro_server_settings"`
@@ -72,9 +74,11 @@ func declaredStrings(ctx context.Context, s types.Set) ([]string, diag.Diagnosti
 }
 
 // ToMap converts the declared (non-null) categories of a Model into a map keyed
-// by wire key. Null/unknown categories are omitted entirely so the caller can
-// honour omit-on-write semantics (the classic PUT merges, retaining categories
-// that are not sent).
+// by wire key. Null/unknown categories are omitted from the map. The result is
+// NOT a wire-ready grid: the classic /accounts endpoints replace the whole
+// privilege grid on any sent <privileges> element, so a partial map sent as-is
+// empties every category it does not name. Callers building a write go through
+// MergeGrid, which fills the undeclared categories from the live server grid.
 func (m *Model) ToMap(ctx context.Context) (map[string][]string, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	out := make(map[string][]string)
@@ -89,6 +93,48 @@ func (m *Model) ToMap(ctx context.Context) (map[string][]string, diag.Diagnostic
 			return nil, diags
 		}
 		out[c.WireKey] = vals
+	}
+	return out, diags
+}
+
+// MergeGrid builds the wire-ready privilege grid for a write: the live server
+// grid with every category the configuration declares replaced by the declared
+// value. It emulates, client-side, the per-category retention the classic API
+// does not provide. Wire-probed 2026-09-06 on Jamf Pro 11.31.1, through the SDK,
+// on both PUT /accounts/groupid/{id} and PUT /accounts/userid/{id}: a sent
+// <privileges> element replaces the entire grid, so every category absent from
+// the body is emptied on the server (jss_settings kept only the server-injected
+// "Read License Information"; jss_actions was cleared) while omitting the
+// element altogether leaves the grid untouched (issue #385). Read hides that
+// loss, because IntersectIntoState treats a null category as unmanaged and never
+// refreshes it, which made the wipe invisible to a plan.
+//
+// The merge is category-granular, the same shape as the shared scope helper's
+// per-category ownership (STYLE_GUIDE §Scope helper): a declared category,
+// including a declared empty set, wins over the server value and an empty set
+// is kept as a present key so it marshals as an empty element and clears the
+// category; an undeclared category is carried from server verbatim, including
+// any dependency privileges the server injected, which the server would
+// re-inject anyway and which Read's intersect already keeps out of state. A nil
+// server grid (Create, before anything exists) yields just the declared
+// categories. server is never mutated.
+func MergeGrid(ctx context.Context, declared *Model, server map[string][]string) (map[string][]string, diag.Diagnostics) {
+	out := make(map[string][]string, len(Categories))
+	for k, v := range server {
+		out[k] = append([]string(nil), v...)
+	}
+	if declared == nil {
+		return out, nil
+	}
+	declaredMap, diags := declared.ToMap(ctx)
+	if diags.HasError() {
+		return nil, diags
+	}
+	for k, v := range declaredMap {
+		if v == nil {
+			v = []string{}
+		}
+		out[k] = v
 	}
 	return out, diags
 }

--- a/internal/common/accountprivileges/sdk.go
+++ b/internal/common/accountprivileges/sdk.go
@@ -89,9 +89,12 @@ func FromGroupPrivileges(p *proclassic.GroupPrivileges) map[string][]string {
 }
 
 // ToAccountPrivileges builds an SDK account privilege grid from a wire-keyed
-// map. Only categories present in the map are emitted (omit-on-write); a
-// category present with an empty slice is emitted as an empty element, which
-// the classic endpoint treats as "clear this category".
+// map. Only categories present in the map are emitted, and a category present
+// with an empty slice is emitted as an empty element. Because the classic
+// endpoint replaces the whole grid on any sent <privileges> (see MergeGrid), an
+// absent category and an empty one both end up cleared on the server; the map
+// must therefore already be the full merged grid, not just the declared
+// categories.
 func ToAccountPrivileges(m map[string][]string) *proclassic.AccountPrivileges {
 	if len(m) == 0 {
 		return nil
@@ -121,7 +124,8 @@ func ToAccountPrivileges(m map[string][]string) *proclassic.AccountPrivileges {
 	return out
 }
 
-// ToGroupPrivileges builds an SDK group privilege grid from a wire-keyed map.
+// ToGroupPrivileges builds an SDK group privilege grid from a wire-keyed map,
+// with the same full-grid expectation as ToAccountPrivileges.
 func ToGroupPrivileges(m map[string][]string) *proclassic.GroupPrivileges {
 	if len(m) == 0 {
 		return nil

--- a/internal/resources/pro/account/crud.go
+++ b/internal/resources/pro/account/crud.go
@@ -7,11 +7,11 @@
 //   pro.UpdateAccountV1               (PUT base fields)
 //   pro.DeleteAccountV1
 //   pro.ResolveAccountV1IDByName      (data source username lookup)
-//   proclassic.GetAccountByUserID     (Custom privilege grid read)
-//   proclassic.UpdateAccountByUserID  (Custom privilege grid write — merge)
+//   proclassic.GetAccountByUserID     (Custom privilege grid read; live grid before every privilege write)
+//   proclassic.UpdateAccountByUserID  (Custom privilege grid write; a sent <privileges> replaces the whole grid — merged client-side)
 //   proclassic.ListAccounts           (privilege-catalog discovery, ModifyPlan)
 //
-// Status: current. Last reviewed 2026-06-24.
+// Status: current. Last reviewed 2026-09-06.
 
 package account
 
@@ -19,6 +19,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -28,9 +29,11 @@ import (
 )
 
 // Create creates a Jamf Pro admin account via the Pro API, then (for a Custom +
-// Full Access account) writes the privilege grid via the classic API. If the
-// classic step fails, the just-created account is deleted so no half-built
-// account is left behind. Privileges are trusted from the plan (not re-read).
+// Full Access account) writes the privilege grid via the classic API through
+// writeCustomPrivileges, which merges against whatever grid the new account
+// already carries. If the classic step fails, the just-created account is
+// deleted so no half-built account is left behind. Privileges are trusted from
+// the plan (not re-read).
 func (r *AccountResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var plan, cfg AccountResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
@@ -60,21 +63,15 @@ func (r *AccountResource) Create(ctx context.Context, req resource.CreateRequest
 	id := plan.ID.ValueString()
 
 	if custPrivApplicable(plan.PrivilegeSet, plan.AccessLevel) {
-		classicInput, d := buildClassicPrivileges(createCtx, plan)
-		resp.Diagnostics.Append(d...)
-		if resp.Diagnostics.HasError() {
+		d := r.writeCustomPrivileges(createCtx, id, plan, "Error writing Jamf Pro account privileges")
+		if d.HasError() {
+			if delErr := r.proClient.DeleteAccountV1(createCtx, id); delErr != nil {
+				tflog.Error(ctx, "failed to roll back account after privilege write failure", map[string]any{"id": id, "delete_error": delErr.Error()})
+			}
+			resp.Diagnostics.Append(d...)
 			return
 		}
-		if classicInput != nil {
-			if err := r.classicClient.UpdateAccountByUserID(createCtx, id, classicInput); err != nil {
-				// Roll back the account so we do not leave a privilege-less husk.
-				if delErr := r.proClient.DeleteAccountV1(createCtx, id); delErr != nil {
-					tflog.Error(ctx, "failed to roll back account after privilege write failure", map[string]any{"id": id, "delete_error": delErr.Error()})
-				}
-				resp.Diagnostics.AddError("Error writing Jamf Pro account privileges", err.Error())
-				return
-			}
-		}
+		resp.Diagnostics.Append(d...)
 	}
 
 	got, err := r.proClient.GetAccountV1(createCtx, id)
@@ -182,9 +179,9 @@ func (r *AccountResource) Read(ctx context.Context, req resource.ReadRequest, re
 }
 
 // Update applies base-field changes via Pro PUT and Custom privilege changes via
-// the classic API. Each side is called only when its inputs actually changed, so
-// a privilege-only edit skips the Pro PUT and a base-only edit skips the classic
-// write.
+// the classic API through writeCustomPrivileges. Each side is called only when
+// it has something to send, so a privilege-only edit skips the Pro PUT and a
+// plan with no declared privilege category skips the classic write.
 func (r *AccountResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	var plan, state, cfg AccountResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
@@ -217,16 +214,9 @@ func (r *AccountResource) Update(ctx context.Context, req resource.UpdateRequest
 	}
 
 	if custPrivApplicable(plan.PrivilegeSet, plan.AccessLevel) {
-		classicInput, d := buildClassicPrivileges(updateCtx, plan)
-		resp.Diagnostics.Append(d...)
+		resp.Diagnostics.Append(r.writeCustomPrivileges(updateCtx, id, plan, "Error updating Jamf Pro account privileges")...)
 		if resp.Diagnostics.HasError() {
 			return
-		}
-		if classicInput != nil {
-			if err := r.classicClient.UpdateAccountByUserID(updateCtx, id, classicInput); err != nil {
-				resp.Diagnostics.AddError("Error updating Jamf Pro account privileges", err.Error())
-				return
-			}
 		}
 	}
 
@@ -272,6 +262,37 @@ func (r *AccountResource) Delete(ctx context.Context, req resource.DeleteRequest
 		}
 		resp.Diagnostics.AddError("Error deleting Jamf Pro account", fmt.Sprintf("API error: %v", err))
 	}
+}
+
+// writeCustomPrivileges sends the Custom privilege grid for account id through
+// the classic API as a read-merge-write: the live grid is read first and every
+// category the plan declares replaces the server's, while undeclared categories
+// are re-sent as the server holds them. That is what makes "omit a category and
+// the server keeps it" true — the endpoint replaces the whole grid on any sent
+// <privileges> (wire-probed 2026-09-06, Jamf Pro 11.31.1, issue #385), so a
+// partial body would empty the rest. Nothing is sent, and nothing read, when the
+// plan declares no category at all; the server then keeps its grid untouched.
+// errSummary is the diagnostic summary for a failed write, so Create and Update
+// read distinctly in the output.
+func (r *AccountResource) writeCustomPrivileges(ctx context.Context, id string, plan AccountResourceModel, errSummary string) diag.Diagnostics {
+	var diags diag.Diagnostics
+	if !managesPrivileges(plan) {
+		return diags
+	}
+	live, err := r.classicClient.GetAccountByUserID(ctx, id)
+	if err != nil {
+		diags.AddError("Error reading Jamf Pro account privileges before write", err.Error())
+		return diags
+	}
+	classicInput, d := buildClassicPrivileges(ctx, plan, live)
+	diags.Append(d...)
+	if diags.HasError() || classicInput == nil {
+		return diags
+	}
+	if err := r.classicClient.UpdateAccountByUserID(ctx, id, classicInput); err != nil {
+		diags.AddError(errSummary, err.Error())
+	}
+	return diags
 }
 
 // baseFieldsChanged reports whether any Pro-owned base field differs between

--- a/internal/resources/pro/account/input_builders.go
+++ b/internal/resources/pro/account/input_builders.go
@@ -84,22 +84,38 @@ func boolOrDefault(v types.Bool, def bool) *bool {
 }
 
 // buildClassicPrivileges projects the Custom privilege grid into a ProClassic
-// Account payload carrying only <privileges>. The classic PUT merges, so other
-// account fields are intentionally omitted (they are owned by the Pro side).
+// Account payload carrying only <privileges>. The classic PUT merges at the top
+// level, so other account fields are intentionally omitted (they are owned by
+// the Pro side). Inside <privileges> it does not merge: a sent element replaces
+// the whole grid (wire-probed 2026-09-06, Jamf Pro 11.31.1, issue #385), so the
+// grid is built by accountprivileges.MergeGrid from live, the account as the
+// classic endpoint currently returns it, replacing only the declared categories
+// and carrying the rest verbatim. live may be nil when nothing has been read.
 // Returns nil when there are no privileges to send.
-func buildClassicPrivileges(ctx context.Context, plan AccountResourceModel) (*proclassic.Account, diag.Diagnostics) {
+func buildClassicPrivileges(ctx context.Context, plan AccountResourceModel, live *proclassic.Account) (*proclassic.Account, diag.Diagnostics) {
 	var diags diag.Diagnostics
-	if plan.Privileges == nil || plan.Privileges.IsEmpty() {
+	if !managesPrivileges(plan) {
 		return nil, diags
 	}
-	privMap, d := plan.Privileges.ToMap(ctx)
+	var serverGrid map[string][]string
+	if live != nil {
+		serverGrid = accountprivileges.FromAccountPrivileges(live.Privileges)
+	}
+	merged, d := accountprivileges.MergeGrid(ctx, plan.Privileges, serverGrid)
 	diags.Append(d...)
 	if diags.HasError() {
 		return nil, diags
 	}
-	grid := accountprivileges.ToAccountPrivileges(privMap)
+	grid := accountprivileges.ToAccountPrivileges(merged)
 	if grid == nil {
 		return nil, diags
 	}
 	return &proclassic.Account{Privileges: grid}, diags
+}
+
+// managesPrivileges reports whether the plan declares at least one privilege
+// category. When false no classic write is issued and the server keeps its
+// grid, which is the one retention the wire does provide.
+func managesPrivileges(plan AccountResourceModel) bool {
+	return plan.Privileges != nil && !plan.Privileges.IsEmpty()
 }

--- a/internal/resources/pro/account/resource_acceptance_test.go
+++ b/internal/resources/pro/account/resource_acceptance_test.go
@@ -367,31 +367,22 @@ func accountRetainedOnServer(t *testing.T) resource.TestCheckFunc {
 // Pro side sees no base-field change. Each step's implicit post-apply plan must
 // be empty, which is what makes the contract usable.
 //
-// Step 2 fails today, and the failure is the resource's, not the server's: it
-// builds the <privileges> element through the same accountprivileges.ToMap
-// per-category omission as jamfplatform_pro_account_group, and the server
-// treats a sent <privileges> as a whole-grid replace, so the two undeclared
-// categories are emptied while Read's null-means-unmanaged gate hides the loss
-// (issue #385). Wire-probed 2026-09-06 on Jamf Pro 11.31.1 through the SDK: a
-// PUT /accounts/userid/{id} carrying only <jss_objects> left jss_settings as
-// the server-injected "Read License Information" alone and jss_actions empty.
-// The whole-block omission in step 3 retains correctly, verified by running
-// the steps in the order full, header-only, objects-only: the header-only step
-// issued no classic PUT, the post-apply plan was empty and every step-1 value
-// survived. The test stays written as the contract the resource claims, and
-// skips until #385 is fixed, so that the fix is proven by deleting the skip
-// rather than by rewriting the assertion.
-// skipUntilPrivilegeCategoryMergeIsFixed gates the omit-retains test on issue
-// #385. Delete this function, and the call to it, when the resource either
-// emulates the category-level retention it promises or stops promising it.
-func skipUntilPrivilegeCategoryMergeIsFixed(t *testing.T) {
-	t.Helper()
-	t.Skip("jamfplatform_pro_account sends a partial <privileges> that the server treats as a full replace, wiping undeclared categories; see issue #385")
-}
-
+// Step 2 is the step the wire cannot satisfy on its own. Wire-probed 2026-09-06
+// on Jamf Pro 11.31.1 through the SDK: a PUT /accounts/userid/{id} carrying only
+// <jss_objects> left jss_settings as the server-injected "Read License
+// Information" alone and jss_actions empty — the server treats a sent
+// <privileges> as a whole-grid replace, and Read's null-means-unmanaged gate
+// hid the loss (issue #385). The resource now emulates the retention it
+// documents — every privilege write reads the live grid first and re-emits the
+// undeclared categories through accountprivileges.MergeGrid — and this step is
+// the proof: the server-side check after step 2 must still find "Read SMTP
+// Server" and the remote-lock action that only the carry-over could have sent.
+// The whole-block omission in step 3 retains on the wire itself, verified by
+// running the steps in the order full, header-only, objects-only: the
+// header-only step issued no classic PUT, the post-apply plan was empty and
+// every step-1 value survived.
 func TestAccResource_ProAccount_OmittedBlocksRetained(t *testing.T) {
 	testhelpers.AccPreCheck(t)
-	skipUntilPrivilegeCategoryMergeIsFixed(t)
 	suffix := testhelpers.RunSuffix()
 
 	resource.Test(t, resource.TestCase{

--- a/internal/resources/pro/account_group/crud.go
+++ b/internal/resources/pro/account_group/crud.go
@@ -4,13 +4,13 @@
 // SDK endpoints used (Pro v1 /account-groups is read-only AND gateway-blocked,
 // so every surface — resource, data source, list — goes through ProClassic):
 //   proclassic.CreateAccountGroupByID   (POST id="0")
-//   proclassic.GetAccountGroupByID      (read; data source id lookup; list expand)
+//   proclassic.GetAccountGroupByID      (read; data source id lookup; list expand; live grid before an Update that sends <privileges>)
 //   proclassic.GetAccountGroupByName    (data source name lookup)
-//   proclassic.UpdateAccountGroupByID   (PUT, 201 empty body)
+//   proclassic.UpdateAccountGroupByID   (PUT, 201 empty body; a sent <privileges> replaces the whole grid — merged client-side)
 //   proclassic.DeleteAccountGroupByID
 //   proclassic.ListAccounts             (list-resource enumeration; privilege-catalog discovery in ModifyPlan)
 //
-// Status: current. Last reviewed 2026-06-24.
+// Status: current. Last reviewed 2026-09-06.
 
 package account_group
 
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/proclassic"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
@@ -42,7 +43,7 @@ func (r *AccountGroupResource) Create(ctx context.Context, req resource.CreateRe
 	createCtx, cancel := context.WithTimeout(ctx, createTimeout)
 	defer cancel()
 
-	input, diags := buildAccountGroupInput(createCtx, plan)
+	input, diags := buildAccountGroupInput(createCtx, plan, nil)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -161,9 +162,14 @@ func (r *AccountGroupResource) Read(ctx context.Context, req resource.ReadReques
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
-// Update updates a Jamf Pro account group. UpdateAccountGroupByID returns 201
-// with an empty body — GET to refresh server-derived base fields; privileges
-// and members are trusted from the plan.
+// Update updates a Jamf Pro account group. When the plan declares privileges
+// the live group is read first and the PUT carries the full grid merged by
+// accountprivileges.MergeGrid — the classic endpoint replaces the whole grid on
+// any sent <privileges>, so undeclared categories must be re-emitted from the
+// server to survive (issue #385). The merged grid is wire-only; state is set
+// from the plan, which keeps only the declared categories. UpdateAccountGroupByID
+// returns 201 with an empty body — GET to refresh server-derived base fields;
+// privileges and members are trusted from the plan.
 func (r *AccountGroupResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	var plan AccountGroupResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
@@ -179,7 +185,17 @@ func (r *AccountGroupResource) Update(ctx context.Context, req resource.UpdateRe
 	updateCtx, cancel := context.WithTimeout(ctx, updateTimeout)
 	defer cancel()
 
-	input, diags := buildAccountGroupInput(updateCtx, plan)
+	var live *proclassic.Group
+	if managesPrivileges(plan) {
+		current, err := r.client.GetAccountGroupByID(updateCtx, plan.ID.ValueString())
+		if err != nil {
+			resp.Diagnostics.AddError("Error reading Jamf Pro account group before update", err.Error())
+			return
+		}
+		live = current
+	}
+
+	input, diags := buildAccountGroupInput(updateCtx, plan, live)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/resources/pro/account_group/input_builders.go
+++ b/internal/resources/pro/account_group/input_builders.go
@@ -14,12 +14,17 @@ import (
 )
 
 // buildAccountGroupInput converts the Terraform plan into an SDK Group payload.
-// The classic /accounts/groupid PUT is a category-level merge: fields and
-// privilege categories that are not sent are retained, so null members /
-// null privilege categories are omitted (retained) and an explicitly empty
-// members set clears membership. Privileges are only emitted when the privilege
-// set is Custom (Jamf Pro ignores them otherwise).
-func buildAccountGroupInput(ctx context.Context, plan AccountGroupResourceModel) (*proclassic.Group, diag.Diagnostics) {
+// The classic /accounts/groupid PUT merges at the top level only: an element
+// that is not sent is retained, so null members are omitted (retained) and an
+// explicitly empty members set clears membership. Inside <privileges> there is
+// no merge — a sent element replaces the whole grid (wire-probed 2026-09-06,
+// Jamf Pro 11.31.1, issue #385) — so when the plan declares privileges the grid
+// is built by accountprivileges.MergeGrid from the live group's grid, replacing
+// only the declared categories and carrying the rest verbatim. live is the
+// group as the server currently holds it and may be nil on Create, where nothing
+// exists to carry. Privileges are only emitted when the privilege set is Custom
+// (Jamf Pro ignores them otherwise).
+func buildAccountGroupInput(ctx context.Context, plan AccountGroupResourceModel, live *proclassic.Group) (*proclassic.Group, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
 	group := &proclassic.Group{
@@ -51,15 +56,26 @@ func buildAccountGroupInput(ctx context.Context, plan AccountGroupResourceModel)
 		group.Members = &proclassic.GroupMembers{User: &users}
 	}
 
-	// Privileges: only when Custom and the block is present with content.
-	if plan.PrivilegeSet.ValueString() == proclassic.GroupPrivilegeSetCustom && plan.Privileges != nil && !plan.Privileges.IsEmpty() {
-		privMap, d := plan.Privileges.ToMap(ctx)
+	if managesPrivileges(plan) {
+		var serverGrid map[string][]string
+		if live != nil {
+			serverGrid = accountprivileges.FromGroupPrivileges(live.Privileges)
+		}
+		merged, d := accountprivileges.MergeGrid(ctx, plan.Privileges, serverGrid)
 		diags.Append(d...)
 		if diags.HasError() {
 			return nil, diags
 		}
-		group.Privileges = accountprivileges.ToGroupPrivileges(privMap)
+		group.Privileges = accountprivileges.ToGroupPrivileges(merged)
 	}
 
 	return group, diags
+}
+
+// managesPrivileges reports whether the plan will send a <privileges> element:
+// the group is Custom and the block is present with at least one declared
+// category. When false the element is omitted and the server keeps its grid,
+// which is the one retention the wire does provide.
+func managesPrivileges(plan AccountGroupResourceModel) bool {
+	return plan.PrivilegeSet.ValueString() == proclassic.GroupPrivilegeSetCustom && plan.Privileges != nil && !plan.Privileges.IsEmpty()
 }

--- a/internal/resources/pro/account_group/resource_acceptance_test.go
+++ b/internal/resources/pro/account_group/resource_acceptance_test.go
@@ -379,25 +379,17 @@ func accountGroupRetainedOnServer(t *testing.T) resource.TestCheckFunc {
 // the header alone. Each step's implicit post-apply plan must be empty, which
 // is what makes the contract usable.
 //
-// Step 2 fails today, and the failure is the resource's, not the server's:
-// wire-probed 2026-09-06 on Jamf Pro 11.31.1, a sent <privileges> replaces the
-// whole grid, so the two undeclared categories are emptied while Read's
-// null-means-unmanaged gate hides the loss (issue #385). The whole-block
-// omission in step 3 and the members omission both retain correctly. The test
-// stays written as the contract the resource claims, and skips until #385 is
-// fixed, so that the fix is proven by deleting the skip rather than by
-// rewriting the assertion.
-// skipUntilPrivilegeCategoryMergeIsFixed gates the omit-retains test on issue
-// #385. Delete this function, and the call to it, when the resource either
-// emulates the category-level retention it promises or stops promising it.
-func skipUntilPrivilegeCategoryMergeIsFixed(t *testing.T) {
-	t.Helper()
-	t.Skip("jamfplatform_pro_account_group sends a partial <privileges> that the server treats as a full replace, wiping undeclared categories; see issue #385")
-}
-
+// Step 2 is the step the wire cannot satisfy on its own: probed 2026-09-06 on
+// Jamf Pro 11.31.1, a sent <privileges> replaces the whole grid, so a partial
+// body empties the two undeclared categories while Read's null-means-unmanaged
+// gate hides the loss (issue #385). The resource now emulates the retention it
+// documents — Update reads the live grid and re-emits the undeclared categories
+// through accountprivileges.MergeGrid — and this step is the proof: the
+// server-side check after step 2 must still find "Read SMTP Server" and the
+// remote-lock action that only the carry-over could have sent. The whole-block
+// omission in step 3 and the members omission retain on the wire itself.
 func TestAccResource_ProAccountGroup_OmittedBlocksRetained(t *testing.T) {
 	testhelpers.AccPreCheck(t)
-	skipUntilPrivilegeCategoryMergeIsFixed(t)
 	suffix := testhelpers.RunSuffix()
 	name := "tf-acc-account-group-omit-" + suffix
 


### PR DESCRIPTION
Fixes #385.

## What

A sent `<privileges>` element **replaces the whole privilege grid** on both `PUT /accounts/groupid/{id}` and `PUT /accounts/userid/{id}` — every category absent from the body is emptied. Omitting the element entirely leaves the grid untouched. There is no per-category merge on the wire (wire-probed 2026-09-06, Jamf Pro 11.31.1).

Both resources documented the opposite. `accountprivileges.ToMap` drops null categories so the classic PUT could "merge" them, so an apply that declared two of three categories silently wiped the third — and `IntersectIntoState`'s null-means-unmanaged read hid the loss, so no plan ever showed it.

## Fix

Keep the documented contract and make it true client-side. `accountprivileges.MergeGrid` takes the live grid and the declared model, replaces each declared category (a declared `[]` stays present, so it still clears), and carries every undeclared category verbatim — server-injected dependency privileges included. Both resources now GET the live object before any write that sends `<privileges>`:

- `account_group` in `Update` (Create has nothing to carry)
- `account` in Create and Update, via a new `writeCustomPrivileges`

State is still set from the plan, and Read's intersect semantics are unchanged, so the declared-only view of the grid is what Terraform tracks.

Nothing is read and nothing is sent when the plan declares no category at all (`managesPrivileges`) — the server then keeps its grid, which is the one retention the wire does provide.

## Test evidence

Acceptance, serial, against the EU test tenant on 2026-09-06 (Jamf Pro 11.31.1), rebased onto `test/classic-omit-retains-contract`:

```
ok  internal/resources/pro/account        42.240s
ok  internal/resources/pro/account_group  31.151s
45 PASS, 0 FAIL, 0 SKIP
```

That includes the two tests this PR un-skips — the #385 gates come off:

```
--- PASS: TestAccResource_ProAccount_OmittedBlocksRetained       (10.04s)
--- PASS: TestAccResource_ProAccountGroup_OmittedBlocksRetained  (13.52s)
```

Four new unit tests pin `MergeGrid`: declared replaces / undeclared carried (including the server-injected `Read License Information`), declared `[]` stays present and clears, nil server grid (Create), nil declared model. `golangci-lint` clean on all three packages.

## Review notes

- **Read-modify-write carries an inherent TOCTOU.** A UI change to an *undeclared* category between the pre-write GET and the PUT is lost. Unavoidable without an ETag on these endpoints, and strictly better than today, where the same category is wiped unconditionally. Not addressed here.
- **A failed pre-write GET aborts the write** with a named diagnostic rather than falling back to a partial body, which would reintroduce the wipe.
- On Create for `account`, the merge base is the grid the Pro create already assigned, so server defaults are carried rather than cleared. That is the contract, but it is worth a reviewer's eye.

## Merge order

This PR is **third** in a four-PR chain. It is based on `test/classic-omit-retains-contract`, not `main`, because it edits acceptance tests that only exist there.

1. **#381** — `fix/singleton-identity-import` (root of the stack)
2. **#386** — `test/classic-omit-retains-contract` (the omit-retains contract tests; this PR un-skips two of them)
3. **this PR** (issue #385)
4. **#390** (issue #384) — `fix/384-classic-always-emit-scalars`, which must be rebased onto this branch before it merges: it touches `pro/account_group/{crud,input_builders,resource_acceptance_test}.go` too, and this PR changes `buildAccountGroupInput`'s signature.

Note stacked PRs get no integration CI here (`integration-tests.yml` is main-only), so the acceptance run above is the evidence, not a green check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
