### PR TITLE
test(pro): stop the omit-retains configs declaring attributes #387 made read-only

### DIFF
--- a/internal/resources/pro/mobile_device_app/resource_acceptance_test.go
+++ b/internal/resources/pro/mobile_device_app/resource_acceptance_test.go
@@ -756,7 +756,6 @@ func mobileAppOmitRetainsConfig(suffix, name string) string {
 				version         = "1.0"
 				bundle_id       = "com.example.tfacc.mobileapp.omit"
 				os_type         = "iOS"
-				deployment_type = "Make Available in Self Service"
 			}
 			scope = {
 				targets = {
@@ -808,7 +807,6 @@ func mobileAppOmitRetainsParentsOnlyConfig(suffix, name string) string {
 				version         = "1.0"
 				bundle_id       = "com.example.tfacc.mobileapp.omit"
 				os_type         = "iOS"
-				deployment_type = "Make Available in Self Service"
 			}
 			scope = {
 				targets = {
@@ -835,7 +833,6 @@ func mobileAppOmitRetainsGeneralOnlyConfig(suffix, name string) string {
 				version         = "1.0"
 				bundle_id       = "com.example.tfacc.mobileapp.omit"
 				os_type         = "iOS"
-				deployment_type = "Make Available in Self Service"
 			}
 		}
 	`, name)

--- a/internal/resources/pro/policy/resource_acceptance_test.go
+++ b/internal/resources/pro/policy/resource_acceptance_test.go
@@ -2709,21 +2709,18 @@ const policyOmitRetainsGeneralScalars = `
 // both need an out-of-band upload (JCDS, icon bytes) this test cannot supply.
 // Four general leaves are left undeclared because wire probes on 2026-09-06
 // showed the server ignores them on both POST and PUT and echoes its own
-// value, which would fail step 1 on content rather than on retention:
-// date_time_limitations.no_execute_start / no_execute_end always echo
-// empty, network_limitations.minimum_network_connection always echoes
-// "No Minimum", and override_default_settings.force_afp_smb always echoes
-// false. network_limitations.network_segment_ids and any_ip_address are
-// server-derived mirrors of scope.limitations.network_segment_ids, and a
-// <network_limitations> element naming only one of any_ip_address /
-// minimum_network_connection is refused 409 "Problem with general", so the
-// block declares both with the values the server will echo. The four
-// self_service notification leaves are declared but not asserted: the
-// classic GET on this tenant echoes no <notification>, <notification_type>,
-// <notification_subject> or <notification_message> element at all, so the
-// wire cannot witness them either way. printers.leave_existing_default is
-// declared false because the server echoes false whatever is sent while a
-// printer in the same block carries make_default = true.
+// value, which would fail step 1 on content rather than on retention.
+//
+// network_limitations and override_default_settings are declared EMPTY. Every
+// child of both is Computed-only — Jamf Pro derives each from a setting that
+// lives elsewhere and refuses a write — so declaring the block is the whole
+// gesture, and the wire assertions below check the projections rather than
+// anything this configuration set. printers.leave_existing_default is gone
+// altogether, having modelled a dead wire element. Both changes landed in #387.
+//
+// The four self_service notification leaves are declared but not asserted: the
+// classic GET echoes them only while the tenant-level Self Service
+// notifications toggle is on, so an acceptance test must not depend on them.
 func policyOmitRetainsConfig(n policyOmitRetainsNames) string {
 	return policyOmitRetainsFixtures(n) + fmt.Sprintf(`
 resource "jamfplatform_pro_policy" "test" {
@@ -2735,16 +2732,8 @@ resource "jamfplatform_pro_policy" "test" {
       expiration_date = "2027-02-03 04:05:06"
       no_execute_on   = ["Tue", "Thu"]
     }
-    network_limitations = {
-      minimum_network_connection = "No Minimum"
-      any_ip_address             = false
-    }
-    override_default_settings = {
-      target_drive       = "/"
-      distribution_point = "default"
-      force_afp_smb      = false
-      sus                = "default"
-    }
+    network_limitations       = {}
+    override_default_settings = {}
   }
   scope = {
     targets = {
@@ -2792,7 +2781,6 @@ resource "jamfplatform_pro_policy" "test" {
     ]
   }
   printers = {
-    leave_existing_default = false
     printers = [
       {
         id           = jamfplatform_pro_printer.fixture.id
@@ -3120,9 +3108,6 @@ func policyLinkedObjectsRetained(p *proclassic.Policy, n policyOmitRetainsNames)
 	}
 	if p.Printers == nil {
 		return fmt.Errorf("printers: absent")
-	}
-	if err := testhelpers.RequireEqual("printers.leave_existing_default", false, testhelpers.Deref(p.Printers.LeaveExistingDefault)); err != nil {
-		return err
 	}
 	if err := requireSingleNamed("printers", p.Printers.Printer, func(pr proclassic.PolicyPrintersPrinterItem) *string { return pr.Name }, n.Printer); err != nil {
 		return err


### PR DESCRIPTION
## The pro lane has been red on main since #388 merged

Three tests, seen on [#390's run](https://github.com/Jamf-Concepts/terraform-provider-jamfplatform/actions/runs/34115256907/job/101721092997):

* `TestAccResource_ProPolicy_OmittedBlocksRetained`
* `TestAccResource_ProMobileApp_OmittedBlocksRetained`
* `TestAccResource_MacOSConfigurationProfile_OmittedBlocksRetained` — different cause, fixed in #396

```
Error: Invalid Configuration for Read-Only Attribute
  111:       minimum_network_connection = "No Minimum"
Cannot set value for this attribute as the provider has marked it as read-only.
```

## Why neither PR's CI caught it

A semantic collision between two PRs that never conflicted textually.

**#386** added the omit-retains contract tests, whose whole design is to *declare a value for every attribute a resource has*, so a server that stopped retaining an omitted element is caught on content rather than presence.

**#388** then reclassified nine policy attributes and `mobile_device_app.general.deployment_type` as Computed-only, and removed `printers.leave_existing_default` outright, on wire evidence that Jamf Pro never accepted a write to any of them.

When #388's acceptance ran, its branch predated #386 — so the tests that declare those attributes did not exist yet. Textually the two PRs touch different lines; semantically one invalidates the other's configs. Merge order did the rest.

## Ten invalid declarations

Enumerated programmatically rather than one at a time, which mattered: the CI log stopped after six errors and never reached the seventh.

| resource | attribute | why invalid |
|---|---|---|
| `policy` | `network_limitations.minimum_network_connection`, `.any_ip_address` | Computed-only |
| `policy` | `override_default_settings.target_drive`, `.distribution_point`, `.force_afp_smb`, `.sus` | Computed-only |
| `policy` | `printers.leave_existing_default` | **removed**, not read-only |
| `mobile_device_app` | `general.deployment_type` × 3 configs | Computed-only |

`mobile_device_app:286` also matches the grep but is deliberate — `DeploymentTypeIsUnconfigurable` asserts the refusal, and it still passes.

## The fix

The two policy projection blocks are declared **empty**. That preserves what the contract needs — a declared block is what makes the provider read the projection into state — while setting nothing the server would refuse.

Their wire assertions are untouched and still hold. I checked rather than assumed:

* `target_drive` defaults to `/`, so the `override_default_settings.target_drive` assertion of `/` stands.
* `network_requirements` is unset, so it is `Any`, so `minimum_network_connection` projects to `No Minimum`.
* `scope.limitations.network_segment_ids` **is** populated in this config, so `any_ip_address` is genuinely `false` rather than incidentally so.
* The retry trio still satisfies #388's new frequency validator (`retry_event = "none"`, `retry_attempts = -1`, `notify_on_each_failed_retry` unset).

`printers.leave_existing_default` goes from the config **and its wire assertion** — that assertion could only ever have passed vacuously, the element being one Jamf Pro answers empty however it is written.

The stale doc comment describing the old declarations is rewritten.

## Verification

Against a tenant:

| test | before | after |
|---|---|---|
| `ProPolicy_OmittedBlocksRetained` | FAIL | **PASS** 11.2s |
| `ProMobileApp_OmittedBlocksRetained` | FAIL | **PASS** 8.2s |
| `ProMobileApp_DeploymentTypeIsUnconfigurable` | PASS | **PASS** (not collateral) |

`make fmt lint test` green, `go vet -tags acceptance ./...` clean.

## How to stop this recurring

Worth a follow-up: nothing mechanically ties the omit-retains contract to the schema, so an attribute reclassified as Computed-only silently invalidates a config that declares it, and only the `pro` lane notices. A unit test walking the schema and refusing a Computed-only attribute in any acceptance config string would catch it in `make test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)