### PR TITLE
fix(cloud_identity_provider): preserve Entra attribute mappings on omission (#404)

### DIFF
--- a/docs/resources/pro_cloud_identity_provider.md
+++ b/docs/resources/pro_cloud_identity_provider.md
@@ -108,7 +108,7 @@ Required:
 Optional:
 
 - `enabled` (Boolean) Whether the Entra ID connection is enabled. Defaults to `true`.
-- `mappings` (Attributes) Entra ID attribute mappings. Omit the block to let Jamf Pro generate defaults, or supply it to override them. (see [below for nested schema](#nestedatt--entra_id--mappings))
+- `mappings` (Attributes) Entra ID attribute mappings. Omit the block to leave the connection's current mappings untouched. Jamf Pro supplies no defaults here, so a connection created without the block has all eleven mappings empty. Declare it and Terraform owns every field: a field you leave out inside the block clears that mapping. (see [below for nested schema](#nestedatt--entra_id--mappings))
 - `membership_calculation_optimization_enabled` (Boolean) Whether membership-calculation optimization is enabled. Defaults to `false`.
 - `search_timeout` (Number) Search timeout in seconds. Defaults to `30`.
 - `transitive_directory_membership_enabled` (Boolean) Whether transitive directory membership is enabled. Defaults to `false`.

--- a/internal/resources/pro/cloud_identity_provider/crud_azure.go
+++ b/internal/resources/pro/cloud_identity_provider/crud_azure.go
@@ -6,6 +6,7 @@ package cloud_identity_provider
 import (
 	"context"
 
+	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/pro"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -80,12 +81,30 @@ func (r *CloudIdentityProviderResource) readAzure(ctx context.Context, state *Cl
 
 // updateAzure full-replaces via PUT /v1/cloud-azure/{id}, then GET.
 // The state and cfg args are unused for Azure.
+//
+// A configuration that declares no mappings block costs an extra GET first: the
+// eleven mapping keys are always on the wire, so preserving what the connection
+// holds means reading it before writing it back (#404, see buildAzureMappings).
+// A declared block needs no merge base and skips the read.
 func (r *CloudIdentityProviderResource) updateAzure(ctx context.Context, plan, _, _ CloudIdentityProviderResourceModel, resp *resource.UpdateResponse) {
 	if plan.Azure == nil {
 		resp.Diagnostics.AddError(missingProviderBlockError(providerEntraID, "entra_id"))
 		return
 	}
-	body := buildAzureUpdateRequest(plan)
+
+	var liveMappings *pro.AzureMappings
+	if plan.Azure.Mappings == nil {
+		live, err := r.client.GetCloudAzureV1(ctx, plan.ID.ValueString())
+		if err != nil {
+			resp.Diagnostics.AddError("Error reading Jamf Pro Cloud Identity Provider (Azure) attribute mappings", err.Error())
+			return
+		}
+		if live != nil && live.Server != nil {
+			liveMappings = live.Server.Mappings
+		}
+	}
+
+	body := buildAzureUpdateRequest(plan, liveMappings)
 
 	if _, err := r.client.UpdateCloudAzureV1(ctx, plan.ID.ValueString(), body); err != nil {
 		resp.Diagnostics.AddError("Error updating Jamf Pro Cloud Identity Provider (Azure)", err.Error())

--- a/internal/resources/pro/cloud_identity_provider/input_builders_azure.go
+++ b/internal/resources/pro/cloud_identity_provider/input_builders_azure.go
@@ -39,7 +39,7 @@ func buildAzureCreateRequest(plan CloudIdentityProviderResourceModel) *pro.Azure
 			TransitiveMembershipEnabled:              az.TransitiveMembershipEnabled.ValueBool(),
 			TransitiveMembershipUserField:            az.TransitiveMembershipUserField.ValueString(),
 			TransitiveDirectoryMembershipEnabled:     az.TransitiveDirectoryMembershipEnabled.ValueBool(),
-			Mappings:                                 buildAzureMappings(az.Mappings),
+			Mappings:                                 buildAzureMappings(az.Mappings, nil),
 			// ID and Type are omitempty *string — left nil on create.
 		},
 	}
@@ -48,7 +48,12 @@ func buildAzureCreateRequest(plan CloudIdentityProviderResourceModel) *pro.Azure
 // buildAzureUpdateRequest assembles the Azure Cloud Identity Provider update
 // body from the plan. There is no Code, TenantID, or Type on the update shape.
 // Server.ID is the same as the CloudIdP id (the TF state id).
-func buildAzureUpdateRequest(plan CloudIdentityProviderResourceModel) *pro.AzureConfigurationUpdate {
+//
+// live carries the connection's stored attribute mappings, for the case where
+// the configuration declares no mappings block — see buildAzureMappings. The
+// caller reads them only in that case, so it is nil whenever the block is
+// authored.
+func buildAzureUpdateRequest(plan CloudIdentityProviderResourceModel, live *pro.AzureMappings) *pro.AzureConfigurationUpdate {
 	az := plan.Azure
 	return &pro.AzureConfigurationUpdate{
 		CloudIDPCommon: pro.CloudIDPCommon{
@@ -64,16 +69,42 @@ func buildAzureUpdateRequest(plan CloudIdentityProviderResourceModel) *pro.Azure
 			TransitiveMembershipEnabled:              az.TransitiveMembershipEnabled.ValueBool(),
 			TransitiveMembershipUserField:            az.TransitiveMembershipUserField.ValueString(),
 			TransitiveDirectoryMembershipEnabled:     az.TransitiveDirectoryMembershipEnabled.ValueBool(),
-			Mappings:                                 buildAzureMappings(az.Mappings),
+			Mappings:                                 buildAzureMappings(az.Mappings, live),
 		},
 	}
 }
 
-// buildAzureMappings converts the TF mappings model to the SDK struct. When m
-// is nil a zero AzureMappings is returned so the non-pointer field is always
-// present on the wire (the server generates defaults for empty values).
-func buildAzureMappings(m *cloudAzureMappingsModel) pro.AzureMappings {
+// buildAzureMappings converts the TF mappings model to the SDK struct.
+//
+// Mappings is a non-pointer field on both request shapes with no omitempty, so
+// all eleven keys are always on the wire and there is no way to omit them. Jamf
+// Pro stores exactly what it is sent and generates nothing — wire-probed on the
+// EU tenant 2026-09-07 and recorded above azureMappingsAreWireEmpty. So an
+// undeclared block would send eleven empty strings and wipe whatever mappings
+// the connection holds (#404).
+//
+// live is the answer: when the configuration declares no block, the connection's
+// stored mappings go back out unchanged and the omission preserves them, the
+// same contract every other undeclared block in the provider keeps. A create
+// passes nil because a connection being minted has nothing to preserve, and the
+// zero value it sends is what the read path recognises as never-written.
+//
+// A declared block stays authoritative, down to the field: a leaf the
+// configuration omits inside one is written empty and clears that mapping, which
+// is the block-versus-field split mobile_device_enrollment_profile documents.
+//
+// The erasure itself could not be observed on the wire: every PUT to an
+// unconsented Entra connection is refused 400 INVALID_CONNECTION before it
+// reaches persistence (probed 2026-09-08 — the stored mappings were byte
+// identical afterwards), and a consented connection needs a real Entra tenant
+// that has completed the interactive consent step in the admin UI. Carrying the
+// stored mappings across is correct under both readings: a no-op if the server
+// would have preserved them, a rescue if it would not.
+func buildAzureMappings(m *cloudAzureMappingsModel, live *pro.AzureMappings) pro.AzureMappings {
 	if m == nil {
+		if live != nil {
+			return *live
+		}
 		return pro.AzureMappings{}
 	}
 	return pro.AzureMappings{

--- a/internal/resources/pro/cloud_identity_provider/input_builders_test.go
+++ b/internal/resources/pro/cloud_identity_provider/input_builders_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/base64"
 	"testing"
 
+	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/pro"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -292,7 +293,7 @@ func TestBuildAzureUpdateRequest_ServerIDFromPlanID(t *testing.T) {
 	plan := minimalAzurePlan("11111111-2222-3333-4444-555555555557")
 	plan.ID = types.StringValue("azure-server-id-abc")
 
-	got := buildAzureUpdateRequest(plan)
+	got := buildAzureUpdateRequest(plan, nil)
 	if got.Server.ID != "azure-server-id-abc" {
 		t.Errorf("Server.ID must equal plan ID; got %q", got.Server.ID)
 	}
@@ -309,7 +310,7 @@ func TestBuildAzureUpdateRequest_NoCode(t *testing.T) {
 	plan.ID = types.StringValue("some-id")
 	// buildAzureUpdateRequest returns AzureConfigurationUpdate which has no Code
 	// field — this test confirms the function compiles and returns a non-nil result.
-	got := buildAzureUpdateRequest(plan)
+	got := buildAzureUpdateRequest(plan, nil)
 	if got == nil {
 		t.Errorf("buildAzureUpdateRequest must not return nil")
 	}
@@ -317,12 +318,48 @@ func TestBuildAzureUpdateRequest_NoCode(t *testing.T) {
 
 // --- buildAzureMappings ------------------------------------------------------
 
-// TestBuildAzureMappings_NilReturnsEmpty verifies that nil mappings produces a
-// zero AzureMappings struct (all empty strings), not a nil pointer.
+// TestBuildAzureMappings_NilReturnsEmpty verifies that nil mappings with no
+// merge base produces a zero AzureMappings struct (all empty strings), not a nil
+// pointer. That is the create path: nothing declared and nothing to preserve.
 func TestBuildAzureMappings_NilReturnsEmpty(t *testing.T) {
-	got := buildAzureMappings(nil)
+	got := buildAzureMappings(nil, nil)
 	if got.UserID != "" || got.Email != "" || got.GroupName != "" {
 		t.Errorf("nil mappings must produce zero AzureMappings; got %+v", got)
+	}
+}
+
+// TestBuildAzureMappings_UndeclaredBlockCarriesTheStoredMappings pins #404. The
+// eleven keys are always on the wire and Jamf Pro stores what it is sent, so an
+// undeclared block sending empty strings wipes the connection's mappings. The
+// stored set goes back out instead, which is what makes the omission preserve.
+func TestBuildAzureMappings_UndeclaredBlockCarriesTheStoredMappings(t *testing.T) {
+	live := &pro.AzureMappings{
+		UserID:    "id",
+		UserName:  "userPrincipalName",
+		Email:     "mail",
+		GroupName: "displayName",
+	}
+
+	got := buildAzureMappings(nil, live)
+	if got.UserID != "id" || got.UserName != "userPrincipalName" || got.Email != "mail" || got.GroupName != "displayName" {
+		t.Errorf("an undeclared block must carry the stored mappings; got %+v", got)
+	}
+}
+
+// TestBuildAzureMappings_DeclaredBlockIgnoresTheStoredMappings pins the other
+// half of the contract: a declared block is authoritative, so a field left out
+// inside it is written empty and clears that mapping rather than inheriting what
+// the connection holds.
+func TestBuildAzureMappings_DeclaredBlockIgnoresTheStoredMappings(t *testing.T) {
+	live := &pro.AzureMappings{UserID: "id", Email: "mail"}
+	m := &cloudAzureMappingsModel{UserID: types.StringValue("objectId")}
+
+	got := buildAzureMappings(m, live)
+	if got.UserID != "objectId" {
+		t.Errorf("the declared field must win; got %q", got.UserID)
+	}
+	if got.Email != "" {
+		t.Errorf("a field omitted inside a declared block must be written empty, got %q", got.Email)
 	}
 }
 
@@ -343,7 +380,7 @@ func TestBuildAzureMappings_FieldsRoundTrip(t *testing.T) {
 		GroupName:  types.StringValue("displayName"),
 	}
 
-	got := buildAzureMappings(m)
+	got := buildAzureMappings(m, nil)
 	if got.UserID != "id" {
 		t.Errorf("UserID mismatch")
 	}

--- a/internal/resources/pro/cloud_identity_provider/resource.go
+++ b/internal/resources/pro/cloud_identity_provider/resource.go
@@ -240,7 +240,7 @@ func (r *CloudIdentityProviderResource) Schema(ctx context.Context, req resource
 					"migrated":           computedBool("Whether the connection has been migrated. Read-only."),
 					"deprecated_consent": computedBool("Whether the connection uses a deprecated consent flow. Read-only."),
 					"mappings": schema.SingleNestedAttribute{
-						MarkdownDescription: "Entra ID attribute mappings. Omit the block to let Jamf Pro generate defaults, or supply it to override them.",
+						MarkdownDescription: "Entra ID attribute mappings. Omit the block to leave the connection's current mappings untouched. Jamf Pro supplies no defaults here, so a connection created without the block has all eleven mappings empty. Declare it and Terraform owns every field: a field you leave out inside the block clears that mapping.",
 						Optional:            true,
 						Attributes: map[string]schema.Attribute{
 							"user_id":    nestedOptString("Attribute mapped to user ID (e.g. `id`)."),

--- a/internal/resources/pro/cloud_identity_provider/resource_acceptance_test.go
+++ b/internal/resources/pro/cloud_identity_provider/resource_acceptance_test.go
@@ -375,6 +375,14 @@ resource "jamfplatform_pro_cloud_identity_provider" "test" {
 // TestAccResource_ProCloudIdentityProvider_Azure_UpdateSkipped is an explicit
 // skip placeholder. It appears in test output so the omission is visible and
 // documented rather than silent.
+//
+// One consequence is worth naming, because it is the reason #404 was fixed
+// blind: the mappings-preserving merge base the Entra update now builds has no
+// acceptance coverage and cannot have any here. The refusal lands before
+// persistence — probed 2026-09-08, an update sending eleven empty mappings to an
+// unconsented connection left the stored ones byte identical — so nothing on
+// this estate can observe either the erasure or the fix. The unit tests over
+// buildAzureMappings are the whole guard.
 func TestAccResource_ProCloudIdentityProvider_Azure_UpdateSkipped(t *testing.T) {
 	t.Skip("Azure update requires a real consented Entra connection; PUT 400 INVALID_CONNECTION otherwise — see resource docs")
 }


### PR DESCRIPTION
Closes #404.

The Entra ID update carried all eleven `entra_id.mappings` keys and carried them
empty when the configuration did not declare the block. Jamf Pro stores exactly
what it is sent and generates nothing, so an apply changing any other attribute
on a connection whose attribute mappings were set elsewhere wiped all eleven.

## The fix

`Mappings` is a non-pointer field on both request shapes with no `omitempty`, so
there is no key to omit. The update reads the connection first when the block is
undeclared and sends its stored mappings straight back: one extra GET in that
case, none when the block is authored. A declared block stays authoritative down
to the field, so a leaf left out inside one is written empty and clears that
mapping.

Google is unaffected. Its mappings request is a pointer with `omitempty` and the
builder returns nil for an undeclared block, so the key never reaches the wire.

## What is proven and what is not

Proven on the wire (EU test tenant, 2026-09-08):

- `POST /pro/v1/cloud-azure` with populated mappings answers `201`, and a `GET`
  reads all eleven back verbatim.
- `PUT` with all-empty mappings on that connection answers `400`
  `INVALID_CONNECTION` "Azure AD connection verification failed.", and a `GET`
  afterwards is byte-identical. The refusal lands before persistence.

Not proven: the same PUT against a **consented** connection, which needs a real
Entra tenant that has completed the interactive consent step in the admin UI.
That is the same wall that made the Azure update acceptance round-trip a
documented `t.Skip` when this resource was built, and it is why there is no
acceptance coverage here — recorded on that skip.

So the erasure is an inference from two facts, not a wire observation: the body
always carries eleven empty strings, and the create path proves the server
stores what mappings it is sent. The fix is correct either way — a no-op if the
server would have preserved them, a rescue if it would not.

The false claim in `buildAzureMappings` ("the server generates defaults for
empty values") is gone; the probe that disproves it was already recorded two
functions away, above `azureMappingsAreWireEmpty`.

## Verification

`make fix fmt lint test` clean, three new unit tests over the builder.
Acceptance not run — needs the Pro estate, and the update path cannot be
covered there at all.
