### PR TITLE
fix(pro): hydrate list results whose endpoint returns only a summary row

### DIFF
--- a/internal/resources/pro/advanced_computer_search/list_resource.go
+++ b/internal/resources/pro/advanced_computer_search/list_resource.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/list"
 	listschema "github.com/hashicorp/terraform-plugin-framework/list/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/filters"
@@ -23,6 +22,10 @@ import (
 // defaultListTimeout caps how long the list operation waits on the classic
 // /advancedcomputersearches endpoint.
 const defaultListTimeout = 90 * time.Second
+
+// defaultItemReadTimeout bounds each per-item hydration GET issued when
+// IncludeResource asks for full resource state.
+const defaultItemReadTimeout = 30 * time.Second
 
 var _ list.ListResource = &AdvancedComputerSearchListResource{}
 var _ list.ListResourceWithConfigure = &AdvancedComputerSearchListResource{}
@@ -36,8 +39,8 @@ func NewAdvancedComputerSearchListResource() list.ListResource {
 // AdvancedComputerSearchListResource implements Terraform query list support.
 // Classic /advancedcomputersearches has no RSQL — the optional `filter` block is
 // applied client-side via filters.ApplyClassicFilter after the full list is
-// fetched. List items carry only id and name on the wire; every other resource
-// attribute is set to null on list results.
+// fetched. List items carry only id and name on the wire, so IncludeResource
+// hydrates each record with a singular GET.
 type AdvancedComputerSearchListResource struct {
 	client *proclassic.Client
 }
@@ -137,16 +140,30 @@ func (r *AdvancedComputerSearchListResource) List(ctx context.Context, req list.
 		}
 
 		if req.IncludeResource {
-			// List response carries id and name only. Every other Optional/Computed
-			// attribute is null on list results.
+			// The /advancedcomputersearches list response carries id and name only. A list
+			// result with null criteria makes `terraform query
+			// -generate-config-out` write a search with no criteria at all, and
+			// applying that config back would delete the ones the search
+			// actually has — so follow up with a singular GET and hydrate from
+			// the same state builder Read uses.
+			itemCtx, cancel := context.WithTimeout(ctx, defaultItemReadTimeout)
+			full, err := r.client.GetAdvancedComputerSearchByID(itemCtx, id.ValueString())
+			cancel()
+			if err != nil {
+				tflog.Warn(ctx, "Skipping advanced computer search from generated config after per-item read failure", map[string]any{
+					"id":    id.ValueString(),
+					"error": err.Error(),
+				})
+				continue
+			}
 			state := AdvancedComputerSearchResourceModel{
-				ID:            id,
-				Name:          helpers.StringPointerValueOrNull(s.Name),
-				SiteID:        types.StringNull(),
-				SiteName:      types.StringNull(),
-				Criteria:      nil,
-				DisplayFields: types.SetNull(types.StringType),
-				Timeouts:      helpers.NewResourceTimeoutsNullValue(advancedComputerSearchTimeoutAttributeTypes),
+				ID:       id,
+				Timeouts: helpers.NewResourceTimeoutsNullValue(advancedComputerSearchTimeoutAttributeTypes),
+			}
+			result.Diagnostics.Append(assignAdvancedComputerSearchResourceModel(itemCtx, &state, full)...)
+			if result.Diagnostics.HasError() {
+				stream.Results = list.ListResultsStreamDiagnostics(result.Diagnostics)
+				return
 			}
 			result.Diagnostics.Append(result.Resource.Set(ctx, &state)...)
 			if result.Diagnostics.HasError() {

--- a/internal/resources/pro/advanced_computer_search/permissions.go
+++ b/internal/resources/pro/advanced_computer_search/permissions.go
@@ -47,6 +47,9 @@ var dataSourcePrivileges = permissions.Section(proclassic.Privileges, dataSource
 // privilege registry.
 var listResourceSDKMethods = []string{
 	"ListAdvancedComputerSearches",
+	// The per-item hydration GET the list resource issues when
+	// IncludeResource asks for full resource state.
+	"GetAdvancedComputerSearchByID",
 }
 
 // listResourcePrivileges is the rendered "Required Jamf permissions" Markdown

--- a/internal/resources/pro/advanced_computer_search/resource_acceptance_test.go
+++ b/internal/resources/pro/advanced_computer_search/resource_acceptance_test.go
@@ -325,6 +325,14 @@ func TestAccListResource_ProAdvancedComputerSearch_Basic(t *testing.T) {
 						queryfilter.ByDisplayName(knownvalue.StringExact(name)),
 						[]querycheck.KnownValueCheck{
 							{Path: tfjsonpath.New("name"), KnownValue: knownvalue.StringExact(name)},
+							// criteria is NOT in the /advancedcomputersearches summary
+							// row, which carries id and name only. Asserting name alone
+							// is what let a list resource emitting null criteria pass:
+							// `terraform query -generate-config-out` then wrote a search
+							// with no criteria, and applying it back deleted the real
+							// ones. This pins the per-item GET.
+							{Path: tfjsonpath.New("criteria").AtSliceIndex(0).AtMapKey("name"), KnownValue: knownvalue.StringExact("Computer Name")},
+							{Path: tfjsonpath.New("criteria").AtSliceIndex(0).AtMapKey("value"), KnownValue: knownvalue.StringExact("lab")},
 						},
 					),
 				},

--- a/internal/resources/pro/advanced_user_search/list_resource.go
+++ b/internal/resources/pro/advanced_user_search/list_resource.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/list"
 	listschema "github.com/hashicorp/terraform-plugin-framework/list/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/filters"
@@ -23,6 +22,10 @@ import (
 // defaultListTimeout caps how long the list operation waits on the classic
 // /advancedusersearches endpoint.
 const defaultListTimeout = 90 * time.Second
+
+// defaultItemReadTimeout bounds each per-item hydration GET issued when
+// IncludeResource asks for full resource state.
+const defaultItemReadTimeout = 30 * time.Second
 
 var _ list.ListResource = &AdvancedUserSearchListResource{}
 var _ list.ListResourceWithConfigure = &AdvancedUserSearchListResource{}
@@ -36,8 +39,8 @@ func NewAdvancedUserSearchListResource() list.ListResource {
 // AdvancedUserSearchListResource implements Terraform query list support.
 // Classic /advancedusersearches has no RSQL — the optional `filter` block is
 // applied client-side via filters.ApplyClassicFilter after the full list is
-// fetched. List items carry only id and name on the wire; every other resource
-// attribute is set to null on list results.
+// fetched. List items carry only id and name on the wire, so IncludeResource
+// hydrates each record with a singular GET.
 type AdvancedUserSearchListResource struct {
 	client *proclassic.Client
 }
@@ -137,16 +140,30 @@ func (r *AdvancedUserSearchListResource) List(ctx context.Context, req list.List
 		}
 
 		if req.IncludeResource {
-			// List response carries id and name only. Every other Optional/Computed
-			// attribute is null on list results.
+			// The /advancedusersearches list response carries id and name only. A list
+			// result with null criteria makes `terraform query
+			// -generate-config-out` write a search with no criteria at all, and
+			// applying that config back would delete the ones the search
+			// actually has — so follow up with a singular GET and hydrate from
+			// the same state builder Read uses.
+			itemCtx, cancel := context.WithTimeout(ctx, defaultItemReadTimeout)
+			full, err := r.client.GetAdvancedUserSearchByID(itemCtx, id.ValueString())
+			cancel()
+			if err != nil {
+				tflog.Warn(ctx, "Skipping advanced user search from generated config after per-item read failure", map[string]any{
+					"id":    id.ValueString(),
+					"error": err.Error(),
+				})
+				continue
+			}
 			state := AdvancedUserSearchResourceModel{
-				ID:            id,
-				Name:          helpers.StringPointerValueOrNull(s.Name),
-				SiteID:        types.StringNull(),
-				SiteName:      types.StringNull(),
-				Criteria:      nil,
-				DisplayFields: types.SetNull(types.StringType),
-				Timeouts:      helpers.NewResourceTimeoutsNullValue(advancedUserSearchTimeoutAttributeTypes),
+				ID:       id,
+				Timeouts: helpers.NewResourceTimeoutsNullValue(advancedUserSearchTimeoutAttributeTypes),
+			}
+			result.Diagnostics.Append(assignAdvancedUserSearchResourceModel(itemCtx, &state, full)...)
+			if result.Diagnostics.HasError() {
+				stream.Results = list.ListResultsStreamDiagnostics(result.Diagnostics)
+				return
 			}
 			result.Diagnostics.Append(result.Resource.Set(ctx, &state)...)
 			if result.Diagnostics.HasError() {

--- a/internal/resources/pro/advanced_user_search/permissions.go
+++ b/internal/resources/pro/advanced_user_search/permissions.go
@@ -42,6 +42,9 @@ var dataSourcePrivileges = permissions.Section(proclassic.Privileges, dataSource
 // resource's List path calls.
 var listResourceSDKMethods = []string{
 	"ListAdvancedUserSearches",
+	// The per-item hydration GET the list resource issues when
+	// IncludeResource asks for full resource state.
+	"GetAdvancedUserSearchByID",
 }
 
 // listResourcePrivileges is the rendered "Required Jamf permissions" Markdown

--- a/internal/resources/pro/advanced_user_search/resource_acceptance_test.go
+++ b/internal/resources/pro/advanced_user_search/resource_acceptance_test.go
@@ -344,6 +344,14 @@ func TestAccListResource_ProAdvancedUserSearch_Basic(t *testing.T) {
 						queryfilter.ByDisplayName(knownvalue.StringExact(name)),
 						[]querycheck.KnownValueCheck{
 							{Path: tfjsonpath.New("name"), KnownValue: knownvalue.StringExact(name)},
+							// criteria is NOT in the /advancedusersearches summary row,
+							// which carries id and name only. Asserting name alone is
+							// what let a list resource emitting null criteria pass:
+							// `terraform query -generate-config-out` then wrote a search
+							// with no criteria, and applying it back deleted the real
+							// ones. This pins the per-item GET.
+							{Path: tfjsonpath.New("criteria").AtSliceIndex(0).AtMapKey("name"), KnownValue: knownvalue.StringExact("Full Name")},
+							{Path: tfjsonpath.New("criteria").AtSliceIndex(0).AtMapKey("value"), KnownValue: knownvalue.StringExact("a")},
 						},
 					),
 				},

--- a/internal/resources/pro/class/list_resource.go
+++ b/internal/resources/pro/class/list_resource.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/list"
 	listschema "github.com/hashicorp/terraform-plugin-framework/list/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/filters"
@@ -23,6 +22,10 @@ import (
 // defaultListTimeout caps how long the list operation waits on the classic
 // /classes endpoint.
 const defaultListTimeout = 90 * time.Second
+
+// defaultItemReadTimeout bounds each per-item hydration GET issued when
+// IncludeResource asks for full resource state.
+const defaultItemReadTimeout = 30 * time.Second
 
 var _ list.ListResource = &ClassListResource{}
 var _ list.ListResourceWithConfigure = &ClassListResource{}
@@ -135,23 +138,30 @@ func (r *ClassListResource) List(ctx context.Context, req list.ListRequest, stre
 		}
 
 		if req.IncludeResource {
-			// List response carries id, name, and description only. Every membership
-			// attribute is null on list results.
+			// The list response carries id, name and description only. A list
+			// result with null membership makes `terraform query
+			// -generate-config-out` write a class with no students, teachers or
+			// groups, and applying that config back would empty the class —
+			// membership is authoritative on write. Follow up with a singular
+			// GET and hydrate from the same state builder Read uses.
+			itemCtx, cancel := context.WithTimeout(ctx, defaultItemReadTimeout)
+			full, err := r.client.GetClassByID(itemCtx, id.ValueString())
+			cancel()
+			if err != nil {
+				tflog.Warn(ctx, "Skipping class from generated config after per-item read failure", map[string]any{
+					"id":    id.ValueString(),
+					"error": err.Error(),
+				})
+				continue
+			}
 			state := ClassResourceModel{
-				ID:                   id,
-				Name:                 helpers.StringPointerValueOrNull(c.Name),
-				Description:          helpers.StringPointerValueOrNull(c.Description),
-				SiteID:               types.StringNull(),
-				SiteName:             types.StringNull(),
-				Source:               types.StringNull(),
-				Students:             types.SetNull(types.StringType),
-				Teachers:             types.SetNull(types.StringType),
-				StudentGroupIDs:      types.SetNull(types.StringType),
-				TeacherGroupIDs:      types.SetNull(types.StringType),
-				MobileDeviceGroupIDs: types.SetNull(types.StringType),
-				StudentIDs:           types.SetNull(types.StringType),
-				TeacherIDs:           types.SetNull(types.StringType),
-				Timeouts:             helpers.NewResourceTimeoutsNullValue(classTimeoutAttributeTypes),
+				ID:       id,
+				Timeouts: helpers.NewResourceTimeoutsNullValue(classTimeoutAttributeTypes),
+			}
+			result.Diagnostics.Append(assignClassResourceModel(itemCtx, &state, full)...)
+			if result.Diagnostics.HasError() {
+				stream.Results = list.ListResultsStreamDiagnostics(result.Diagnostics)
+				return
 			}
 			result.Diagnostics.Append(result.Resource.Set(ctx, &state)...)
 			if result.Diagnostics.HasError() {

--- a/internal/resources/pro/class/permissions.go
+++ b/internal/resources/pro/class/permissions.go
@@ -40,6 +40,9 @@ var dataSourcePrivileges = permissions.Section(proclassic.Privileges, dataSource
 // listResourceSDKMethods lists the SDK methods the class list resource calls.
 var listResourceSDKMethods = []string{
 	"ListClasses",
+	// The per-item hydration GET the list resource issues when
+	// IncludeResource asks for full resource state.
+	"GetClassByID",
 }
 
 // listResourcePrivileges is the rendered "Required Jamf permissions" Markdown

--- a/internal/resources/pro/class/resource_acceptance_test.go
+++ b/internal/resources/pro/class/resource_acceptance_test.go
@@ -337,7 +337,10 @@ func TestAccListResource_ProClass_Basic(t *testing.T) {
 			{
 				Config: fmt.Sprintf(`
 					resource "jamfplatform_pro_class" "test" {
-						name = %q
+						name        = %q
+						description = "list hydration fixture"
+
+						students = ["tf-acc-class-list-student@example.com"]
 					}
 				`, name),
 				Check: resource.TestCheckResourceAttrSet(classResource, "id"),
@@ -365,6 +368,16 @@ func TestAccListResource_ProClass_Basic(t *testing.T) {
 						queryfilter.ByDisplayName(knownvalue.StringExact(name)),
 						[]querycheck.KnownValueCheck{
 							{Path: tfjsonpath.New("name"), KnownValue: knownvalue.StringExact(name)},
+							// The /classes summary row carries id, name and description
+							// only — never membership. Asserting name alone is what let a
+							// list resource emitting null students/teachers/groups pass,
+							// while `terraform query -generate-config-out` wrote a class
+							// with no members. Membership is authoritative on write, so
+							// applying that back emptied the class. This pins the
+							// per-item GET.
+							{Path: tfjsonpath.New("students"), KnownValue: knownvalue.SetExact([]knownvalue.Check{
+								knownvalue.StringExact("tf-acc-class-list-student@example.com"),
+							})},
 						},
 					),
 				},

--- a/internal/resources/pro/enrollment_customization/list_resource.go
+++ b/internal/resources/pro/enrollment_customization/list_resource.go
@@ -29,6 +29,10 @@ import (
 // enough for tenants with hundreds of customizations.
 const defaultListTimeout = 90 * time.Second
 
+// defaultItemReadTimeout bounds each per-item pane hydration issued when
+// IncludeResource asks for full resource state.
+const defaultItemReadTimeout = 30 * time.Second
+
 var (
 	_ list.ListResource              = &EnrollmentCustomizationListResource{}
 	_ list.ListResourceWithConfigure = &EnrollmentCustomizationListResource{}
@@ -140,14 +144,26 @@ func (r *EnrollmentCustomizationListResource) List(ctx context.Context, req list
 		}
 
 		if req.IncludeResource {
-			// IncludeResource targets the resource schema. The list endpoint
-			// only carries the parent record; panes stay null in the result
-			// state — admins who need pane-level detail should follow up with
-			// a singular resource read by ID.
+			// The list endpoint carries only the parent record. Leaving the
+			// panes null makes `terraform query -generate-config-out` write a
+			// customization with no text, LDAP or SSO panes, and applying that
+			// config back would delete the ones it has — so hydrate them with
+			// the same helper Read uses. Only the panes need fetching; the
+			// parent is already in hand.
 			state := EnrollmentCustomizationResourceModel{
 				Timeouts: helpers.NewResourceTimeoutsNullValue(enrollmentCustomizationTimeoutAttributeTypes),
 			}
 			assignParentToResource(&state, &item)
+			itemCtx, cancel := context.WithTimeout(ctx, defaultItemReadTimeout)
+			err := hydratePanels(itemCtx, r.client, &state)
+			cancel()
+			if err != nil {
+				tflog.Warn(ctx, "Skipping enrollment customization from generated config after pane read failure", map[string]any{
+					"id":    state.ID.ValueString(),
+					"error": err.Error(),
+				})
+				continue
+			}
 			result.Diagnostics.Append(result.Resource.Set(ctx, &state)...)
 			if result.Diagnostics.HasError() {
 				stream.Results = list.ListResultsStreamDiagnostics(result.Diagnostics)

--- a/internal/resources/pro/enrollment_customization/list_resource_acceptance_test.go
+++ b/internal/resources/pro/enrollment_customization/list_resource_acceptance_test.go
@@ -39,6 +39,17 @@ func TestAccListResource_ProEnrollmentCustomization_Basic(t *testing.T) {
 						display_name = %q
 						description  = "tf acc list"
 						%s
+
+						text_panes = [
+							{
+								display_name         = "Welcome"
+								rank                 = 0
+								title                = "Welcome"
+								body                 = "list hydration fixture"
+								previous_button_text = "Back"
+								next_button_text     = "Next"
+							},
+						]
 					}
 				`, name, configCommon()),
 				Check: resource.TestCheckResourceAttrSet("jamfplatform_pro_enrollment_customization.src", "id"),
@@ -66,6 +77,14 @@ func TestAccListResource_ProEnrollmentCustomization_Basic(t *testing.T) {
 						queryfilter.ByDisplayName(knownvalue.StringExact(name)),
 						[]querycheck.KnownValueCheck{
 							{Path: tfjsonpath.New("display_name"), KnownValue: knownvalue.StringExact(name)},
+							// The list endpoint carries the parent record only — panes
+							// live on their own endpoints. Asserting display_name alone
+							// is what let a list resource leaving them null pass, while
+							// `terraform query -generate-config-out` wrote a
+							// customization with no panes, and applying that back deleted
+							// them. This pins the pane hydration.
+							{Path: tfjsonpath.New("text_panes").AtSliceIndex(0).AtMapKey("title"), KnownValue: knownvalue.StringExact("Welcome")},
+							{Path: tfjsonpath.New("text_panes").AtSliceIndex(0).AtMapKey("body"), KnownValue: knownvalue.StringExact("list hydration fixture")},
 						},
 					),
 				},

--- a/internal/resources/pro/licensed_software/list_resource.go
+++ b/internal/resources/pro/licensed_software/list_resource.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/list"
 	listschema "github.com/hashicorp/terraform-plugin-framework/list/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/filters"
@@ -23,6 +22,10 @@ import (
 // defaultListTimeout caps how long the list operation waits on the classic
 // /licensedsoftware endpoint.
 const defaultListTimeout = 90 * time.Second
+
+// defaultItemReadTimeout bounds each per-item hydration GET issued when
+// IncludeResource asks for full resource state.
+const defaultItemReadTimeout = 30 * time.Second
 
 var _ list.ListResource = &LicensedSoftwareListResource{}
 var _ list.ListResourceWithConfigure = &LicensedSoftwareListResource{}
@@ -132,23 +135,31 @@ func (r *LicensedSoftwareListResource) List(ctx context.Context, req list.ListRe
 
 		if req.IncludeResource {
 			// The classic /licensedsoftware list response carries id and name
-			// only. Every other Optional/Computed attribute is null on list
-			// results; full detail requires a per-record read.
+			// only. A list result with null software_definitions and licenses
+			// makes `terraform query -generate-config-out` write a title with
+			// neither, and applying that config back would strip both — so
+			// follow up with a singular GET and hydrate from the same state
+			// builder Read uses. firstHydration is true here for the same
+			// reason it is on an import: the incoming model is unpopulated, so
+			// the wire-present optional lists are the ones to adopt.
+			itemCtx, cancel := context.WithTimeout(ctx, defaultItemReadTimeout)
+			full, err := r.client.GetLicensedSoftwareByID(itemCtx, id.ValueString())
+			cancel()
+			if err != nil {
+				tflog.Warn(ctx, "Skipping licensed software from generated config after per-item read failure", map[string]any{
+					"id":    id.ValueString(),
+					"error": err.Error(),
+				})
+				continue
+			}
 			state := LicensedSoftwareResourceModel{
-				ID:                                 id,
-				Name:                               helpers.StringPointerValueOrNull(item.Name),
-				Publisher:                          types.StringNull(),
-				Platform:                           types.StringNull(),
-				Notes:                              types.StringNull(),
-				SendEmailOnViolation:               types.BoolNull(),
-				RemoveTitlesFromInventoryReports:   types.BoolNull(),
-				ExcludeTitlesPurchasedFromAppStore: types.BoolNull(),
-				SiteID:                             types.StringNull(),
-				SiteName:                           types.StringNull(),
-				SoftwareDefinitions:                nil,
-				Licenses:                           nil,
-				Computers:                          types.ListNull(computerObjectType),
-				Timeouts:                           helpers.NewResourceTimeoutsNullValue(licensedSoftwareTimeoutAttributeTypes),
+				ID:       id,
+				Timeouts: helpers.NewResourceTimeoutsNullValue(licensedSoftwareTimeoutAttributeTypes),
+			}
+			result.Diagnostics.Append(assignLicensedSoftwareResourceModel(itemCtx, &state, full, true)...)
+			if result.Diagnostics.HasError() {
+				stream.Results = list.ListResultsStreamDiagnostics(result.Diagnostics)
+				return
 			}
 			result.Diagnostics.Append(result.Resource.Set(ctx, &state)...)
 			if result.Diagnostics.HasError() {

--- a/internal/resources/pro/licensed_software/permissions.go
+++ b/internal/resources/pro/licensed_software/permissions.go
@@ -41,6 +41,9 @@ var dataSourcePrivileges = permissions.Section(proclassic.Privileges, dataSource
 // resource calls.
 var listResourceSDKMethods = []string{
 	"ListLicensedSoftware",
+	// The per-item hydration GET the list resource issues when
+	// IncludeResource asks for full resource state.
+	"GetLicensedSoftwareByID",
 }
 
 // listResourcePrivileges is the rendered "Required Jamf permissions" Markdown

--- a/internal/resources/pro/licensed_software/resource_acceptance_test.go
+++ b/internal/resources/pro/licensed_software/resource_acceptance_test.go
@@ -525,7 +525,16 @@ func TestAccListResource_ProLicensedSoftware(t *testing.T) {
 			{
 				Config: fmt.Sprintf(`
 					resource "jamfplatform_pro_licensed_software" "src" {
-						name = %q
+						name      = %q
+						publisher = "Acme Corp"
+
+						software_definitions = [
+							{
+								name         = "Acme Editor"
+								version      = "2.0"
+								compare_type = "is"
+							},
+						]
 					}
 				`, name),
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -555,6 +564,16 @@ func TestAccListResource_ProLicensedSoftware(t *testing.T) {
 						queryfilter.ByDisplayName(knownvalue.StringExact(name)),
 						[]querycheck.KnownValueCheck{
 							{Path: tfjsonpath.New("name"), KnownValue: knownvalue.StringExact(name)},
+							// Neither publisher nor software_definitions is in the
+							// /licensedsoftware summary row, which carries id and name
+							// only. Asserting name alone is what let a list resource
+							// emitting nulls for the rest pass, while
+							// `terraform query -generate-config-out` wrote a title with
+							// no definitions and no licences — and applying that back
+							// stripped both. This pins the per-item GET.
+							{Path: tfjsonpath.New("publisher"), KnownValue: knownvalue.StringExact("Acme Corp")},
+							{Path: tfjsonpath.New("software_definitions").AtSliceIndex(0).AtMapKey("name"), KnownValue: knownvalue.StringExact("Acme Editor")},
+							{Path: tfjsonpath.New("software_definitions").AtSliceIndex(0).AtMapKey("version"), KnownValue: knownvalue.StringExact("2.0")},
 						},
 					),
 				},

--- a/internal/resources/pro/mobile_device_enrollment_profile/list_resource.go
+++ b/internal/resources/pro/mobile_device_enrollment_profile/list_resource.go
@@ -23,6 +23,10 @@ import (
 
 const defaultListTimeout = 90 * time.Second
 
+// defaultItemReadTimeout bounds each per-item hydration GET issued when
+// IncludeResource asks for full resource state.
+const defaultItemReadTimeout = 30 * time.Second
+
 var _ list.ListResource = &EnrollmentProfileListResource{}
 var _ list.ListResourceWithConfigure = &EnrollmentProfileListResource{}
 
@@ -116,17 +120,30 @@ func (r *EnrollmentProfileListResource) List(ctx context.Context, req list.ListR
 		}
 
 		if req.IncludeResource {
+			// The list response carries id, name and invitation only. A list
+			// result with null description and no location or purchasing block
+			// makes `terraform query -generate-config-out` write a profile
+			// without them, and applying that config back would clear them — so
+			// follow up with a singular GET and hydrate from the same state
+			// builder Read uses. The hydrating flag is true for the same reason
+			// it is on an import: the incoming model is unpopulated, so the
+			// wire-present optional blocks are the ones to adopt.
+			itemCtx, cancel := context.WithTimeout(ctx, defaultItemReadTimeout)
+			full, err := r.client.GetMobileDeviceEnrollmentProfileByID(itemCtx, id.ValueString())
+			cancel()
+			if err != nil {
+				tflog.Warn(ctx, "Skipping mobile device enrollment profile from generated config after per-item read failure", map[string]any{
+					"id":    id.ValueString(),
+					"error": err.Error(),
+				})
+				continue
+			}
 			state := EnrollmentProfileResourceModel{
 				ID:          id,
-				Name:        helpers.StringPointerValueOrNull(p.Name),
-				Description: types.StringNull(),
-				SiteID:      types.StringNull(),
-				SiteName:    types.StringNull(),
-				Invitation:  bigIntStringOrNull(p.Invitation),
-				UUID:        types.StringNull(),
 				Attachments: emptyAttachments,
 				Timeouts:    helpers.NewResourceTimeoutsNullValue(enrollmentProfileTimeoutAttributeTypes),
 			}
+			assignEnrollmentProfileResourceModel(&state, full, true)
 			result.Diagnostics.Append(result.Resource.Set(ctx, &state)...)
 			if result.Diagnostics.HasError() {
 				stream.Results = list.ListResultsStreamDiagnostics(result.Diagnostics)

--- a/internal/resources/pro/mobile_device_enrollment_profile/permissions.go
+++ b/internal/resources/pro/mobile_device_enrollment_profile/permissions.go
@@ -44,6 +44,9 @@ var dataSourcePrivileges = permissions.Section(proclassic.Privileges, dataSource
 // resource calls.
 var listResourceSDKMethods = []string{
 	"ListMobileDeviceEnrollmentProfiles",
+	// The per-item hydration GET the list resource issues when
+	// IncludeResource asks for full resource state.
+	"GetMobileDeviceEnrollmentProfileByID",
 }
 
 // listResourcePrivileges is the rendered "Required Jamf permissions" Markdown

--- a/internal/resources/pro/mobile_device_enrollment_profile/resource_acceptance_test.go
+++ b/internal/resources/pro/mobile_device_enrollment_profile/resource_acceptance_test.go
@@ -25,7 +25,12 @@ import (
 
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/proclassic"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/querycheck"
+	"github.com/hashicorp/terraform-plugin-testing/querycheck/queryfilter"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/helpers"
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/testhelpers"
@@ -453,6 +458,87 @@ func TestAccResource_ProMobileDeviceEnrollmentProfile_OmittedBlocksRetained(t *t
 					resource.TestCheckNoResourceAttr(resAddr, "purchasing.vendor"),
 					mdepRetainedOnServer(t, name, ""),
 				),
+			},
+		},
+	})
+}
+
+// TestAccListResource_ProMobileDeviceEnrollmentProfile_HydratesBeyondTheSummaryRow
+// pins that a list result carries the attributes the
+// /mobiledeviceenrollmentprofiles summary row does not.
+//
+// The summary carries id, name and invitation. The list resource used to emit
+// nulls for description and for the whole location and purchasing blocks, which
+// no query test caught because there was no query test at all — but
+// `terraform query -generate-config-out` wrote a profile without them, and
+// applying that configuration back cleared them on the tenant.
+//
+// This asserts fields that can only have come from the per-item GET. It belongs
+// here rather than on testhelpers.GenerateConfigStep, which adopts through the
+// singular read and never touches the list resource.
+func TestAccListResource_ProMobileDeviceEnrollmentProfile_HydratesBeyondTheSummaryRow(t *testing.T) {
+	testhelpers.AccPreCheck(t)
+	suffix := testhelpers.RunSuffix()
+	name := "tf-acc-pro-mdep-list-" + suffix
+
+	resource.Test(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		ProtoV6ProviderFactories: testhelpers.AccTestProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckEnrollmentProfileDestroy(t),
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+					resource "jamfplatform_pro_mobile_device_enrollment_profile" "test" {
+						name        = %q
+						description = "list hydration fixture"
+
+						location = {
+							username  = "tf-acc-mdep-list-user"
+							real_name = "TF Acc List User"
+							room      = "101"
+						}
+
+						purchasing = {
+							is_purchased    = true
+							vendor          = "Apple"
+							life_expectancy = 3
+						}
+					}
+				`, name),
+				Check: resource.TestCheckResourceAttrSet(resAddr, "id"),
+			},
+			{
+				Query: true,
+				Config: fmt.Sprintf(`
+					provider "jamfplatform" {}
+
+					list "jamfplatform_pro_mobile_device_enrollment_profile" "test" {
+						provider         = jamfplatform
+						include_resource = true
+
+						config {
+							filter = {
+								name_substring = %q
+							}
+						}
+					}
+				`, name),
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					querycheck.ExpectLength("jamfplatform_pro_mobile_device_enrollment_profile.test", 1),
+					querycheck.ExpectResourceKnownValues(
+						"jamfplatform_pro_mobile_device_enrollment_profile.test",
+						queryfilter.ByDisplayName(knownvalue.StringExact(name)),
+						[]querycheck.KnownValueCheck{
+							{Path: tfjsonpath.New("name"), KnownValue: knownvalue.StringExact(name)},
+							// Not in the summary row: these are the fix.
+							{Path: tfjsonpath.New("description"), KnownValue: knownvalue.StringExact("list hydration fixture")},
+							{Path: tfjsonpath.New("location").AtMapKey("real_name"), KnownValue: knownvalue.StringExact("TF Acc List User")},
+							{Path: tfjsonpath.New("purchasing").AtMapKey("vendor"), KnownValue: knownvalue.StringExact("Apple")},
+						},
+					),
+				},
 			},
 		},
 	})

--- a/internal/resources/pro/mobile_device_provisioning_profile/list_resource.go
+++ b/internal/resources/pro/mobile_device_provisioning_profile/list_resource.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/list"
 	listschema "github.com/hashicorp/terraform-plugin-framework/list/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/filters"
@@ -23,6 +22,10 @@ import (
 // defaultListTimeout caps how long the list operation will wait on the classic
 // endpoint. The list resource schema does not expose a user-overridable timeout.
 const defaultListTimeout = 90 * time.Second
+
+// defaultItemReadTimeout bounds each per-item hydration GET issued when
+// IncludeResource asks for full resource state.
+const defaultItemReadTimeout = 30 * time.Second
 
 var _ list.ListResource = &ProvisioningProfileListResource{}
 var _ list.ListResourceWithConfigure = &ProvisioningProfileListResource{}
@@ -129,18 +132,27 @@ func (r *ProvisioningProfileListResource) List(ctx context.Context, req list.Lis
 		}
 
 		if req.IncludeResource {
-			state := ProvisioningProfileResourceModel{
-				ID:                  id,
-				Name:                helpers.StringPointerValueOrNull(p.Name),
-				DisplayName:         helpers.StringPointerValueOrNull(p.DisplayName),
-				ProfileData:         types.StringNull(),
-				UUID:                helpers.StringPointerValueOrNull(p.UUID),
-				CreationDateUTC:     types.StringNull(),
-				CreationDateEpoch:   types.StringNull(),
-				ExpirationDateUTC:   types.StringNull(),
-				ExpirationDateEpoch: types.StringNull(),
-				Timeouts:            helpers.NewResourceTimeoutsNullValue(provisioningProfileTimeoutAttributeTypes),
+			// The list response omits profile_data, and leaving it null is worse
+			// here than on a plain optional attribute: profile_data is
+			// RequiresReplace, so a generated config without it plans a
+			// destroy-and-recreate of an imported profile rather than a no-op.
+			// The singular GET returns it, so hydrate from the same state builder
+			// Read uses.
+			itemCtx, cancel := context.WithTimeout(ctx, defaultItemReadTimeout)
+			full, err := r.client.GetMobileDeviceProvisioningProfileByID(itemCtx, id.ValueString())
+			cancel()
+			if err != nil {
+				tflog.Warn(ctx, "Skipping mobile device provisioning profile from generated config after per-item read failure", map[string]any{
+					"id":    id.ValueString(),
+					"error": err.Error(),
+				})
+				continue
 			}
+			state := ProvisioningProfileResourceModel{
+				ID:       id,
+				Timeouts: helpers.NewResourceTimeoutsNullValue(provisioningProfileTimeoutAttributeTypes),
+			}
+			assignProvisioningProfileResourceModel(&state, full)
 			result.Diagnostics.Append(result.Resource.Set(ctx, &state)...)
 			if result.Diagnostics.HasError() {
 				stream.Results = list.ListResultsStreamDiagnostics(result.Diagnostics)

--- a/internal/resources/pro/mobile_device_provisioning_profile/permissions.go
+++ b/internal/resources/pro/mobile_device_provisioning_profile/permissions.go
@@ -40,6 +40,9 @@ var dataSourcePrivileges = permissions.Section(proclassic.Privileges, dataSource
 // resource (list_resource.go) calls.
 var listResourceSDKMethods = []string{
 	"ListMobileDeviceProvisioningProfiles",
+	// The per-item hydration GET the list resource issues when
+	// IncludeResource asks for full resource state.
+	"GetMobileDeviceProvisioningProfileByID",
 }
 
 // listResourcePrivileges is the rendered "Required Jamf permissions" Markdown

--- a/internal/resources/pro/mobile_device_provisioning_profile/resource_acceptance_test.go
+++ b/internal/resources/pro/mobile_device_provisioning_profile/resource_acceptance_test.go
@@ -30,8 +30,13 @@ import (
 
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/proclassic"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/querycheck"
+	"github.com/hashicorp/terraform-plugin-testing/querycheck/queryfilter"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/helpers"
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/testhelpers"
@@ -256,6 +261,73 @@ func TestAccDataSource_ProMobileDeviceProvisioningProfile_AmbiguousSelector(t *t
 					}
 				`,
 				ExpectError: regexp.MustCompile(`Invalid Attribute Combination`),
+			},
+		},
+	})
+}
+
+// TestAccListResource_ProMobileDeviceProvisioningProfile_HydratesTheBlob pins
+// that a list result carries profile_data.
+//
+// The list endpoint omits the blob, and leaving it null is worse here than on a
+// plain optional attribute: profile_data is RequiresReplace (the server invariant
+// this file's header records — every PUT to a blob-bearing profile returns 500).
+// So `terraform query -generate-config-out` wrote a profile with no
+// profile_data, and planning that configuration against the imported object
+// proposed a DESTROY AND RECREATE rather than a no-op.
+//
+// There was no query test on this resource at all, which is why that went
+// unseen. It belongs here rather than on testhelpers.GenerateConfigStep, which
+// adopts through the singular read — the read that returns the blob correctly —
+// and never touches the list resource.
+func TestAccListResource_ProMobileDeviceProvisioningProfile_HydratesTheBlob(t *testing.T) {
+	testhelpers.AccPreCheck(t)
+	suffix := testhelpers.RunSuffix()
+	name := "tf-acc-pro-mdpp-list-" + suffix
+	b64 := fixtureBase64(t)
+
+	resource.Test(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		ProtoV6ProviderFactories: testhelpers.AccTestProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckProvisioningProfileDestroy(t),
+		Steps: []resource.TestStep{
+			{
+				// display_name is Computed (server-forced to name), so the shared
+				// helper is what defines a settable configuration.
+				Config: provisioningProfileConfig(name, b64),
+				Check:  resource.TestCheckResourceAttrSet(resourceAddr, "id"),
+			},
+			{
+				Query: true,
+				Config: fmt.Sprintf(`
+					provider "jamfplatform" {}
+
+					list "jamfplatform_pro_mobile_device_provisioning_profile" "test" {
+						provider         = jamfplatform
+						include_resource = true
+
+						config {
+							filter = {
+								name_substring = %q
+							}
+						}
+					}
+				`, name),
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					querycheck.ExpectLength("jamfplatform_pro_mobile_device_provisioning_profile.test", 1),
+					querycheck.ExpectResourceKnownValues(
+						"jamfplatform_pro_mobile_device_provisioning_profile.test",
+						queryfilter.ByDisplayName(knownvalue.StringExact(name)),
+						[]querycheck.KnownValueCheck{
+							{Path: tfjsonpath.New("name"), KnownValue: knownvalue.StringExact(name)},
+							// The blob is the fix. Without the per-item GET this is null,
+							// and the generated configuration replaces the profile.
+							{Path: tfjsonpath.New("profile_data"), KnownValue: knownvalue.StringExact(b64)},
+						},
+					),
+				},
 			},
 		},
 	})

--- a/internal/resources/pro/network_segment/crud.go
+++ b/internal/resources/pro/network_segment/crud.go
@@ -67,7 +67,7 @@ func (r *NetworkSegmentResource) Create(ctx context.Context, req resource.Create
 		resp.Diagnostics.AddError("Error reading created Jamf Pro network segment", err.Error())
 		return
 	}
-	assignNetworkSegmentResourceModel(&plan, got)
+	assignNetworkSegmentResourceModel(&plan, got, false)
 
 	resp.Diagnostics.Append(helpers.SetIdentity(ctx, resp.Identity, networkSegmentIdentityModel{ID: plan.ID})...)
 	if resp.Diagnostics.HasError() {
@@ -140,7 +140,7 @@ func (r *NetworkSegmentResource) Read(ctx context.Context, req resource.ReadRequ
 		return
 	}
 
-	assignNetworkSegmentResourceModel(&state, got)
+	assignNetworkSegmentResourceModel(&state, got, false)
 
 	resp.Diagnostics.Append(helpers.SetIdentity(ctx, resp.Identity, networkSegmentIdentityModel{ID: state.ID})...)
 	if resp.Diagnostics.HasError() {
@@ -176,7 +176,7 @@ func (r *NetworkSegmentResource) Update(ctx context.Context, req resource.Update
 		resp.Diagnostics.AddError("Error reading updated Jamf Pro network segment", err.Error())
 		return
 	}
-	assignNetworkSegmentResourceModel(&plan, got)
+	assignNetworkSegmentResourceModel(&plan, got, false)
 
 	resp.Diagnostics.Append(helpers.SetIdentity(ctx, resp.Identity, networkSegmentIdentityModel{ID: plan.ID})...)
 	if resp.Diagnostics.HasError() {

--- a/internal/resources/pro/network_segment/list_resource.go
+++ b/internal/resources/pro/network_segment/list_resource.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/list"
 	listschema "github.com/hashicorp/terraform-plugin-framework/list/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/filters"
@@ -24,6 +23,10 @@ import (
 // /networksegments endpoint. The list resource schema does not expose a user-
 // overridable timeout, so this is a fixed safety bound.
 const defaultListTimeout = 90 * time.Second
+
+// defaultItemReadTimeout bounds each per-item hydration GET issued when
+// IncludeResource asks for full resource state.
+const defaultItemReadTimeout = 30 * time.Second
 
 var _ list.ListResource = &NetworkSegmentListResource{}
 var _ list.ListResourceWithConfigure = &NetworkSegmentListResource{}
@@ -37,8 +40,8 @@ func NewNetworkSegmentListResource() list.ListResource {
 // network segments. Classic /networksegments accepts no query parameters, so the
 // optional `filter` block is applied client-side via filters.ApplyClassicFilter
 // after the full list is fetched. The list-item type carries only id, name,
-// starting_address, and ending_address — every other resource attribute is set to
-// null on list results.
+// starting_address, and ending_address, so IncludeResource hydrates each record
+// with a singular GET rather than emitting nulls for the rest.
 type NetworkSegmentListResource struct {
 	client *proclassic.Client
 }
@@ -133,23 +136,27 @@ func (r *NetworkSegmentListResource) List(ctx context.Context, req list.ListRequ
 		}
 
 		if req.IncludeResource {
-			// List endpoint returns only id, name, starting_address, ending_address.
-			// Every other Optional/Computed attribute is null on a list result.
-			state := NetworkSegmentResourceModel{
-				ID:                  id,
-				Name:                helpers.StringPointerValueOrNull(s.Name),
-				StartingAddress:     helpers.StringPointerValueOrNull(s.StartingAddress),
-				EndingAddress:       helpers.StringPointerValueOrNull(s.EndingAddress),
-				Building:            types.StringNull(),
-				Department:          types.StringNull(),
-				OverrideBuildings:   types.BoolNull(),
-				OverrideDepartments: types.BoolNull(),
-				DistributionPoint:   types.StringNull(),
-				DistributionServer:  types.StringNull(),
-				SwuServer:           types.StringNull(),
-				URL:                 types.StringNull(),
-				Timeouts:            helpers.NewResourceTimeoutsNullValue(networkSegmentTimeoutAttributeTypes),
+			// The /networksegments list response carries only id, name,
+			// starting_address and ending_address. Emitting nulls for the rest
+			// makes `terraform query -generate-config-out` write a network
+			// segment with no building, department or override flags, and
+			// applying that config back would clear them — so follow up with a
+			// singular GET and hydrate from the same state builder Read uses.
+			itemCtx, cancel := context.WithTimeout(ctx, defaultItemReadTimeout)
+			full, err := r.client.GetNetworkSegmentByID(itemCtx, id.ValueString())
+			cancel()
+			if err != nil {
+				tflog.Warn(ctx, "Skipping network segment from generated config after per-item read failure", map[string]any{
+					"id":    id.ValueString(),
+					"error": err.Error(),
+				})
+				continue
 			}
+			state := NetworkSegmentResourceModel{
+				ID:       id,
+				Timeouts: helpers.NewResourceTimeoutsNullValue(networkSegmentTimeoutAttributeTypes),
+			}
+			assignNetworkSegmentResourceModel(&state, full, true)
 			result.Diagnostics.Append(result.Resource.Set(ctx, &state)...)
 			if result.Diagnostics.HasError() {
 				stream.Results = list.ListResultsStreamDiagnostics(result.Diagnostics)

--- a/internal/resources/pro/network_segment/permissions.go
+++ b/internal/resources/pro/network_segment/permissions.go
@@ -52,6 +52,9 @@ var pluralDataSourcePrivileges = permissions.Section(proclassic.Privileges, plur
 // calls.
 var listResourceSDKMethods = []string{
 	"ListNetworkSegments",
+	// The per-item hydration GET the list resource issues when
+	// IncludeResource asks for full resource state.
+	"GetNetworkSegmentByID",
 }
 
 // listResourcePrivileges is the rendered "Required Jamf permissions" Markdown

--- a/internal/resources/pro/network_segment/resource_acceptance_test.go
+++ b/internal/resources/pro/network_segment/resource_acceptance_test.go
@@ -333,3 +333,72 @@ func TestAccListResource_ProNetworkSegment_Basic(t *testing.T) {
 		},
 	})
 }
+
+// TestAccListResource_ProNetworkSegment_HydratesBeyondTheSummaryRow pins that a
+// list result carries the attributes the /networksegments summary row does not.
+//
+// The summary carries id, name, starting_address and ending_address only, and
+// the list resource used to emit nulls for everything else. That is invisible to
+// a query test asserting only summary fields — which is what
+// TestAccListResource_ProNetworkSegment_Basic does, and why it passed
+// throughout — but it is not invisible to `terraform query
+// -generate-config-out`: the generated configuration carried no building,
+// department or override flags, and applying it back would have cleared them.
+//
+// So this asserts a field that can only have come from the per-item GET. It
+// belongs here rather than on testhelpers.GenerateConfigStep, which adopts
+// through the singular read and never touches the list resource at all.
+func TestAccListResource_ProNetworkSegment_HydratesBeyondTheSummaryRow(t *testing.T) {
+	testhelpers.AccPreCheck(t)
+	suffix := testhelpers.RunSuffix()
+	name := "tf-acc-pro-ns-hydrate-" + suffix
+	buildingName := "tf-acc-ns-hydrate-building-" + suffix
+	departmentName := "tf-acc-ns-hydrate-department-" + suffix
+
+	resource.Test(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		ProtoV6ProviderFactories: testhelpers.AccTestProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckNetworkSegmentDestroy(t),
+		Steps: []resource.TestStep{
+			{
+				Config: networkSegmentConfigAllFields(name, buildingName, departmentName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("jamfplatform_pro_network_segment.test", "building", buildingName),
+				),
+			},
+			{
+				Query: true,
+				Config: fmt.Sprintf(`
+					provider "jamfplatform" {}
+
+					list "jamfplatform_pro_network_segment" "test" {
+						provider         = jamfplatform
+						include_resource = true
+
+						config {
+							filter = {
+								name_substring = %q
+							}
+						}
+					}
+				`, name),
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					querycheck.ExpectLength("jamfplatform_pro_network_segment.test", 1),
+					querycheck.ExpectResourceKnownValues(
+						"jamfplatform_pro_network_segment.test",
+						queryfilter.ByDisplayName(knownvalue.StringExact(name)),
+						[]querycheck.KnownValueCheck{
+							// Not in the summary row: these are the fix.
+							{Path: tfjsonpath.New("building"), KnownValue: knownvalue.StringExact(buildingName)},
+							{Path: tfjsonpath.New("department"), KnownValue: knownvalue.StringExact(departmentName)},
+							{Path: tfjsonpath.New("override_buildings"), KnownValue: knownvalue.Bool(true)},
+							{Path: tfjsonpath.New("override_departments"), KnownValue: knownvalue.Bool(true)},
+						},
+					),
+				},
+			},
+		},
+	})
+}

--- a/internal/resources/pro/network_segment/state_builders.go
+++ b/internal/resources/pro/network_segment/state_builders.go
@@ -17,7 +17,16 @@ import (
 // distinction the user set in config is preserved across refreshes. Computed-only
 // server-derived fields (distribution_point, distribution_server, swu_server, url)
 // are populated unconditionally with the API value (or null when absent).
-func assignNetworkSegmentResourceModel(state *NetworkSegmentResourceModel, s *proclassic.NetworkSegment) {
+// adopt selects between the two read contexts, the way the licensed-software and
+// mobile-device-enrollment-profile builders do. A CRUD read reconciles: an
+// Optional+Computed value the practitioner never authored stays null, so a
+// refresh does not snap it to the server default. Config generation has no plan
+// to reconcile against — the list resource builds a fresh model — so the server
+// value is authoritative and a value-carrying flag has to survive into the
+// exported configuration. Reconciling there left override_buildings and
+// override_departments null on every generated network segment even though the
+// endpoint returns them.
+func assignNetworkSegmentResourceModel(state *NetworkSegmentResourceModel, s *proclassic.NetworkSegment, adopt bool) {
 	if s == nil {
 		return
 	}
@@ -33,10 +42,14 @@ func assignNetworkSegmentResourceModel(state *NetworkSegmentResourceModel, s *pr
 	if s.EndingAddress != nil {
 		state.EndingAddress = helpers.StringPointerValueOrNull(s.EndingAddress)
 	}
+	// The two strings need no adopt switch: ReconcileOptionalStringPointer
+	// already returns a wire value the caller never authored, which is why
+	// building and department survived into generated config while the two bools
+	// beside them did not.
 	state.Building = helpers.ReconcileOptionalStringPointer(s.Building, state.Building)
 	state.Department = helpers.ReconcileOptionalStringPointer(s.Department, state.Department)
-	state.OverrideBuildings = helpers.ReconcileOptionalBoolPointer(s.OverrideBuildings, state.OverrideBuildings)
-	state.OverrideDepartments = helpers.ReconcileOptionalBoolPointer(s.OverrideDepartments, state.OverrideDepartments)
+	state.OverrideBuildings = helpers.ReconcileOrAdoptBoolPointer(s.OverrideBuildings, state.OverrideBuildings, adopt)
+	state.OverrideDepartments = helpers.ReconcileOrAdoptBoolPointer(s.OverrideDepartments, state.OverrideDepartments, adopt)
 	state.DistributionPoint = helpers.StringPointerValueOrNull(s.DistributionPoint)
 	state.DistributionServer = helpers.StringPointerValueOrNull(s.DistributionServer)
 	state.SwuServer = helpers.StringPointerValueOrNull(s.SwuServer)

--- a/internal/resources/pro/network_segment/state_builders_test.go
+++ b/internal/resources/pro/network_segment/state_builders_test.go
@@ -46,7 +46,7 @@ func TestAssignNetworkSegmentResourceModel_PopulatesFields(t *testing.T) {
 		URL:                 &url,
 	}
 
-	assignNetworkSegmentResourceModel(&state, api)
+	assignNetworkSegmentResourceModel(&state, api, false)
 
 	if state.ID.ValueString() != "42" {
 		t.Errorf("expected ID 42, got %q", state.ID.ValueString())
@@ -81,7 +81,7 @@ func TestAssignNetworkSegmentResourceModel_PreservesIDWhenAPINil(t *testing.T) {
 	state := NetworkSegmentResourceModel{ID: types.StringValue("9")}
 	api := &proclassic.NetworkSegment{ID: nil}
 
-	assignNetworkSegmentResourceModel(&state, api)
+	assignNetworkSegmentResourceModel(&state, api, false)
 
 	if state.ID.ValueString() != "9" {
 		t.Errorf("expected state.ID preserved as %q, got %q", "9", state.ID.ValueString())
@@ -93,7 +93,7 @@ func TestAssignNetworkSegmentResourceModel_NilAPIIsNoop(t *testing.T) {
 		ID:   types.StringValue("7"),
 		Name: types.StringValue("Keep"),
 	}
-	assignNetworkSegmentResourceModel(&state, nil)
+	assignNetworkSegmentResourceModel(&state, nil, false)
 	if state.ID.ValueString() != "7" || state.Name.ValueString() != "Keep" {
 		t.Errorf("expected state unchanged, got id=%q name=%q", state.ID.ValueString(), state.Name.ValueString())
 	}
@@ -108,7 +108,7 @@ func TestAssignNetworkSegmentResourceModel_OptionalReconcileKeepsNullWhenUnmanag
 	}
 	api := &proclassic.NetworkSegment{Building: nil, OverrideBuildings: nil}
 
-	assignNetworkSegmentResourceModel(&state, api)
+	assignNetworkSegmentResourceModel(&state, api, false)
 
 	if !state.Building.IsNull() {
 		t.Errorf("expected Building to remain null, got %q", state.Building.ValueString())
@@ -170,5 +170,41 @@ func TestAssignNetworkSegmentDataSourceModel_NilAPIIsNoop(t *testing.T) {
 	assignNetworkSegmentDataSourceModel(&state, nil)
 	if state.ID.ValueString() != "preset" || state.Name.ValueString() != "preset" {
 		t.Errorf("expected state unchanged on nil API")
+	}
+}
+
+// TestAssignNetworkSegmentResourceModel_AdoptsOverridesForConfigGeneration pins
+// the adopt switch. A CRUD read must leave an Optional+Computed flag the
+// practitioner never authored null, so a refresh does not snap it to the server
+// default; config generation has no plan to reconcile against, so the server
+// value has to survive. Reconciling on both paths is what left
+// override_buildings and override_departments null on every generated network
+// segment even though /networksegments returns them.
+func TestAssignNetworkSegmentResourceModel_AdoptsOverridesForConfigGeneration(t *testing.T) {
+	on := true
+	name, building, department := "HQ", "HQ Building", "IT"
+	wire := &proclassic.NetworkSegment{
+		Name:                &name,
+		Building:            &building,
+		Department:          &department,
+		OverrideBuildings:   &on,
+		OverrideDepartments: &on,
+	}
+
+	// Config generation: a fresh model, so the wire value is authoritative.
+	var generated NetworkSegmentResourceModel
+	assignNetworkSegmentResourceModel(&generated, wire, true)
+	if generated.OverrideBuildings.IsNull() || !generated.OverrideBuildings.ValueBool() {
+		t.Errorf("override_buildings = %s, want the wire value adopted", generated.OverrideBuildings)
+	}
+	if generated.OverrideDepartments.IsNull() || !generated.OverrideDepartments.ValueBool() {
+		t.Errorf("override_departments = %s, want the wire value adopted", generated.OverrideDepartments)
+	}
+
+	// A CRUD read against state that never authored them keeps them null.
+	var refreshed NetworkSegmentResourceModel
+	assignNetworkSegmentResourceModel(&refreshed, wire, false)
+	if !refreshed.OverrideBuildings.IsNull() {
+		t.Errorf("override_buildings = %s, want null on a refresh that never authored it", refreshed.OverrideBuildings)
 	}
 }

--- a/internal/resources/pro/patch_external_source/list_resource.go
+++ b/internal/resources/pro/patch_external_source/list_resource.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/list"
 	listschema "github.com/hashicorp/terraform-plugin-framework/list/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/filters"
@@ -24,6 +23,10 @@ import (
 // /patchexternalsources endpoint. The list resource schema does not expose a
 // user-overridable timeout, so this is a fixed safety bound.
 const defaultListTimeout = 90 * time.Second
+
+// defaultItemReadTimeout bounds each per-item hydration GET issued when
+// IncludeResource asks for full resource state.
+const defaultItemReadTimeout = 30 * time.Second
 
 var _ list.ListResource = &PatchExternalSourceListResource{}
 var _ list.ListResourceWithConfigure = &PatchExternalSourceListResource{}
@@ -140,18 +143,25 @@ func (r *PatchExternalSourceListResource) List(ctx context.Context, req list.Lis
 		}
 
 		if req.IncludeResource {
-			// The list endpoint exposes only id+name; the remaining attributes
-			// are left null (see method doc).
-			state := PatchExternalSourceResourceModel{
-				ID:                           id,
-				Name:                         helpers.StringPointerValueOrNull(s.Name),
-				Enabled:                      types.BoolNull(),
-				HostName:                     types.StringNull(),
-				Port:                         types.Int64Null(),
-				SslEnabled:                   types.BoolNull(),
-				CertificateValidationEnabled: types.BoolNull(),
-				Timeouts:                     helpers.NewResourceTimeoutsNullValue(patchExternalSourceTimeoutAttributeTypes),
+			// The list endpoint exposes only id+name, and host_name is Required
+			// on the resource schema — a list result carrying null for it
+			// generates config the provider then refuses to plan. Follow up with
+			// a singular GET and hydrate from the state builder Read uses.
+			itemCtx, cancel := context.WithTimeout(ctx, defaultItemReadTimeout)
+			full, err := r.client.GetPatchExternalSourceByID(itemCtx, id.ValueString())
+			cancel()
+			if err != nil {
+				tflog.Warn(ctx, "Skipping patch external source from generated config after per-item read failure", map[string]any{
+					"id":    id.ValueString(),
+					"error": err.Error(),
+				})
+				continue
 			}
+			state := PatchExternalSourceResourceModel{
+				ID:       id,
+				Timeouts: helpers.NewResourceTimeoutsNullValue(patchExternalSourceTimeoutAttributeTypes),
+			}
+			assignPatchExternalSourceResourceModel(&state, full)
 			result.Diagnostics.Append(result.Resource.Set(ctx, &state)...)
 			if result.Diagnostics.HasError() {
 				stream.Results = list.ListResultsStreamDiagnostics(result.Diagnostics)

--- a/internal/resources/pro/patch_external_source/permissions.go
+++ b/internal/resources/pro/patch_external_source/permissions.go
@@ -43,6 +43,9 @@ var dataSourcePrivileges = permissions.Section(proclassic.Privileges, dataSource
 // listResourceSDKMethods lists the SDK methods the list resource calls.
 var listResourceSDKMethods = []string{
 	"ListPatchExternalSources",
+	// The per-item hydration GET the list resource issues when
+	// IncludeResource asks for full resource state.
+	"GetPatchExternalSourceByID",
 }
 
 // listResourcePrivileges is the rendered "Required Jamf permissions" Markdown

--- a/internal/resources/pro/patch_external_source/resource_acceptance_test.go
+++ b/internal/resources/pro/patch_external_source/resource_acceptance_test.go
@@ -268,6 +268,11 @@ func TestAccListResource_ProPatchExternalSource_Basic(t *testing.T) {
 						queryfilter.ByDisplayName(knownvalue.StringExact(name)),
 						[]querycheck.KnownValueCheck{
 							{Path: tfjsonpath.New("name"), KnownValue: knownvalue.StringExact(name)},
+							// host_name is NOT in the summary row, and it is Required on
+							// the schema — a list result carrying null for it generates
+							// configuration the provider refuses to plan. This pins the
+							// per-item GET.
+							{Path: tfjsonpath.New("host_name"), KnownValue: knownvalue.StringExact("definitions.example.com/v2/")},
 						},
 					),
 				},


### PR DESCRIPTION
## What

Nine list resources emitted `null` for every attribute their list endpoint does not carry. Harmless for a `terraform query` listing; wrong for `terraform query -generate-config-out`, where a null means *delete this on apply*. The generated configuration dropped criteria, class membership, licences, enrollment panes and blob payloads — and applying it back to the tenant it came from removed them.

| Resource | What the generated config lost |
|---|---|
| `pro_advanced_computer_search` | `criteria`, `display_fields` |
| `pro_advanced_user_search` | `criteria`, `display_fields` |
| `pro_class` | students, teachers, all group membership |
| `pro_licensed_software` | `software_definitions`, `licenses`, publisher |
| `pro_enrollment_customization` | all text / LDAP / SSO panes |
| `pro_network_segment` | building, department, both override flags |
| `pro_mobile_device_enrollment_profile` | description, `location`, `purchasing` |
| `pro_patch_external_source` | `host_name` — **Required**, so the block would not plan |
| `pro_mobile_device_provisioning_profile` | `profile_data` — **RequiresReplace**, so the plan proposed a destroy/recreate |

## Why it needs a per-item GET

These endpoints return a summary row — `proclassic.IDName` for the two advanced searches and patch external sources, a slightly wider item for the rest — so there is no data for a state-builder flag to adopt. This is a different class from the `includeUnmanaged` work in v0.31.0, which covers 11 resources whose list endpoints return the full object; none of the nine here mentions that flag.

Each now follows the pattern `dock_item`, `ldap_server`, `ibeacon` and ~14 other types already use: fetch inside `if req.IncludeResource`, hydrate through the same `assign*ResourceModel` builder `Read` uses, warn-and-skip a record whose read fails rather than failing the whole type. `enrollment_customization` is the exception — its list carries the parent record, so only the panes needed fetching and it calls `hydratePanels`.

## The network_segment twist

Its two override flags stayed `null` even after the GET. Not an API gap — the raw endpoint returns both. `ReconcileOptionalBoolPointer` deliberately keeps an Optional+Computed bool null when the caller never authored it, so a refresh does not snap it to the server default, and a list result has no prior state to reconcile against. The builder now takes an `adopt bool` and uses `ReconcileOrAdoptBoolPointer`, matching `assignLicensedSoftwareResourceModel` and `assignEnrollmentProfileResourceModel`. The strings need no switch: `ReconcileOptionalStringPointer` already returns an unauthored wire value, which is exactly why building and department survived while the bools beside them did not.

## Testing

Guarded by **query-result** acceptance checks, not `testhelpers.GenerateConfigStep` — that step adopts through the singular read and never touches a list resource, so it cannot see any of this.

The existing list tests asserted only `name`, the one field every summary row already carried. That is precisely why this survived. Each now asserts a field that can only have come from the per-item GET.

**Acceptance: 10 run, 10 pass** against a live EU tenant (`RUN=10 PASS=10 SKIP=0 FAIL=0`). Unit tests and `golangci-lint` clean.

## How it was found

Exporting a live tenant with jamformer and planning the result. The import plan over that tenant went from `317 import / 29 add / 27 change / 6 errors` to `350 import / 0 add / 20 change / 0 errors` across this and the sibling PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
