### PR TITLE
fix(mobile_device_configuration_profile)!: remove self_service_description (#393)

### DIFF
--- a/docs/resources/pro_mobile_device_configuration_profile.md
+++ b/docs/resources/pro_mobile_device_configuration_profile.md
@@ -141,9 +141,7 @@ Required:
 Optional:
 
 - `category_id` (String) Jamf Pro category ID. Use `-1` (default) for "no category".
-- `description` (String) Free-text description of the profile. Jamf Pro shows it on the General tab and reuses it as the profile's Self Service description.
-
-The admin UI offers those as two separate fields. The classic API keeps one: whatever you write to the Self Service description lands here, and Jamf Pro never returns the other field, so this provider exposes only this attribute. Put the Self Service wording here. To make the two read differently, set them in the admin UI and leave this attribute unset, so Terraform asserts neither. Probed against Jamf Pro 11.31.1 on 2026-09-07; the macOS profile endpoint keeps its two fields independent, which makes this a Jamf Pro defect.
+- `description` (String) Free-text description of the profile, shown on its General tab in Jamf Pro. Jamf Pro keeps one description for both places it appears, so whatever you set here is also the profile's Self Service description. To give the two different text, set them on the profile's Options and Self Service tabs in Jamf Pro and leave this attribute unset.
 - `distribution_method` (String) How the profile reaches devices. `Install Automatically` pushes via MDM; `Make Available in Self Service` lists the profile in Self Service so users install it manually.
 - `level` (String) Profile delivery level. Mirrors the admin UI dropdown: `Device Level` (default) or `User Level`.
 - `redeploy_days_before_certificate_expires` (Number) Number of days before a certificate in the profile expires that should trigger redeployment. `0` disables certificate-expiry redeployment.

--- a/docs/resources/pro_mobile_device_configuration_profile.md
+++ b/docs/resources/pro_mobile_device_configuration_profile.md
@@ -104,9 +104,8 @@ resource "jamfplatform_pro_mobile_device_configuration_profile" "self_service" {
   }
 
   self_service = {
-    self_service_description = "Installs the corporate VPN configuration."
-    feature_on_main_page     = true
-    removal_disallowed       = "Never"
+    feature_on_main_page = true
+    removal_disallowed   = "Never"
     categories = [
       { id = "44" },
     ]
@@ -142,7 +141,9 @@ Required:
 Optional:
 
 - `category_id` (String) Jamf Pro category ID. Use `-1` (default) for "no category".
-- `description` (String) Free-text description shown in the Jamf Pro admin UI.
+- `description` (String) Free-text description of the profile. Jamf Pro shows it on the General tab and reuses it as the profile's Self Service description.
+
+The admin UI offers those as two separate fields. The classic API keeps one: whatever you write to the Self Service description lands here, and Jamf Pro never returns the other field, so this provider exposes only this attribute. Put the Self Service wording here. To make the two read differently, set them in the admin UI and leave this attribute unset, so Terraform asserts neither. Probed against Jamf Pro 11.31.1 on 2026-09-07; the macOS profile endpoint keeps its two fields independent, which makes this a Jamf Pro defect.
 - `distribution_method` (String) How the profile reaches devices. `Install Automatically` pushes via MDM; `Make Available in Self Service` lists the profile in Self Service so users install it manually.
 - `level` (String) Profile delivery level. Mirrors the admin UI dropdown: `Device Level` (default) or `User Level`.
 - `redeploy_days_before_certificate_expires` (Number) Number of days before a certificate in the profile expires that should trigger redeployment. `0` disables certificate-expiry redeployment.
@@ -219,7 +220,6 @@ Optional:
 - `categories` (Attributes List) Categories under which the profile appears in Self Service. Listing a category displays the profile in it, matching the admin UI's "Display in" tick; Jamf Pro keeps no undisplayed state and offers no per-category "Feature in" control for mobile profiles, so neither is exposed here. (see [below for nested schema](#nestedatt--self_service--categories))
 - `feature_on_main_page` (Boolean) Feature the profile on the Self Service main page.
 - `removal_disallowed` (String) Removal-by-end-user policy. Valid values: `Never`, `Always`, `With Authorization`. Pair `With Authorization` with `authorization_password` to require a password at removal time.
-- `self_service_description` (String) Description shown in Self Service.
 
 <a id="nestedatt--self_service--categories"></a>
 ### Nested Schema for `self_service.categories`

--- a/docs/resources/pro_mobile_device_configuration_profile.md
+++ b/docs/resources/pro_mobile_device_configuration_profile.md
@@ -141,7 +141,7 @@ Required:
 Optional:
 
 - `category_id` (String) Jamf Pro category ID. Use `-1` (default) for "no category".
-- `description` (String) Free-text description of the profile, shown on its General tab in Jamf Pro. Jamf Pro keeps one description for both places it appears, so whatever you set here is also the profile's Self Service description. To give the two different text, set them on the profile's Options and Self Service tabs in Jamf Pro and leave this attribute unset.
+- `description` (String) Free-text description of the profile. It doubles as the Self Service description, because Jamf Pro stores one for both. To set those separately, use the profile's Options and Self Service tabs and leave this attribute unset.
 - `distribution_method` (String) How the profile reaches devices. `Install Automatically` pushes via MDM; `Make Available in Self Service` lists the profile in Self Service so users install it manually.
 - `level` (String) Profile delivery level. Mirrors the admin UI dropdown: `Device Level` (default) or `User Level`.
 - `redeploy_days_before_certificate_expires` (Number) Number of days before a certificate in the profile expires that should trigger redeployment. `0` disables certificate-expiry redeployment.

--- a/examples/resources/jamfplatform_pro_mobile_device_configuration_profile/resource.tf
+++ b/examples/resources/jamfplatform_pro_mobile_device_configuration_profile/resource.tf
@@ -45,9 +45,8 @@ resource "jamfplatform_pro_mobile_device_configuration_profile" "self_service" {
   }
 
   self_service = {
-    self_service_description = "Installs the corporate VPN configuration."
-    feature_on_main_page     = true
-    removal_disallowed       = "Never"
+    feature_on_main_page = true
+    removal_disallowed   = "Never"
     categories = [
       { id = "44" },
     ]

--- a/internal/resources/pro/mobile_device_configuration_profile/input_builders.go
+++ b/internal/resources/pro/mobile_device_configuration_profile/input_builders.go
@@ -305,8 +305,7 @@ func buildScopeExclusions(ctx context.Context, m *scope.MobileScopeExclusionsMod
 func buildSelfService(m *SelfServiceModel) (*proclassic.MobileDeviceConfigurationProfileSelfService, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	ss := &proclassic.MobileDeviceConfigurationProfileSelfService{
-		SelfServiceDescription: helpers.OptionalStringPointer(m.SelfServiceDescription),
-		FeatureOnMainPage:      helpers.OptionalBoolPointer(m.FeatureOnMainPage),
+		FeatureOnMainPage: helpers.OptionalBoolPointer(m.FeatureOnMainPage),
 	}
 
 	hasDisallowed := !m.RemovalDisallowed.IsNull() && !m.RemovalDisallowed.IsUnknown() && m.RemovalDisallowed.ValueString() != ""

--- a/internal/resources/pro/mobile_device_configuration_profile/input_builders.go
+++ b/internal/resources/pro/mobile_device_configuration_profile/input_builders.go
@@ -294,6 +294,17 @@ func buildScopeExclusions(ctx context.Context, m *scope.MobileScopeExclusionsMod
 
 // buildSelfService maps the Self Service block onto the classic payload.
 //
+// It never emits <self_service_description>, and there is no attribute for one:
+// the field is a write-alias for <description>, so sending it overwrote a value
+// the practitioner had set under general, an empty one erased that value, and a
+// read returned an empty element every time. Probed across eighteen create and
+// update combinations against Jamf Pro 11.31.1 on 2026-09-07; deployment_method
+// made no difference and update matched create. Issue #393 has the tables, and
+// TestBuildSelfService_NeverSendsASelfServiceDescription pins the omission. The
+// admin UI does offer the two descriptions separately and the macOS profile
+// keeps them independent, so this is a Jamf Pro defect: if it is fixed, restore
+// the attribute rather than reviving this field on its own.
+//
 // Every <category> it emits carries display_in=true, because that is what makes
 // Jamf Pro store the category at all — see helpers.SelfServiceCategoryDisplayIn
 // for the wire law, which is identical on all six classic resources carrying

--- a/internal/resources/pro/mobile_device_configuration_profile/model_types.go
+++ b/internal/resources/pro/mobile_device_configuration_profile/model_types.go
@@ -55,11 +55,10 @@ type GeneralModel struct {
 // profiles omit the notification block, install_button_text, display_name,
 // and force_users_to_view_description that macOS profiles carry.
 type SelfServiceModel struct {
-	SelfServiceDescription types.String              `tfsdk:"self_service_description"`
-	FeatureOnMainPage      types.Bool                `tfsdk:"feature_on_main_page"`
-	RemovalDisallowed      types.String              `tfsdk:"removal_disallowed"`
-	AuthorizationPassword  types.String              `tfsdk:"authorization_password"`
-	Categories             []SelfServiceCategoryItem `tfsdk:"categories"`
+	FeatureOnMainPage     types.Bool                `tfsdk:"feature_on_main_page"`
+	RemovalDisallowed     types.String              `tfsdk:"removal_disallowed"`
+	AuthorizationPassword types.String              `tfsdk:"authorization_password"`
+	Categories            []SelfServiceCategoryItem `tfsdk:"categories"`
 }
 
 // SelfServiceCategoryItem models a single <category> inside

--- a/internal/resources/pro/mobile_device_configuration_profile/resource.go
+++ b/internal/resources/pro/mobile_device_configuration_profile/resource.go
@@ -105,19 +105,8 @@ func (r *Resource) Schema(_ context.Context, _ resource.SchemaRequest, resp *res
 						Required:            true,
 						Validators:          []validator.String{stringvalidator.LengthAtLeast(1)},
 					},
-					// There is no self_service_description attribute, and adding one
-					// back would reintroduce issue #393. Jamf Pro's read/write API
-					// carries a single description for this object: a Self Service
-					// description sent to it is stored as this field, an empty one
-					// erases this field, and a read never returns it. Probed across
-					// eighteen create and update combinations on Jamf Pro 11.31.1,
-					// 2026-09-07; deployment_method made no difference and update
-					// matched create. The admin UI does offer the two separately, and
-					// the macOS profile equivalent keeps them independent, so this is
-					// a Jamf Pro defect. If it is fixed, restore the attribute rather
-					// than reviving the payload field on its own.
 					"description": optComputedString(
-						"Free-text description of the profile, shown on its General tab in Jamf Pro. Jamf Pro keeps one description for both places it appears, so whatever you set here is also the profile's Self Service description. To give the two different text, set them on the profile's Options and Self Service tabs in Jamf Pro and leave this attribute unset.",
+						"Free-text description of the profile. It doubles as the Self Service description, because Jamf Pro stores one for both. To set those separately, use the profile's Options and Self Service tabs and leave this attribute unset.",
 					),
 					"level": schema.StringAttribute{
 						MarkdownDescription: "Profile delivery level. Mirrors the admin UI dropdown: `Device Level` (default) or `User Level`.",

--- a/internal/resources/pro/mobile_device_configuration_profile/resource.go
+++ b/internal/resources/pro/mobile_device_configuration_profile/resource.go
@@ -105,7 +105,10 @@ func (r *Resource) Schema(_ context.Context, _ resource.SchemaRequest, resp *res
 						Required:            true,
 						Validators:          []validator.String{stringvalidator.LengthAtLeast(1)},
 					},
-					"description": optComputedString("Free-text description shown in the Jamf Pro admin UI."),
+					"description": optComputedString(
+						"Free-text description of the profile. Jamf Pro shows it on the General tab and reuses it as the profile's Self Service description.\n\n" +
+							"The admin UI offers those as two separate fields. The classic API keeps one: whatever you write to the Self Service description lands here, and Jamf Pro never returns the other field, so this provider exposes only this attribute. Put the Self Service wording here. To make the two read differently, set them in the admin UI and leave this attribute unset, so Terraform asserts neither. Probed against Jamf Pro 11.31.1 on 2026-09-07; the macOS profile endpoint keeps its two fields independent, which makes this a Jamf Pro defect.",
+					),
 					"level": schema.StringAttribute{
 						MarkdownDescription: "Profile delivery level. Mirrors the admin UI dropdown: `Device Level` (default) or `User Level`.",
 						Optional:            true,
@@ -181,8 +184,7 @@ func (r *Resource) Schema(_ context.Context, _ resource.SchemaRequest, resp *res
 				MarkdownDescription: "Self Service integration. Only meaningful when `general.distribution_method = \"Make Available in Self Service\"`.",
 				Optional:            true,
 				Attributes: map[string]schema.Attribute{
-					"self_service_description": optComputedString("Description shown in Self Service."),
-					"feature_on_main_page":     optComputedBool("Feature the profile on the Self Service main page."),
+					"feature_on_main_page": optComputedBool("Feature the profile on the Self Service main page."),
 					"removal_disallowed": schema.StringAttribute{
 						MarkdownDescription: "Removal-by-end-user policy. Valid values: `Never`, `Always`, `With Authorization`. Pair `With Authorization` with `authorization_password` to require a password at removal time.",
 						Optional:            true,

--- a/internal/resources/pro/mobile_device_configuration_profile/resource.go
+++ b/internal/resources/pro/mobile_device_configuration_profile/resource.go
@@ -105,9 +105,19 @@ func (r *Resource) Schema(_ context.Context, _ resource.SchemaRequest, resp *res
 						Required:            true,
 						Validators:          []validator.String{stringvalidator.LengthAtLeast(1)},
 					},
+					// There is no self_service_description attribute, and adding one
+					// back would reintroduce issue #393. Jamf Pro's read/write API
+					// carries a single description for this object: a Self Service
+					// description sent to it is stored as this field, an empty one
+					// erases this field, and a read never returns it. Probed across
+					// eighteen create and update combinations on Jamf Pro 11.31.1,
+					// 2026-09-07; deployment_method made no difference and update
+					// matched create. The admin UI does offer the two separately, and
+					// the macOS profile equivalent keeps them independent, so this is
+					// a Jamf Pro defect. If it is fixed, restore the attribute rather
+					// than reviving the payload field on its own.
 					"description": optComputedString(
-						"Free-text description of the profile. Jamf Pro shows it on the General tab and reuses it as the profile's Self Service description.\n\n" +
-							"The admin UI offers those as two separate fields. The classic API keeps one: whatever you write to the Self Service description lands here, and Jamf Pro never returns the other field, so this provider exposes only this attribute. Put the Self Service wording here. To make the two read differently, set them in the admin UI and leave this attribute unset, so Terraform asserts neither. Probed against Jamf Pro 11.31.1 on 2026-09-07; the macOS profile endpoint keeps its two fields independent, which makes this a Jamf Pro defect.",
+						"Free-text description of the profile, shown on its General tab in Jamf Pro. Jamf Pro keeps one description for both places it appears, so whatever you set here is also the profile's Self Service description. To give the two different text, set them on the profile's Options and Self Service tabs in Jamf Pro and leave this attribute unset.",
 					),
 					"level": schema.StringAttribute{
 						MarkdownDescription: "Profile delivery level. Mirrors the admin UI dropdown: `Device Level` (default) or `User Level`.",

--- a/internal/resources/pro/mobile_device_configuration_profile/resource_acceptance_test.go
+++ b/internal/resources/pro/mobile_device_configuration_profile/resource_acceptance_test.go
@@ -337,7 +337,6 @@ resource "jamfplatform_pro_mobile_device_configuration_profile" "test" {
 %sEOF
   }
   self_service = {
-    self_service_description = "Acceptance-test mobile profile auth"
     feature_on_main_page     = true
     removal_disallowed       = "With Authorization"
     authorization_password   = %q
@@ -356,7 +355,6 @@ resource "jamfplatform_pro_mobile_device_configuration_profile" "test" {
 %sEOF
   }
   self_service = {
-    self_service_description = "Acceptance-test mobile profile"
     feature_on_main_page     = true
     removal_disallowed       = "Never"
   }
@@ -1299,7 +1297,6 @@ resource "jamfplatform_pro_mobile_device_configuration_profile" "test" {
     }
   }
   self_service = {
-    self_service_description = "Omit-retains contract description."
     feature_on_main_page     = true
     removal_disallowed       = "Never"
     categories = [
@@ -1348,7 +1345,6 @@ resource "jamfplatform_pro_mobile_device_configuration_profile" "test" {
     }
   }
   self_service = {
-    self_service_description = "Omit-retains contract description."
     removal_disallowed       = "Never"
   }
   depends_on = [
@@ -1447,10 +1443,9 @@ func stateID(s *terraform.State, addr string) (string, error) {
 
 // omitRetainedOnServer asserts the server's copy still carries every value the
 // omit-retains config declared in its first step. Inline fixture ids are read
-// from state because Jamf allocates them at apply. self_service_description is
-// declared but not asserted: the classic GET returns
-// <self_service_description/> for a mobile profile whatever was written
-// (wire-probed 2026-09-06), so no read can witness whether the server kept it.
+// from state because Jamf allocates them at apply. There is no
+// self_service_description to assert: the attribute is gone, because the classic
+// API wrote it into general.description and never echoed it back (issue #393).
 func omitRetainedOnServer(t *testing.T, f omitRetainsFixtures) resource.TestCheckFunc {
 	c := testhelpers.NewProClassicClient(t)
 	const addr = "jamfplatform_pro_mobile_device_configuration_profile.test"
@@ -1639,7 +1634,6 @@ func TestAccResource_MobileDeviceConfigurationProfile_OmittedBlocksRetained(t *t
 				Config: omitRetainsGeneralOnlyConfig(name, payload, f),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckNoResourceAttr(addr, "scope.targets.mobile_device_group_ids.#"),
-					resource.TestCheckNoResourceAttr(addr, "self_service.self_service_description"),
 					omitRetainedOnServer(t, f),
 				),
 			},

--- a/internal/resources/pro/mobile_device_configuration_profile/schema_test.go
+++ b/internal/resources/pro/mobile_device_configuration_profile/schema_test.go
@@ -86,13 +86,16 @@ func TestResource_SelfServiceAttributes(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected self_service to be SingleNestedAttribute")
 	}
-	for _, child := range []string{"self_service_description", "feature_on_main_page", "removal_disallowed", "authorization_password", "categories"} {
+	for _, child := range []string{"feature_on_main_page", "removal_disallowed", "authorization_password", "categories"} {
 		if _, ok := ss.Attributes[child]; !ok {
 			t.Fatalf("expected self_service.%s", child)
 		}
 	}
-	// mobile does NOT have notification or display_name attrs
-	for _, absent := range []string{"self_service_display_name", "install_button_text", "display_notifications", "notification_location", "notification_subject", "notification_message"} {
+	// mobile does NOT have notification or display_name attrs, and
+	// self_service_description is gone: the classic API wrote it into
+	// general.description and never echoed it, so the attribute could only
+	// overwrite a sibling (issue #393).
+	for _, absent := range []string{"self_service_description", "self_service_display_name", "install_button_text", "display_notifications", "notification_location", "notification_subject", "notification_message"} {
 		if _, ok := ss.Attributes[absent]; ok {
 			t.Fatalf("self_service.%s must not exist on mobile profiles", absent)
 		}

--- a/internal/resources/pro/mobile_device_configuration_profile/schema_test.go
+++ b/internal/resources/pro/mobile_device_configuration_profile/schema_test.go
@@ -77,6 +77,11 @@ func TestResource_ScopeAttributes(t *testing.T) {
 	}
 }
 
+// TestResource_SelfServiceAttributes pins the block's shape, including what it
+// deliberately lacks. The mobile profile has no notification or display-name
+// attributes, and no self_service_description: Jamf Pro stored that one as the
+// profile's general description and never returned it, so the attribute could
+// only overwrite a value the practitioner had set (issue #393).
 func TestResource_SelfServiceAttributes(t *testing.T) {
 	t.Parallel()
 	r := NewResource()
@@ -91,10 +96,6 @@ func TestResource_SelfServiceAttributes(t *testing.T) {
 			t.Fatalf("expected self_service.%s", child)
 		}
 	}
-	// mobile does NOT have notification or display_name attrs, and
-	// self_service_description is gone: the classic API wrote it into
-	// general.description and never echoed it, so the attribute could only
-	// overwrite a sibling (issue #393).
 	for _, absent := range []string{"self_service_description", "self_service_display_name", "install_button_text", "display_notifications", "notification_location", "notification_subject", "notification_message"} {
 		if _, ok := ss.Attributes[absent]; ok {
 			t.Fatalf("self_service.%s must not exist on mobile profiles", absent)

--- a/internal/resources/pro/mobile_device_configuration_profile/state_builders.go
+++ b/internal/resources/pro/mobile_device_configuration_profile/state_builders.go
@@ -361,7 +361,6 @@ func flattenSelfService(ss *proclassic.MobileDeviceConfigurationProfileSelfServi
 	if ss == nil {
 		return
 	}
-	state.SelfServiceDescription = helpers.PreserveStringWhenWireEmpty(ss.SelfServiceDescription, state.SelfServiceDescription)
 	state.FeatureOnMainPage = helpers.ReconcileOptionalBoolPointer(ss.FeatureOnMainPage, state.FeatureOnMainPage)
 
 	if ss.Security != nil {

--- a/internal/resources/pro/mobile_device_configuration_profile/state_builders_test.go
+++ b/internal/resources/pro/mobile_device_configuration_profile/state_builders_test.go
@@ -525,3 +525,31 @@ func TestAssignResourceModel_IncludeUnmanagedHydratesFromScratch(t *testing.T) {
 		t.Fatalf("expected SelfService hydrated; got nil")
 	}
 }
+
+// TestBuildSelfService_NeverSendsASelfServiceDescription pins that the input
+// builder emits no <self_service_description>, and says why, because the
+// obvious "the schema is missing a field the API has" reading is wrong.
+//
+// Wire-probed 2026-09-07 across eighteen create and update combinations: the
+// element is a write-alias for <description>. Whatever it carried replaced
+// general.description, an empty value wiped it, and the read returned an empty
+// element every time. Sending it can only overwrite a sibling the practitioner
+// set, so the attribute was removed (issue #393). The admin UI does show a
+// separate Self Service description and the macOS profile endpoint keeps the two
+// independent, so this is a Jamf Pro defect; if it is fixed, restore the
+// attribute rather than reviving the element here on its own.
+func TestBuildSelfService_NeverSendsASelfServiceDescription(t *testing.T) {
+	ss, diags := buildSelfService(&SelfServiceModel{
+		FeatureOnMainPage: types.BoolValue(true),
+		RemovalDisallowed: types.StringValue("Never"),
+	})
+	if diags.HasError() {
+		t.Fatalf("diags: %v", diags)
+	}
+	if ss == nil {
+		t.Fatal("self_service payload must be built")
+	}
+	if ss.SelfServiceDescription != nil {
+		t.Errorf("self_service_description must never be sent; got %q", *ss.SelfServiceDescription)
+	}
+}


### PR DESCRIPTION
Closes #393.

## What the probe found

`<self_service_description>` on the classic mobile-profile endpoint is a **write-alias for `<description>`**. Eighteen combinations, EU test tenant, Jamf Pro 11.31.1, 2026-09-07:

```
sent g | sent ss | ss block || got g | got ss
GEN    | omitted | yes      || GEN   | ""      ← description survives
GEN    | SELF    | yes      || SELF  | ""      ← clobbered
GEN    | ""      | yes      || ""    | ""      ← WIPED by an empty one
nil    | SELF    | yes      || SELF  | ""
```

`deployment_method` made no difference (the `Install Automatically` and `Make Available in Self Service` halves matched row for row), and update behaved the same as create. `self_service_description` read back `""` in every one of the eighteen.

Declaring both attributes with different values failed every apply:

```
Error: Provider produced inconsistent result after apply
.general.description: was cty.StringVal("GENERAL-DESC-393"),
                      but now cty.StringVal("SELFSERVICE-DESC-393")
```

So the attribute could not be written to its own field, could not be read, and its only observable effect was overwriting a sibling the practitioner had set.

## Why removal rather than a validator

The sibling resources settle it. `mobile_device_app` is the mirror image: there `self_service_description` is written **and** echoed, while `general.description` cannot be written on its own (`g=GEN, ss=nil` returns both empty), which matches an admin UI that offers only a Self Service description. `macos_configuration_profile` keeps its two fields genuinely independent.

Each object has exactly one real description field, and the provider should expose that one. The app already does. This profile exposed both, and the dead one silently overwrote the real one.

Removal also keeps the schema simple. An earlier draft paired `ConflictsWith` with a mirror plan modifier; with the dead attribute gone, `general.description` needs neither. It stays plain `Optional + Computed`, and `UseStateForUnknown()` remains correct because nothing else can change the value behind it.

This follows #388's precedent for `policy.printers.leave_existing_default` and `managed_password_length`: a dead element means the attribute goes, rather than being deprecated.

## No state upgrader, verified rather than assumed

I built the prior provider and this one side by side and migrated real state:

1. Prior build created a profile with `self_service_description = "OLD-SS-DESC"`. State recorded it, `schema_version = 0`.
2. This build, attribute removed, no version bump, no upgrader: `terraform plan` reports **`No changes`**, and apply is clean.
3. State comes back without the attribute, and `general.description = "OLD-SS-DESC"` — where Jamf Pro had been keeping it all along.

Terraform drops the attribute when decoding old state against the narrower schema, so the migration documents itself: the practitioner's text shows up in the field that was actually holding it. A practitioner who leaves the attribute in configuration gets `Unsupported argument`, which is the right error.

## Also settled: the categories half of #393

PR #398's `display_in` fix resolved it. Verified live: the GET now returns `{ID: 909, Name: "tf-393-cat-a"}` and a plan straight after create reports `No changes`. No PI needed there.

## This is a Jamf Pro defect, and the schema says so

The admin UI does present a separate Self Service description (Self Service tab → Description) alongside the General one, and the macOS profile endpoint keeps its two fields independent. So the classic API is misrouting an element it should honour. `general.description` now explains that Jamf Pro reuses it as the Self Service description, and tells you to set both in the admin UI and leave the attribute unset if you need them to differ.

If Jamf fixes the API, restore the attribute rather than reviving the wire element on its own. `TestBuildSelfService_NeverSendsASelfServiceDescription` carries that reasoning, because "the schema is missing a field the API has" is the obvious wrong reading.

## Breaking change

Anyone setting `self_service_description` on this resource must drop it. They were overwriting `general.description` without being told, so their profiles already carry that text in the field this attribute now names.

Acceptance suite green against the live tenant. Every probe object deleted; a sweep across mobile profiles, mobile apps and macOS profiles found no leftovers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
