### PR TITLE
fix(ai_governance): type Timeouts when the read has no prior state to decode

### DIFF
--- a/internal/resources/ai_governance/policy/crud.go
+++ b/internal/resources/ai_governance/policy/crud.go
@@ -315,6 +315,13 @@ func (r *PolicyResource) hydrate(ctx context.Context, model *policyModel, id str
 
 // readIdentity fills the model's ID from the resource identity, for a refresh Terraform issues with
 // no prior state — an import addressed by identity rather than by the passthrough import ID.
+//
+// It also gives Timeouts the schema's typed null. The model starts as a zero value here rather than
+// being decoded from state, and a zero timeouts.Value carries an object type with NO attributes, so
+// the state this Read goes on to write would be refused with a "Value Conversion Error" naming
+// timeouts.Type. That is what an `identity = { id = ... }` import block hits — the form
+// `terraform query -generate-config-out` writes — while the `id = ...` form arrives with state
+// already populated and never reaches this branch.
 func readIdentity(ctx context.Context, identity *tfsdk.ResourceIdentity, state *policyModel, diags *diag.Diagnostics) bool {
 	if identity == nil {
 		diags.AddError(
@@ -337,5 +344,6 @@ func readIdentity(ctx context.Context, identity *tfsdk.ResourceIdentity, state *
 		return false
 	}
 	state.ID = model.ID
+	state.Timeouts = helpers.NewResourceTimeoutsNullValue(policyTimeoutAttributeTypes)
 	return true
 }

--- a/internal/resources/ai_governance/policy/crud_partial_state_test.go
+++ b/internal/resources/ai_governance/policy/crud_partial_state_test.go
@@ -659,3 +659,47 @@ func TestPublishFailureIsRetriedByTheNextPlan(t *testing.T) {
 		t.Errorf("published_version = %d, want 1 — the retry mints the first version", got)
 	}
 }
+
+// TestRead_IdentityImportKeepsTimeoutsTyped pins the typing of the model this Read builds when it
+// has no prior state to decode. An `identity = { id = ... }` import block — the form
+// `terraform query -generate-config-out` writes, so the form every generated config is imported
+// with — leaves req.State.Raw null, and readIdentity constructs the model from the identity alone.
+// A zero timeouts.Value carries an object type with no attributes, and the framework then refuses
+// the state this Read writes with a "Value Conversion Error" naming timeouts.Type, taking the whole
+// plan down with it.
+func TestRead_IdentityImportKeepsTimeoutsTyped(t *testing.T) {
+	ctx := context.Background()
+	stub := &policyStub{name: "unit-test-policy"}
+	r := &PolicyResource{client: stub.client(t)}
+
+	policySchema, identity := policySchemas(ctx, t)
+	identityType := identity.Schema.Type().TerraformType(ctx).(tftypes.Object)
+	identity.Raw = tftypes.NewValue(identityType, map[string]tftypes.Value{
+		"id": tftypes.NewValue(tftypes.String, stubPolicyID),
+	})
+
+	nullPriorState := tfsdk.State{
+		Schema: policySchema,
+		Raw:    tftypes.NewValue(policySchema.Type().TerraformType(ctx), nil),
+	}
+	resp := resource.ReadResponse{
+		State:    tfsdk.State{Schema: policySchema},
+		Identity: &identity,
+	}
+	r.Read(ctx, resource.ReadRequest{State: nullPriorState, Identity: &identity}, &resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("reading a policy addressed only by identity: %v", resp.Diagnostics.Errors())
+	}
+	if resp.State.Raw.IsNull() {
+		t.Fatal("the policy must be written to state")
+	}
+
+	var state policyModel
+	if diags := resp.State.Get(ctx, &state); diags.HasError() {
+		t.Fatalf("reading back the state: %v", diags)
+	}
+	if got := len(state.Timeouts.AttributeTypes(ctx)); got != 4 {
+		t.Errorf("timeouts carries %d attribute types, want the schema's 4", got)
+	}
+}

--- a/internal/resources/ai_governance/policy/resource_acceptance_test.go
+++ b/internal/resources/ai_governance/policy/resource_acceptance_test.go
@@ -114,6 +114,15 @@ func TestAccResource_AIGovernancePolicy_Basic(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
+			// The ImportState step above passes the flat `id =` form, which
+			// arrives with state already populated. GenerateConfigStep uses
+			// ImportBlockWithResourceIdentity — the form
+			// `terraform query -generate-config-out` emits — which leaves prior
+			// state null, sends this Read down readIdentity, and used to write a
+			// state the framework refused outright: "Value Conversion Error ...
+			// Path: timeouts", taking the whole plan down. Nothing else in this
+			// suite reaches that branch.
+			testhelpers.GenerateConfigStep(policyResource),
 		},
 	})
 }


### PR DESCRIPTION
## What

An `identity = { id = ... }` import block leaves `req.State.Raw` null. `Read` then branches to `readIdentity`, which built the model from the identity alone and set only `ID`. A zero `timeouts.Value` carries an object type with **no attributes**, so the state the Read went on to write was refused outright:

```
Error: Value Conversion Error
Expected framework type from provider logic: timeouts.Type / underlying type:
tftypes.Object["create":String, "delete":String, "read":String, "update":String]
Received framework type from provider logic: timeouts.Type / underlying type:
tftypes.Object[]
Path: timeouts
```

## Why it matters more than one resource

That diagnostic carries no resource address and it takes the **whole plan** down. A tenant holding a single AI Governance policy could not adopt anything at all — the failure looks like a provider bug report with nothing to attribute it to.

The identity form is what `terraform query -generate-config-out` emits, so it is the form every generated configuration is adopted with. The flat `id = ...` form arrives with state already populated and never reaches the branch, which is why the existing `ImportState` step passed throughout.

## Scope

`readIdentity` is unique to this package — the other 182 resources all seed a typed null on their state-null path, so no sibling carries the same defect. Verified with `git grep -l readIdentity -- internal/resources`.

## Testing

- A unit test that reproduces the diagnostic **verbatim** and fails without the fix.
- `testhelpers.GenerateConfigStep` on the lifecycle test — the only thing in the suite that reaches this branch.

**Acceptance: 1 run, 1 pass** against a live EU tenant. Needs `JAMFPLATFORM_ACC_AIGOVERNANCE_ENVIRONMENT_ID` set to declare the environment holds AI Governance, or the test skips silently.

## A note on how it was localised

I first blamed the two Security Cloud DNS resources, because #411 did delete their `NewResourceTimeoutsNullValue` seeding and that looked like exactly this. It was not: an in-package import-then-Read test showed `ImportStatePassthroughWithIdentity` leaves a properly typed null timeouts there. Since a `Value Conversion Error` carries no address, the way to find it is to bisect the export's import blocks — six plan runs, rather than reasoning from a suspicious diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
