### PR TITLE
test(pro): order the vpp omit-retains teardown so it stops leaking a user group

### DIFF
--- a/internal/resources/pro/vpp_assignment/resource_acceptance_test.go
+++ b/internal/resources/pro/vpp_assignment/resource_acceptance_test.go
@@ -459,6 +459,8 @@ resource "jamfplatform_pro_vpp_assignment" "test" {
       jss_user_group_ids = [jamfplatform_pro_user_group.b.id]
     }
   }
+
+  depends_on = [jamfplatform_pro_user_group.a, jamfplatform_pro_user_group.b]
 }
 `, name)
 }
@@ -483,6 +485,8 @@ resource "jamfplatform_pro_vpp_assignment" "test" {
       jss_user_group_ids = [jamfplatform_pro_user_group.a.id]
     }
   }
+
+  depends_on = [jamfplatform_pro_user_group.a, jamfplatform_pro_user_group.b]
 }
 `, name)
 }
@@ -494,12 +498,22 @@ func vppaOmitRetainsGeneralOnlyConfig(token, suffix, name string) string {
 resource "jamfplatform_pro_vpp_assignment" "test" {
   name                 = %[1]q
   vpp_admin_account_id = jamfplatform_pro_volume_purchasing_location.vpp.id
+
+  depends_on = [jamfplatform_pro_user_group.a, jamfplatform_pro_user_group.b]
 }
 `, name)
 }
 
 // vppaOmitRetainsFixtures is the location + two static user groups every
 // omit-retains step shares.
+//
+// Every omit-retains step's assignment carries an explicit depends_on over both
+// groups, for the reason in vpp_invitation's copy of this fixture: the
+// interpolations that would imply the ordering are what the later steps drop,
+// the server goes on scoping the assignment to a group the configuration no
+// longer mentions, and a group destroyed before it is refused with "The
+// following items are dependent on this Static User Group". depends_on is
+// ordering metadata only and reaches no payload.
 func vppaOmitRetainsFixtures(token, suffix, name string) string {
 	return vppLocationFixture(token, suffix) + fmt.Sprintf(`
 resource "jamfplatform_pro_user_group" "a" {

--- a/internal/resources/pro/vpp_invitation/resource_acceptance_test.go
+++ b/internal/resources/pro/vpp_invitation/resource_acceptance_test.go
@@ -449,6 +449,8 @@ resource "jamfplatform_pro_vpp_invitation" "test" {
       jss_user_group_ids = [jamfplatform_pro_user_group.b.id]
     }
   }
+
+  depends_on = [jamfplatform_pro_user_group.a, jamfplatform_pro_user_group.b]
 }
 `, name)
 }
@@ -468,6 +470,8 @@ resource "jamfplatform_pro_vpp_invitation" "test" {
       jss_user_group_ids = [jamfplatform_pro_user_group.a.id]
     }
   }
+
+  depends_on = [jamfplatform_pro_user_group.a, jamfplatform_pro_user_group.b]
 }
 `, name)
 }
@@ -481,12 +485,24 @@ resource "jamfplatform_pro_vpp_invitation" "test" {
   vpp_account_id              = jamfplatform_pro_volume_purchasing_location.vpp.id
   distribution_method         = "Prompt users to accept/make available in Self Service"
   auto_register_managed_users = true
+
+  depends_on = [jamfplatform_pro_user_group.a, jamfplatform_pro_user_group.b]
 }
 `, name)
 }
 
 // vppiOmitRetainsFixtures is the location + two static user groups every
 // omit-retains step shares.
+//
+// Every omit-retains step's invitation carries an explicit depends_on over both
+// groups. The interpolations that would imply the ordering are exactly what the
+// later steps drop, and the retention this test exists to prove is what makes
+// that fatal: the server keeps scoping the invitation to a group the
+// configuration no longer mentions, so Terraform sees no edge, destroys the
+// group first, and Jamf Pro refuses it with "The following items are dependent
+// on this Static User Group" (USERS_VPP_INVITATIONS). The run then fails in
+// CheckDestroy having leaked the group. depends_on is ordering metadata only
+// and reaches no payload, so it cannot weaken what the steps assert.
 func vppiOmitRetainsFixtures(token, suffix, name string) string {
 	return vppLocationFixture(token, suffix) + fmt.Sprintf(`
 resource "jamfplatform_pro_user_group" "a" {


### PR DESCRIPTION
## What

`TestAccResource_ProVPPInvitation_OmittedBlocksRetained` and its `vpp_assignment` twin both fail in `CheckDestroy`, leaking the static user group they create:

```
Error deleting Jamf Pro user group
DeleteUserGroupByID(984): 400 — The following items are dependent on this
Static User Group and need to be updated: USERS_VPP_INVITATIONS
```

## Why

The test's own contract defeats its teardown.

Its later steps drop the scope from configuration — that is the thing under test. Dropping it also removes the interpolations Terraform was taking its dependency edges from. And the retention the test exists to prove is exactly what makes that fatal: the server goes on scoping the object to a group the configuration no longer mentions. With no edge left, Terraform destroys the group first, and Jamf Pro refuses.

So the failure is not a provider defect and not a wrong value. It is a missing ordering constraint in the fixture, on a path where the usual implicit one cannot exist.

## Fix

Every omit-retains step names both groups in an explicit `depends_on`. It goes on all three steps rather than only the last, so the ordering survives a step being added later or a run stopping part way. `depends_on` is ordering metadata and reaches no payload, so it cannot weaken what the steps assert.

## Neither test had ever run

Both are gated on `JAMFPLATFORM_ACC_PRO_VPP_TOKEN`, and no CI lane supplies one — `vpp_invitation/crud.go` says as much in a comment ("no VPP token on the test estate"). This surfaced only because I ran them against a tenant that has one while resolving the #390 merge conflict.

Confirmed pre-existing rather than introduced: the same test fails identically on `a8a7d9a9` (plain `main`), with the same dependency error and only the group id differing.

That the tests are unrun is the more interesting finding, and it is worth a follow-up: the `pro` lane's `require` token cannot make these fail loudly the way `JAMFPLATFORM_ACC_REQUIRE` does for a whole credential set, so 20-odd VPP acceptance tests currently self-skip green.

## Verification

Run against a tenant with a VPP token:

| test | before | after |
|---|---|---|
| `TestAccResource_ProVPPInvitation_OmittedBlocksRetained` | FAIL (leaked group 984) | **PASS** 25.8s |
| `TestAccResource_ProVPPAssignment_OmittedBlocksRetained` | never executed | **PASS** 55.1s |

2 passed, 0 failed, 0 skipped, and both destroyed without leaking. The groups leaked by the failing runs were cleaned off the estate by hand.

`make fmt lint test` green, `go vet -tags acceptance ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)