### PR TITLE
chore(deps): SDK v0.22.1, and fix the two macOS profile defects it exposed

### DIFF
--- a/docs/resources/pro_macos_configuration_profile.md
+++ b/docs/resources/pro_macos_configuration_profile.md
@@ -230,11 +230,13 @@ Optional:
 Optional:
 
 - `categories` (Attributes List) Categories under which the profile appears in Self Service. Each entry pairs a category ID with `display_in` / `feature_in` toggles matching the Self Service "Display in" / "Feature in" columns of the admin UI. (see [below for nested schema](#nestedatt--self_service--categories))
-- `display_notifications` (Boolean) Whether Self Service surfaces a notification when the profile becomes available. Pair with `notification_location` to set the delivery target.
+- `display_notifications` (Boolean) Whether Self Service surfaces a notification when the profile becomes available. See `notification_location` for the one pairing Jamf Pro cannot store.
 - `ensure_users_view_description` (Boolean) Force users to view the description before installing.
 - `feature_on_main_page` (Boolean) Feature the profile on the Self Service main page.
 - `install_button_text` (String) Install-button label. Defaults to `Install`.
-- `notification_location` (String) Notification delivery location. Valid values: `Self Service`, `Self Service and Notification Center`.
+- `notification_location` (String) Where Self Service surfaces the notification. `Self Service` or `Self Service and Notification Center`.
+
+Jamf Pro stores this and `display_notifications` in one field, and setting either resets the other, so `Self Service and Notification Center` cannot be combined with `display_notifications = true` and is refused at plan time. To have both, set them under Self Service ▸ Notification in the Jamf Pro admin UI and leave both attributes out of the configuration; Terraform reads the pairing back and preserves it.
 - `notification_message` (String) Notification body text. Displays in Self Service only.
 - `notification_subject` (String) Notification subject line.
 - `removal_disallowed` (String) Removal-by-end-user policy for the Self Service profile. Valid values: `Never`, `Always`, `With Authorization`. `With Authorization` also needs an authorization password, which this resource does not yet expose. Open an issue if you need it.

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Jamf-Concepts/terraform-provider-jamfplatform
 go 1.26.6
 
 require (
-	github.com/Jamf-Concepts/jamfplatform-go-sdk v0.22.0
+	github.com/Jamf-Concepts/jamfplatform-go-sdk v0.22.1
 	github.com/hashicorp/terraform-plugin-framework v1.19.0
 	github.com/hashicorp/terraform-plugin-framework-timeouts v0.7.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.19.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
 dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
-github.com/Jamf-Concepts/jamfplatform-go-sdk v0.22.0 h1:0QSF5fqDMoQjwkv+aO4lMGeQjq17FZ6ni4hJGzrxP/k=
-github.com/Jamf-Concepts/jamfplatform-go-sdk v0.22.0/go.mod h1:gUL5YSSzFcEQ758X7/b8sAxVLEoHq4DcdrmRYYyxbiU=
+github.com/Jamf-Concepts/jamfplatform-go-sdk v0.22.1 h1:dCFeNWTuVo1wbg3XxmOBy2S+k62Ps4iv2brtoEEHYZo=
+github.com/Jamf-Concepts/jamfplatform-go-sdk v0.22.1/go.mod h1:gUL5YSSzFcEQ758X7/b8sAxVLEoHq4DcdrmRYYyxbiU=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/ProtonMail/go-crypto v1.4.1 h1:9RfcZHqEQUvP8RzecWEUafnZVtEvrBVL9BiF67IQOfM=

--- a/internal/resources/pro/macos_configuration_profile/input_builders.go
+++ b/internal/resources/pro/macos_configuration_profile/input_builders.go
@@ -159,7 +159,7 @@ func buildScope(ctx context.Context, m *scope.ComputerScopeModel) (*proclassic.O
 	})
 	diags.Append(d...)
 	if jssUserGroups != nil {
-		s.JssUserGroups = &proclassic.OsXConfigurationProfileScopeJssUserGroups{JssUserGroup: jssUserGroups}
+		s.JssUserGroups = &proclassic.OsXConfigurationProfileScopeJssUserGroups{UserGroup: jssUserGroups}
 	}
 
 	if m.Limitations != nil {
@@ -330,21 +330,7 @@ func buildSelfService(m *SelfServiceModel) (*proclassic.OsXConfigurationProfileS
 		NotificationSubject:         helpers.OptionalStringPointer(m.NotificationSubject),
 	}
 
-	// Notification (dual <notification> wire element via NotificationValue custom marshaller).
-	hasNotificationBool := !m.DisplayNotifications.IsNull() && !m.DisplayNotifications.IsUnknown()
-	hasNotificationLoc := !m.NotificationLocation.IsNull() && !m.NotificationLocation.IsUnknown() && m.NotificationLocation.ValueString() != ""
-	if hasNotificationBool || hasNotificationLoc {
-		nv := &proclassic.NotificationValue{}
-		if hasNotificationBool {
-			b := m.DisplayNotifications.ValueBool()
-			nv.Enabled = &b
-		}
-		if hasNotificationLoc {
-			s := m.NotificationLocation.ValueString()
-			nv.Method = &s
-		}
-		ss.Notification = nv
-	}
+	ss.Notification = buildSelfServiceNotification(m)
 
 	// Security (removal_disallowed only — Password companion not surfaced).
 	if v := m.RemovalDisallowed.ValueString(); !m.RemovalDisallowed.IsNull() && !m.RemovalDisallowed.IsUnknown() && v != "" {
@@ -371,4 +357,67 @@ func buildSelfService(m *SelfServiceModel) (*proclassic.OsXConfigurationProfileS
 	}
 
 	return ss, diags
+}
+
+// buildSelfServiceNotification projects display_notifications and
+// notification_location onto the single <notification> wire element, and
+// returns nil to omit it.
+//
+// The two attributes are one field on the wire. <notification> takes either a
+// bool or a location string, the LAST occurrence in a request wins, and
+// applying either one RESETS the other to its default — the bool to false, the
+// location to "Self Service". Wire-probed on two tenants against Jamf Pro
+// 11.31.1 on 2026-09-07:
+//
+//	write                        -> stored (enabled | location)
+//	true                         -> true  | Self Service      (location reset)
+//	"…Notification Center"       -> false | …Notification Center (bool reset)
+//	location, then true          -> true  | Self Service
+//	true, then location          -> false | …Notification Center
+//	true, location, true         -> true  | Self Service
+//
+// So (true, "…Notification Center") cannot be written at all. Nothing rescues
+// it: no ordering, no third occurrence, no nested <enabled>/<location> shape,
+// no method=/enabled= attributes, no <notification_location> /
+// <notification_enabled> / <display_notifications> / <notification_center>
+// sibling element, and not the notification_subject the admin UI insists on.
+// Every one of those is ignored outright. The admin UI stores the pairing
+// happily, because it posts to a legacy servlet rather than this API, so the
+// state is reachable and the classic write path simply cannot express it —
+// Jamf PI-1662, and the same shape as the policy no-execute window in PI-1661.
+//
+// Two consequences, and the second is why this function exists rather than the
+// original inline block. A configured pairing is refused at plan time by
+// notificationCenterUnwritableValidator, so it never reaches here. But an
+// IMPORTED profile that the admin UI had set to the pairing puts it in state,
+// notification_location being Optional+Computed carries it into the next plan,
+// and emitting it would silently downgrade somebody's setting to
+// "Self Service" while reporting success. Omitting the element preserves
+// whatever the server holds (wire-verified: a PUT with no <notification> left
+// the UI-set pairing intact), so that is what this returns for the
+// unwritable combination.
+func buildSelfServiceNotification(m *SelfServiceModel) *proclassic.NotificationValue {
+	hasBool := !m.DisplayNotifications.IsNull() && !m.DisplayNotifications.IsUnknown()
+	hasLoc := !m.NotificationLocation.IsNull() && !m.NotificationLocation.IsUnknown() && m.NotificationLocation.ValueString() != ""
+
+	if hasBool && hasLoc &&
+		m.DisplayNotifications.ValueBool() &&
+		m.NotificationLocation.ValueString() == notificationLocationSelfServiceAndCenter {
+		return nil
+	}
+
+	if !hasBool && !hasLoc {
+		return nil
+	}
+
+	nv := &proclassic.NotificationValue{}
+	if hasBool {
+		b := m.DisplayNotifications.ValueBool()
+		nv.Enabled = &b
+	}
+	if hasLoc {
+		s := m.NotificationLocation.ValueString()
+		nv.Method = &s
+	}
+	return nv
 }

--- a/internal/resources/pro/macos_configuration_profile/input_builders_test.go
+++ b/internal/resources/pro/macos_configuration_profile/input_builders_test.go
@@ -197,11 +197,21 @@ func TestBuildScope_ExclusionsPopulated(t *testing.T) {
 	}
 }
 
+// TestBuildSelfService_NotificationSplit pins that the two Terraform attributes
+// still split into the one dual-valued wire element for a pairing Jamf Pro can
+// store.
+//
+// It used to assert the pairing with notificationLocationSelfServiceAndCenter,
+// which Jamf Pro cannot store at all: the flag and the location share one
+// element and setting either resets the other, so that request stores
+// "Self Service" and reports success. The unwritable pairing is refused at plan
+// time now and omitted from the payload — see buildSelfServiceNotification and
+// TestBuildSelfServiceNotification.
 func TestBuildSelfService_NotificationSplit(t *testing.T) {
 	t.Parallel()
 	ss, _ := buildSelfService(&SelfServiceModel{
 		DisplayNotifications: types.BoolValue(true),
-		NotificationLocation: types.StringValue(notificationLocationSelfServiceAndCenter),
+		NotificationLocation: types.StringValue(notificationLocationSelfService),
 		NotificationSubject:  types.StringValue("Subj"),
 		NotificationMessage:  types.StringValue("Body"),
 	})
@@ -211,8 +221,11 @@ func TestBuildSelfService_NotificationSplit(t *testing.T) {
 	if ss.Notification.Enabled == nil || !*ss.Notification.Enabled {
 		t.Fatal("expected Enabled=true")
 	}
-	if ss.Notification.Method == nil || *ss.Notification.Method != notificationLocationSelfServiceAndCenter {
-		t.Fatalf("expected Method = %q, got %v", notificationLocationSelfServiceAndCenter, ss.Notification.Method)
+	if ss.Notification.Method == nil || *ss.Notification.Method != notificationLocationSelfService {
+		t.Fatalf("expected Method = %q, got %v", notificationLocationSelfService, ss.Notification.Method)
+	}
+	if ss.NotificationSubject == nil || *ss.NotificationSubject != "Subj" {
+		t.Fatalf("expected NotificationSubject Subj, got %v", ss.NotificationSubject)
 	}
 }
 
@@ -314,4 +327,97 @@ func TestBuildScopeExclusions_NetworkSegmentsCarryDedicatedItemType(t *testing.T
 	// Type assert to the resource's network segment item type to confirm the
 	// builder uses the dedicated item struct (not bare IDName).
 	_ = proclassic.OsXConfigurationProfileScopeExclusionsNetworkSegmentsNetworkSegmentItem(items[0])
+}
+
+// TestBuildSelfServiceNotification pins the projection of the two Terraform
+// attributes onto the single <notification> wire element, including the pairing
+// Jamf Pro cannot store. The wire evidence is on buildSelfServiceNotification.
+func TestBuildSelfServiceNotification(t *testing.T) {
+	t.Parallel()
+
+	const center = "Self Service and Notification Center"
+
+	for _, tc := range []struct {
+		name       string
+		display    types.Bool
+		location   types.String
+		wantNil    bool
+		wantBool   *bool
+		wantMethod *string
+	}{
+		{
+			name: "neither set omits the element", display: types.BoolNull(), location: types.StringNull(),
+			wantNil: true,
+		},
+		{
+			name: "flag alone", display: types.BoolValue(true), location: types.StringNull(),
+			wantBool: new(true),
+		},
+		{
+			name: "flag false alone", display: types.BoolValue(false), location: types.StringNull(),
+			wantBool: new(false),
+		},
+		{
+			name: "location alone", display: types.BoolNull(), location: types.StringValue(center),
+			wantMethod: new(center),
+		},
+		{
+			name: "the reachable pairing is sent whole", display: types.BoolValue(true), location: types.StringValue("Self Service"),
+			wantBool: new(true), wantMethod: new("Self Service"),
+		},
+		{
+			// The whole point: emitting this would silently downgrade an
+			// admin-UI-set profile to "Self Service" while reporting success,
+			// so the element is withheld and the server keeps what it has.
+			name:    "the unwritable pairing omits the element entirely",
+			display: types.BoolValue(true), location: types.StringValue(center),
+			wantNil: true,
+		},
+		{
+			name:    "flag false with Notification Center is reachable, so it is sent",
+			display: types.BoolValue(false), location: types.StringValue(center),
+			wantBool: new(false), wantMethod: new(center),
+		},
+		{
+			name: "unknown values are treated as unset", display: types.BoolUnknown(), location: types.StringUnknown(),
+			wantNil: true,
+		},
+		{
+			name: "an empty location string is treated as unset", display: types.BoolNull(), location: types.StringValue(""),
+			wantNil: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := buildSelfServiceNotification(&SelfServiceModel{
+				DisplayNotifications: tc.display,
+				NotificationLocation: tc.location,
+			})
+			if tc.wantNil {
+				if got != nil {
+					t.Fatalf("want nil, got %+v", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatal("want a value, got nil")
+			}
+			switch {
+			case tc.wantBool == nil && got.Enabled != nil:
+				t.Errorf("Enabled: want nil, got %v", *got.Enabled)
+			case tc.wantBool != nil && got.Enabled == nil:
+				t.Errorf("Enabled: want %v, got nil", *tc.wantBool)
+			case tc.wantBool != nil && *got.Enabled != *tc.wantBool:
+				t.Errorf("Enabled: want %v, got %v", *tc.wantBool, *got.Enabled)
+			}
+			switch {
+			case tc.wantMethod == nil && got.Method != nil:
+				t.Errorf("Method: want nil, got %q", *got.Method)
+			case tc.wantMethod != nil && got.Method == nil:
+				t.Errorf("Method: want %q, got nil", *tc.wantMethod)
+			case tc.wantMethod != nil && *got.Method != *tc.wantMethod:
+				t.Errorf("Method: want %q, got %q", *tc.wantMethod, *got.Method)
+			}
+		})
+	}
 }

--- a/internal/resources/pro/macos_configuration_profile/notification_acceptance_test.go
+++ b/internal/resources/pro/macos_configuration_profile/notification_acceptance_test.go
@@ -1,0 +1,154 @@
+// Copyright Jamf Software LLC 2026
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build acceptance
+
+// Coverage for the Self Service notification pairing Jamf Pro's classic API
+// cannot store. See buildSelfServiceNotification for the wire record and Jamf
+// PI-1662 for the defect.
+
+package macos_configuration_profile_test
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/proclassic"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
+	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/testhelpers"
+)
+
+// TestAccResource_MacOSConfigurationProfile_NotificationCenterRefused pins the
+// plan-time refusal. It protects practitioners from an apply that would report
+// success having stored "Self Service", and it goes when PI-1662 is fixed.
+func TestAccResource_MacOSConfigurationProfile_NotificationCenterRefused(t *testing.T) {
+	testhelpers.AccPreCheck(t)
+	name := "tf-acc-mcp-notifloc-" + testhelpers.RunSuffix()
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testhelpers.AccTestProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      notificationCenterConfig(name),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`Notification Center cannot be combined with display_notifications`),
+			},
+		},
+	})
+}
+
+func notificationCenterConfig(name string) string {
+	return fmt.Sprintf(`
+resource "jamfplatform_pro_macos_configuration_profile" "test" {
+  general = {
+    name                = %q
+    distribution_method = "Make Available in Self Service"
+    payloads            = %q
+  }
+  self_service = {
+    display_notifications = true
+    notification_location = "Self Service and Notification Center"
+  }
+}
+`, name, minimalPayload)
+}
+
+const minimalPayload = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict><key>PayloadContent</key><array/><key>PayloadDisplayName</key><string>tf acc notifloc</string><key>PayloadIdentifier</key><string>com.example.tfacc.notifloc</string><key>PayloadType</key><string>Configuration</string><key>PayloadUUID</key><string>5E2C1A70-9999-4888-8777-666655554444</string><key>PayloadVersion</key><integer>1</integer></dict></plist>`
+
+// TestAccResource_MacOSConfigurationProfile_NotificationCenterIsUnwritable is
+// the canary. It goes round the provider and writes the pairing through the SDK
+// directly, then asserts the server did NOT store it.
+//
+// A FAILURE HERE IS GOOD NEWS: it means PI-1662 is fixed. Delete
+// notificationCenterUnwritableValidator, restore the plain projection in
+// buildSelfServiceNotification, drop the refusal test above, and delete this
+// file.
+//
+// The write goes through the SDK rather than raw HTTP for the reason in
+// feedback_probe_through_the_sdk_not_curl: it is the path the provider takes,
+// so a fix the SDK's marshalling cannot express is not one this provider could
+// adopt.
+func TestAccResource_MacOSConfigurationProfile_NotificationCenterIsUnwritable(t *testing.T) {
+	testhelpers.AccPreCheck(t)
+	ctx := context.Background()
+	c := proclassic.New(testhelpers.NewAcceptanceClient(t))
+	name := "tf-acc-mcp-notifloc-canary-" + testhelpers.RunSuffix()
+
+	const center = "Self Service and Notification Center"
+	yes := true
+	method := center
+	subject := "canary subject"
+	distribution := "Make Available in Self Service"
+	payload := minimalPayload
+
+	created, err := c.CreateOSXConfigurationProfileByID(ctx, "0", &proclassic.OsXConfigurationProfile{
+		General: &proclassic.OsXConfigurationProfileGeneral{
+			Name:               &name,
+			DistributionMethod: &distribution,
+			Payloads:           (*proclassic.PayloadsXMLText)(&payload),
+		},
+		SelfService: &proclassic.OsXConfigurationProfileSelfService{
+			Notification:        &proclassic.NotificationValue{Enabled: &yes, Method: &method},
+			NotificationSubject: &subject,
+		},
+	})
+	if err != nil {
+		t.Fatalf("create canary profile: %s", err)
+	}
+	id := fmt.Sprintf("%d", derefInt(created.ID))
+	t.Cleanup(func() {
+		if err := c.DeleteOSXConfigurationProfileByID(ctx, id); err != nil {
+			t.Logf("cleanup: delete profile %s: %s", id, err)
+		}
+	})
+
+	got, err := c.GetOSXConfigurationProfileByID(ctx, id)
+	if err != nil {
+		t.Fatalf("read back canary profile %s: %s", id, err)
+	}
+	ss := got.SelfService
+	if ss == nil || ss.Notification == nil {
+		t.Fatalf("profile %s came back with no self_service notification at all", id)
+	}
+	// notification_subject is the control: it travels in the same block and
+	// persists, so an empty one means the write never landed and the result
+	// says nothing about the pairing.
+	if strings.TrimSpace(derefString(ss.NotificationSubject)) == "" {
+		t.Fatalf("notification_subject did not persist either — the write did not land, so this proves nothing")
+	}
+
+	enabled, location := ss.Notification.Enabled, derefString(ss.Notification.Method)
+	if enabled != nil && *enabled && location == center {
+		t.Fatalf(
+			"Jamf Pro now stores the pairing (enabled=%v, location=%q).\n\n"+
+				"This is PI-1662 landing, not a regression. Remove the workaround:\n"+
+				"  1. delete notificationCenterUnwritableValidator and its wiring in resource.go\n"+
+				"  2. restore the plain projection in buildSelfServiceNotification\n"+
+				"  3. drop TestAccResource_MacOSConfigurationProfile_NotificationCenterRefused\n"+
+				"  4. delete this file and re-declare the pairing in the omit-retains config\n"+
+				"  5. close Jamf PI-1662",
+			*enabled, location,
+		)
+	}
+	t.Logf("still unwritable, as expected: enabled=%v location=%q", enabled, location)
+}
+
+func derefString(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}
+
+func derefInt(i *int) int {
+	if i == nil {
+		return 0
+	}
+	return *i
+}

--- a/internal/resources/pro/macos_configuration_profile/resource.go
+++ b/internal/resources/pro/macos_configuration_profile/resource.go
@@ -81,6 +81,13 @@ func (r *Resource) IdentitySchema(_ context.Context, _ resource.IdentitySchemaRe
 }
 
 // Schema returns the Terraform schema.
+// ConfigValidators returns the resource's plan-time cross-field checks.
+func (r *Resource) ConfigValidators(context.Context) []resource.ConfigValidator {
+	return []resource.ConfigValidator{
+		notificationCenterUnwritableValidator{},
+	}
+}
+
 func (r *Resource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		MarkdownDescription: "Manages a macOS configuration profile in Jamf Pro. The `general.payloads` attribute carries the raw `.mobileconfig` plist XML for the configuration the profile delivers to enrolled Macs.\n\n### Payload diff handling\n\nJamf Pro normalises every uploaded payload: it assigns its own top-level identifiers, fills in default values for fields you omit, and re-serialises the XML. The provider hides those normalisations from `terraform plan`, so applies stay quiet when nothing meaningful has changed. Real drift still surfaces in two cases:\n\n  - You edited the payload in Terraform. `plan` shows the change and `apply` pushes it.\n  - Someone edited the profile in the Jamf Pro admin UI. `plan` shows the drift on the next refresh, so you can either bring the change back into your Terraform config or `apply` to reassert the Terraform-managed value.\n\nA small set of profile-level fields (`PayloadDisplayName`, `PayloadIdentifier`, `PayloadUUID`, `PayloadOrganization`, `PayloadDescription`, `PayloadEnabled`) is managed entirely by Jamf Pro. Any value you supply for them inside `payloads` is replaced, so the provider ignores them in the diff. Use `general.name`, `general.description` and the other top-level attributes to control the equivalent fields.\n\n### Scope\n\nScope blocks mirror `jamfplatform_pro_policy`. Targets, limitations and exclusions all carry flat sets of Jamf Pro IDs, or directory-service names where appropriate. `all_computers` and `all_jss_users` conflict with their per-ID siblings.\n\n### Profile identity on update\n\nOn update the provider re-applies the existing top-level `PayloadUUID` and `PayloadIdentifier` from state into every payload it sends back to Jamf Pro, so the profile's identity stays stable across applies. Without that, every update would look like a brand-new profile to enrolled Macs and macOS would treat it as a fresh installation.\n\n### Characters Jamf Pro cannot store\n\nIn most payload types `&` and `<` come back with an extra layer of escaping, line feeds and tabs are removed, and emoji are replaced. Write line breaks as `&#13;`. An \"Application & Custom Settings\" payload stores all of these faithfully. Rather than alter a payload silently, the provider refuses it on create, on edit and on import, naming the offending value." + resourcePrivileges,
@@ -185,9 +192,9 @@ func (r *Resource) Schema(_ context.Context, _ resource.SchemaRequest, resp *res
 					"self_service_description":      optComputedString("Description shown in Self Service. Markdown supported."),
 					"ensure_users_view_description": optComputedBool("Force users to view the description before installing."),
 					"feature_on_main_page":          optComputedBool("Feature the profile on the Self Service main page."),
-					"display_notifications":         optComputedBool("Whether Self Service surfaces a notification when the profile becomes available. Pair with `notification_location` to set the delivery target."),
+					"display_notifications":         optComputedBool("Whether Self Service surfaces a notification when the profile becomes available. See `notification_location` for the one pairing Jamf Pro cannot store."),
 					"notification_location": schema.StringAttribute{
-						MarkdownDescription: "Notification delivery location. Valid values: `Self Service`, `Self Service and Notification Center`.",
+						MarkdownDescription: "Where Self Service surfaces the notification. `Self Service` or `Self Service and Notification Center`.\n\nJamf Pro stores this and `display_notifications` in one field, and setting either resets the other, so `Self Service and Notification Center` cannot be combined with `display_notifications = true` and is refused at plan time. To have both, set them under Self Service ▸ Notification in the Jamf Pro admin UI and leave both attributes out of the configuration; Terraform reads the pairing back and preserves it.",
 						Optional:            true,
 						Computed:            true,
 						PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},

--- a/internal/resources/pro/macos_configuration_profile/resource_acceptance_test.go
+++ b/internal/resources/pro/macos_configuration_profile/resource_acceptance_test.go
@@ -1633,6 +1633,11 @@ resource "jamfplatform_device_group" "exclude" {
   device_type = "computer"
 }
 
+resource "jamfplatform_pro_user_group" "target" {
+  name       = "tf-acc-mcp-omit-ug-t-%[1]s"
+  group_type = "static"
+}
+
 resource "jamfplatform_pro_user_group" "exclude" {
   name       = "tf-acc-mcp-omit-ug-x-%[1]s"
   group_type = "static"
@@ -1671,14 +1676,14 @@ resource "jamfplatform_pro_ibeacon" "exclude" {
 // distinctive value so that a server which stopped retaining an omitted
 // element is caught on content, not on presence. Left out: the two
 // directory-service user-group categories, because the server refuses a group
-// name that does not resolve against the tenant's directory integration; and
-// scope.targets.user_group_ids, because the SDK's
-// OsXConfigurationProfileScopeJssUserGroups decodes the child as
-// <jss_user_group> while the server answers <user_group> (wire-probed
-// 2026-09-06: both spellings are accepted on write, only <user_group> is ever
-// read back), so on this resource that category never round-trips and would
-// fail the create, not the contract under test. The exclusions counterpart is
-// tagged correctly and stays covered.
+// name that does not resolve against the tenant's directory integration.
+//
+// scope.targets.user_group_ids used to be left out too: the SDK tagged
+// OsXConfigurationProfileScopeJssUserGroups' child as <jss_user_group> while
+// the server answers <user_group>, so the category never read back and would
+// have failed the create rather than the contract under test. SDK v0.22.1
+// corrected the tag — it was the last one of the sixteen still mis-spelled —
+// and the category is covered here now.
 func omitRetainsConfig(name, payload string, f omitRetainsFixtures) string {
 	return omitRetainsFixtureHCL(f.suffix) + fmt.Sprintf(`
 resource "jamfplatform_pro_macos_configuration_profile" "test" {
@@ -1695,6 +1700,7 @@ resource "jamfplatform_pro_macos_configuration_profile" "test" {
       building_ids       = [jamfplatform_pro_building.target.id]
       department_ids     = [jamfplatform_pro_department.target.id]
       user_ids           = [%q]
+      user_group_ids     = [jamfplatform_pro_user_group.target.id]
     }
     limitations = {
       network_segment_ids                   = [jamfplatform_pro_network_segment.limit.id]
@@ -1720,7 +1726,7 @@ resource "jamfplatform_pro_macos_configuration_profile" "test" {
     ensure_users_view_description = true
     feature_on_main_page          = true
     display_notifications         = true
-    notification_location         = "Self Service and Notification Center"
+    notification_location         = "Self Service"
     notification_subject          = "Omit retains subject"
     notification_message          = "Omit retains message"
     removal_disallowed            = "Never"
@@ -1778,7 +1784,7 @@ resource "jamfplatform_pro_macos_configuration_profile" "test" {
     self_service_description  = "Omit-retains contract description."
     feature_on_main_page      = true
     display_notifications     = true
-    notification_location     = "Self Service and Notification Center"
+    notification_location     = "Self Service"
     notification_subject      = "Omit retains subject"
     notification_message      = "Omit retains message"
     removal_disallowed        = "Never"
@@ -1868,13 +1874,18 @@ func stateID(s *terraform.State, addr, attr string) (string, error) {
 
 // omitRetainedOnServer asserts the server's copy still carries every value the
 // omit-retains config declared in its first step. Inline fixture ids are read
-// from state because Jamf allocates them at apply. The four notification
-// attributes (display_notifications, notification_location,
-// notification_subject, notification_message) are declared but not asserted:
-// the classic GET never echoes <notification>, <notification_subject> or
-// <notification_message> for a macOS profile (wire-probed 2026-09-06 on a
-// profile created with all three set), so no read can witness whether the
-// server kept them.
+// from state because Jamf allocates them at apply.
+//
+// The four notification attributes are declared but not asserted here. An
+// earlier reading had them down as never echoed — "the classic GET never
+// echoes <notification>, <notification_subject> or <notification_message> for
+// a macOS profile" — which is not so: a re-probe on 2026-09-07 read all three
+// back on every GET. What is true is subtler, and belongs to
+// buildSelfServiceNotification rather than to this contract: the flag and the
+// location share one wire element, so a write carries only one of them and the
+// pair cannot be asserted as declared. notification_location is set to
+// "Self Service" above for that reason, the location being the half this
+// provider's write order loses.
 func omitRetainedOnServer(t *testing.T, f omitRetainsFixtures) resource.TestCheckFunc {
 	c := testhelpers.NewProClassicClient(t)
 	const addr = "jamfplatform_pro_macos_configuration_profile.test"
@@ -1888,6 +1899,7 @@ func omitRetainedOnServer(t *testing.T, f omitRetainsFixtures) resource.TestChec
 			{"depX", "jamfplatform_pro_department.exclude", "id"},
 			{"grpT", "jamfplatform_device_group.target", "jamf_pro_id"},
 			{"grpX", "jamfplatform_device_group.exclude", "jamf_pro_id"},
+			{"ugT", "jamfplatform_pro_user_group.target", "id"},
 			{"ugX", "jamfplatform_pro_user_group.exclude", "id"},
 			{"segL", "jamfplatform_pro_network_segment.limit", "id"},
 			{"segX", "jamfplatform_pro_network_segment.exclude", "id"},
@@ -1918,6 +1930,9 @@ func omitRetainedOnServer(t *testing.T, f omitRetainsFixtures) resource.TestChec
 					requireOnlyIDName("scope.targets.building_ids", derefField(sc.Buildings, func(b *proclassic.OsXConfigurationProfileScopeBuildings) *[]proclassic.IDName { return b.Building }), want["bldT"]),
 					requireOnlyIDName("scope.targets.department_ids", derefField(sc.Departments, func(d *proclassic.OsXConfigurationProfileScopeDepartments) *[]proclassic.IDName { return d.Department }), want["depT"]),
 					requireOnlyIDName("scope.targets.user_ids", derefField(sc.JssUsers, func(u *proclassic.OsXConfigurationProfileScopeJssUsers) *[]proclassic.IDName { return u.User }), f.targetUser),
+					requireOnlyIDName("scope.targets.user_group_ids", derefField(sc.JssUserGroups, func(u *proclassic.OsXConfigurationProfileScopeJssUserGroups) *[]proclassic.IDName {
+						return u.UserGroup
+					}), want["ugT"]),
 				}
 				for _, err := range checks {
 					if err != nil {

--- a/internal/resources/pro/macos_configuration_profile/state_builders.go
+++ b/internal/resources/pro/macos_configuration_profile/state_builders.go
@@ -239,7 +239,7 @@ func idNameSliceFromJssUserGroups(u *proclassic.OsXConfigurationProfileScopeJssU
 	if u == nil {
 		return nil
 	}
-	return u.JssUserGroup
+	return u.UserGroup
 }
 
 func idNameSliceFromLimIbeacons(i *proclassic.OsXConfigurationProfileScopeLimitationsIbeacons) *[]proclassic.IDName {

--- a/internal/resources/pro/macos_configuration_profile/validators.go
+++ b/internal/resources/pro/macos_configuration_profile/validators.go
@@ -1,0 +1,86 @@
+// Copyright Jamf Software LLC 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package macos_configuration_profile
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// notificationCenterUnwritableValidator refuses the one Self Service
+// notification pairing Jamf Pro's classic API cannot store: notifications on
+// with the location set to Notification Center.
+//
+// The two attributes are a projection of a single wire element. `<notification>`
+// takes either a bool or a location string, the LAST occurrence in a request
+// wins, and applying either one resets the other to its default — the bool to
+// false, the location to "Self Service". Sending both therefore always loses
+// one of them, whichever came first, and no ordering, third element, extra
+// occurrence or companion field changes that. Wire-probed on two tenants
+// against Jamf Pro 11.31.1 on 2026-09-07; the full record is on
+// buildSelfServiceNotification.
+//
+// The admin UI stores the pairing perfectly well, so this is a defect in the
+// classic API rather than a state Jamf Pro cannot hold — which is exactly why
+// refusing it at plan time is the honest answer. Applying it would report
+// success and store "Self Service", and a practitioner comparing Terraform
+// against the admin UI would find the provider had quietly changed a setting it
+// claimed to have written. Tracked as Jamf PI-1662.
+//
+// Delete this validator when the API accepts the pair; the acceptance canary
+// TestAccResource_MacOSConfigurationProfile_NotificationCenterIsUnwritable
+// fails on that day and says so.
+type notificationCenterUnwritableValidator struct{}
+
+// Description returns a plain-text description of the validator.
+func (notificationCenterUnwritableValidator) Description(context.Context) string {
+	return `self_service.notification_location cannot be "` + notificationLocationSelfServiceAndCenter + `" while self_service.display_notifications is true`
+}
+
+// MarkdownDescription returns the markdown description.
+func (v notificationCenterUnwritableValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+// ValidateResource implements the plan-time cross-field check.
+//
+// It reads one attribute at a time rather than decoding the whole model: a
+// profile configuration routinely carries unknown nested values (an
+// interpolated scope id, a payload from a function), and Config.Get on the
+// whole model fails outright on those, which would disable every validator on
+// the resource.
+func (notificationCenterUnwritableValidator) ValidateResource(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	locationPath := path.Root("self_service").AtName("notification_location")
+
+	var location types.String
+	if diags := req.Config.GetAttribute(ctx, locationPath, &location); diags.HasError() {
+		return
+	}
+	if location.IsNull() || location.IsUnknown() || location.ValueString() != notificationLocationSelfServiceAndCenter {
+		return
+	}
+
+	var display types.Bool
+	if diags := req.Config.GetAttribute(ctx, path.Root("self_service").AtName("display_notifications"), &display); diags.HasError() {
+		return
+	}
+	// Null or unknown is not a violation: null leaves the flag to Jamf Pro,
+	// which defaults it off, and unknown resolves after apply.
+	if display.IsNull() || display.IsUnknown() || !display.ValueBool() {
+		return
+	}
+
+	resp.Diagnostics.AddAttributeError(
+		locationPath,
+		"Notification Center cannot be combined with display_notifications",
+		"Jamf Pro stores a profile's notification flag and its notification location in one field, and setting either one resets the other. "+
+			"With display_notifications = true the location always comes back as \""+notificationLocationSelfService+"\", so this configuration would report success and store something else.\n\n"+
+			"Either set self_service.notification_location = \""+notificationLocationSelfService+"\", or drop self_service.display_notifications and set the location on its own.\n\n"+
+			"To have both, set them under Self Service ▸ Notification in the Jamf Pro admin UI, which is not subject to this limitation, and leave both attributes out of the configuration. "+
+			"Terraform reads the pairing back and preserves it.",
+	)
+}


### PR DESCRIPTION
## What

Bumps `jamfplatform-go-sdk` to **v0.22.1**, which corrects one mis-tagged XML element:

```diff
 type OsXConfigurationProfileScopeJssUserGroups struct {
-    JssUserGroup *[]IDName `xml:"jss_user_group,omitempty"`
+    UserGroup    *[]IDName `xml:"user_group,omitempty"`
 }
```

## Which constructs are impacted: one

I checked whether other types shared the fault rather than assuming. All **16** `*ScopeJssUserGroups` container types now spell the child `user_group`, and this was the **last one still wrong**. So `jamfplatform_pro_macos_configuration_profile` is the only construct affected — and only its `scope.targets`, the exclusions type having been correct already.

Two call sites move to the new field name; they were the only compile errors. `go mod tidy` was also needed, since `go get` alone left the v0.22.0 hashes in `go.sum` beside the new ones.

## The workaround this lets us delete

The repo already knew about the mis-tag. `resource_acceptance_test.go` deliberately left `scope.targets.user_group_ids` out of the omit-retains contract, explaining that the SDK decoded `<jss_user_group>` while the server answers `<user_group>`, "so on this resource that category never round-trips and would fail the create". Per that probe, writes were accepted either way but the read never populated — so the practitioner symptom was a failed apply, not silent data loss.

That workaround is lifted: a target user-group fixture, the declaration, the want key and the wire assertion. **The category is covered for the first time.**

## A second defect, found by actually running the package

Pre-existing and unrelated to the bump — reproduced identically on plain `main` — but fixed here since the same test surfaces it.

`self_service.display_notifications` and `self_service.notification_location` are **one wire element**. `<notification>` takes either a bool or a location string, the **last occurrence wins**, and applying either **resets the other to its default**:

| sent | stored flag | stored location |
|---|---|---|
| `true` | true | **reset to `Self Service`** |
| `…Notification Center` | **reset to false** | `…Notification Center` |
| location, then `true` | true | `Self Service` |
| `true`, then location | false | `…Notification Center` |
| `true`, location, `true` | true | `Self Service` |

So `(true, "Self Service and Notification Center")` is unreachable. Ruled out, each ignored outright: nested `<enabled>`/`<location>`, nested `<enabled>`/`<method>`, `method=`/`enabled=` attributes, sibling `<notification_location>` / `<notification_enabled>` / `<display_notifications>` / `<notification_center>`, a comma-joined value, and the `notification_subject` the admin UI *requires* before it will save. Also POST and PUT alike, on two tenants.

**The admin UI stores the pairing fine** (verified by hand, then read back through the API), because it posts to a legacy servlet. So the state is reachable and the classic write path cannot express it — **Jamf PI-1662**, the same shape as PI-1661.

**Not an SDK defect.** Every probe was raw XML with no SDK in the path, and the SDK's `NotificationValue` type-sniff matches the server's read shape exactly. Marshal order is the only lever and merely swaps which attribute breaks. There is no Pro (v1) profile endpoint to migrate to.

### Two fixes, and the second is the sharper one

- **Plan-time refusal** of the pairing, rather than applying it and reporting success having stored `Self Service`.
- **Omit rather than downgrade.** `notification_location` is Optional+Computed, so an imported UI-configured profile carries the pairing into the next plan with no config change at all, and emitting it would silently downgrade somebody's setting. `buildSelfServiceNotification` withholds the element for that combination — wire-verified to preserve what the server holds.

## Two stale comments corrected

Both claimed the classic GET "never echoes `<notification>`, `<notification_subject>` or `<notification_message>`" for a macOS profile. A re-probe read all three back on **every** GET. Same over-broad "never echoed" shape as the corrections in #388.

## Verification

`macos_configuration_profile` acceptance: **26 passed, 0 failed, 2 skipped.**

| test | before | after |
|---|---|---|
| `OmittedBlocksRetained` | FAIL on `main` | **PASS** |
| `NotificationCenterRefused` | new | **PASS** |
| `NotificationCenterIsUnwritable` (canary) | new | **PASS** |

The two skips are pre-existing and unrelated: they need a hand-made `Fidelity Test Sentinel [DO NOT DELETE]` profile that the test estate lacks, and the skip message says how to recreate it.

`make fix fmt lint test` green, `go vet -tags acceptance ./...` clean, `make generate` run.

No conflict with any open PR — this touches `go.mod`, `go.sum` and `macos_configuration_profile` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)